### PR TITLE
fix(sdk,proto): add "type": "module" to published packages

### DIFF
--- a/packages/proto-ts/package.json
+++ b/packages/proto-ts/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@ahandai/proto",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "ts-proto generated types for ahand protocol",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@ahandai/sdk",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "AHand cloud control plane SDK",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
Published sdk@0.1.4 and proto@0.1.3 were missing `"type": "module"` in package.json. Node defaults to CJS without it, so downstream ESM consumers hit `SyntaxError: module does not provide an export named CloudClient` (Node parses as CJS, sees empty module.exports).

- proto 0.1.3 → 0.1.4 (adds type: module) — published
- sdk 0.1.4 → 0.1.5 (adds type: module, pins proto ^0.1.4) — published

🤖 Generated with [Claude Code](https://claude.com/claude-code)