### PR TITLE
feat(contracts): JSON Schema for hub control-plane + webhook (Phase 9 / Task 9.5)

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,41 @@
+# Contracts
+
+JSON Schema (Draft 2020-12) definitions for the wire formats that cross repository boundaries. Each schema is the single source of truth for one cross-repo contract; downstream services validate against the file, not the Rust types directly.
+
+## Files
+
+| File | What it pins | Producer | Consumer |
+| --- | --- | --- | --- |
+| `hub-webhook.json` | The JSON envelope the hub POSTs to a downstream gateway on device lifecycle events. | `crates/ahand-hub/src/webhook/mod.rs::WebhookPayload` (Rust serde) | `team9/apps/server/apps/gateway/src/ahand/dto/webhook-event.dto.ts` (NestJS class-validator DTO) |
+| `hub-control-plane.json` | Request bodies, success responses, error envelopes, and SSE event payloads of `/api/control/jobs*`. | `crates/ahand-hub/src/http/control_plane.rs` (Rust axum handlers) | `packages/sdk/src/cloud-client.ts::CloudClient` (TypeScript SDK) |
+
+## Stability rules
+
+A schema change is **breaking** (and downstream consumers must be updated in lockstep, or the change must be staged behind a version bump) when it:
+
+- adds a new required field;
+- tightens an existing field's type, format, or range;
+- removes or renames an existing enum value or property;
+- toggles `additionalProperties` from `true`/absent to `false`.
+
+A schema change is **additive** (safe) when it:
+
+- adds an optional property to a structure that already had `additionalProperties: true` or implicit;
+- widens an enum (consumers must accept unknown values gracefully — the gateway DTO already does for non-listed `eventType`s by rejecting them at the validator, while the SDK ignores unknown SSE event names by design);
+- relaxes a `minLength`/`pattern` constraint.
+
+## Verification
+
+Each repository owns a thin contract test that loads the JSON Schema, validates the canonical happy-path payload, and asserts that the producer/consumer can round-trip through it:
+
+- **`team9/apps/server/apps/gateway/test/contracts/hub-webhook.contract.e2e-spec.ts`** — bootstraps the webhook controller, signs a canonical payload, asserts 204; also exercises rejection paths against fuzz inputs the schema marks invalid.
+- **`team9-agent-pi/packages/sdk-contracts/src/cloud-client.contract.test-d.ts`** — `tsd` type-level locks for `CloudClient.spawn`, `CloudClient.cancel`, and `CloudClient`'s exported types so a refactor of `@ahandai/sdk` cannot silently drift the consumer side.
+- **`team9/k6/ahand-load-baseline.js`** — feeds the gateway a stream of schema-conforming webhook payloads under load, with payloads pre-signed by `team9/k6/scripts/gen-webhook-payloads.mjs`.
+
+When a downstream consumer's contract test fails after a hub change, the hub author is expected to re-publish the schema before merging — that's the gating signal.
+
+## Versioning
+
+The schemas use `$id` URIs (`https://ahand.team9.ai/contracts/<name>.json`) but are NOT served from that URL. The URI is purely an identifier for `$ref` resolution and tooling; downstream consumers vendor the file via a git path or CI-downloaded artifact.
+
+If a breaking change ever requires concurrent old + new shapes in the wild, append a `-v2` suffix to the file name and `$id` rather than mutating the existing file.

--- a/contracts/hub-control-plane.json
+++ b/contracts/hub-control-plane.json
@@ -1,0 +1,229 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ahand.team9.ai/contracts/hub-control-plane.json",
+  "title": "Hub control-plane REST + SSE wire contract",
+  "description": "Canonical JSON shapes consumed by `@ahandai/sdk::CloudClient` (`packages/sdk/src/cloud-client.ts`) and emitted by the hub control-plane router (`crates/ahand-hub/src/http/control_plane.rs`). All bodies are camelCase via serde `rename_all = \"camelCase\"`. The SSE channel emits one event per JSON object — keepalives are SSE comments (`:keepalive`) and are NOT covered by these schemas because they aren't `data:` frames.",
+
+  "$defs": {
+    "DeviceId": {
+      "description": "Lowercase hex encoding of the daemon's 32-byte ed25519 public key.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+
+    "JobId": {
+      "description": "Hub-minted ULID assigned at job dispatch.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[A-Za-z0-9_-]+$"
+    },
+
+    "CreateJobRequest": {
+      "description": "Body of `POST /api/control/jobs`. Source: `CreateJobRequest` in `crates/ahand-hub/src/http/control_plane.rs`. The SDK builds this body in `CloudClient.spawn` (`packages/sdk/src/cloud-client.ts`).",
+      "type": "object",
+      "required": ["deviceId", "tool"],
+      "additionalProperties": false,
+      "properties": {
+        "deviceId": { "$ref": "#/$defs/DeviceId" },
+        "tool": {
+          "description": "Executable name resolved by the daemon (e.g. `bash`, `playwright-cli`, or a `$SHELL`/`shell` alias).",
+          "type": "string",
+          "minLength": 1
+        },
+        "args": {
+          "description": "Argument vector. Defaults to `[]` on the hub side via `serde(default)`.",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "cwd": {
+          "description": "Working directory the daemon should `cd` into before spawning. Defaults to the daemon's own cwd.",
+          "type": "string"
+        },
+        "env": {
+          "description": "Extra environment variables. Defaults to `{}`.",
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "timeoutMs": {
+          "description": "Hard kill after this many milliseconds. Hub default when absent: 5 minutes (`DEFAULT_JOB_TIMEOUT_MS`).",
+          "type": "integer",
+          "minimum": 1
+        },
+        "interactive": {
+          "description": "If true, the daemon runs the job under a PTY. Defaults to false.",
+          "type": "boolean"
+        },
+        "correlationId": {
+          "description": "Idempotency key. Re-submitting the same `(externalUserId, correlationId)` while the original job is still live returns the original `jobId` with HTTP 200 instead of 202.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+
+    "CreateJobResponse": {
+      "description": "Body of a successful `POST /api/control/jobs`. 202 on dispatch, 200 on idempotent replay.",
+      "type": "object",
+      "required": ["jobId"],
+      "additionalProperties": false,
+      "properties": {
+        "jobId": { "$ref": "#/$defs/JobId" }
+      }
+    },
+
+    "ErrorEnvelope": {
+      "description": "Body of a 4xx/5xx response. Hub source: `ErrorEnvelope` in `control_plane.rs`. `code` is one of `UNAUTHORIZED`, `FORBIDDEN`, `VALIDATION_ERROR`, `DEVICE_NOT_FOUND`, `DEVICE_OFFLINE`, `JOB_NOT_FOUND`, `RATE_LIMITED`, `INTERNAL_ERROR` — but the schema does NOT pin the enum because future error codes must not break existing clients.",
+      "type": "object",
+      "required": ["error"],
+      "additionalProperties": false,
+      "properties": {
+        "error": {
+          "type": "object",
+          "required": ["code", "message"],
+          "additionalProperties": false,
+          "properties": {
+            "code": { "type": "string", "minLength": 1 },
+            "message": { "type": "string" }
+          }
+        }
+      }
+    },
+
+    "SseEventStdout": {
+      "description": "`event: stdout` — a stdout chunk. The chunk is emitted as-is; multi-line content is NOT split. Source: `render_sse_event` in `control_plane.rs`.",
+      "type": "object",
+      "required": ["chunk"],
+      "additionalProperties": false,
+      "properties": { "chunk": { "type": "string" } }
+    },
+
+    "SseEventStderr": {
+      "description": "`event: stderr` — a stderr chunk.",
+      "type": "object",
+      "required": ["chunk"],
+      "additionalProperties": false,
+      "properties": { "chunk": { "type": "string" } }
+    },
+
+    "SseEventProgress": {
+      "description": "`event: progress` — opt-in progress reporting from the daemon. `message` is omitted when not provided (Rust serde branches on `Option<String>`).",
+      "type": "object",
+      "required": ["percent"],
+      "additionalProperties": false,
+      "properties": {
+        "percent": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "message": { "type": "string" }
+      }
+    },
+
+    "SseEventFinished": {
+      "description": "`event: finished` — terminal success. The SSE stream closes after this frame. SDK resolves `spawn()` with this shape.",
+      "type": "object",
+      "required": ["exitCode", "durationMs"],
+      "additionalProperties": false,
+      "properties": {
+        "exitCode": { "type": "integer" },
+        "durationMs": { "type": "integer", "minimum": 0 }
+      }
+    },
+
+    "SseEventError": {
+      "description": "`event: error` — terminal failure. The SSE stream closes after this frame. SDK rejects `spawn()` with `code = job_error`. `code` and `message` are forwarded to the SDK's `CloudClientError.jobErrorCode` / `.jobErrorMessage`.",
+      "type": "object",
+      "required": ["code", "message"],
+      "additionalProperties": false,
+      "properties": {
+        "code": { "type": "string", "minLength": 1 },
+        "message": { "type": "string" }
+      }
+    },
+
+    "SseEventByName": {
+      "description": "Tagged-union helper. `event` is the SSE event name; `data` matches the per-event schema. Used by the contract harness so a single test loop can assert on any frame.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["event", "data"],
+          "additionalProperties": false,
+          "properties": {
+            "event": { "const": "stdout" },
+            "data": { "$ref": "#/$defs/SseEventStdout" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["event", "data"],
+          "additionalProperties": false,
+          "properties": {
+            "event": { "const": "stderr" },
+            "data": { "$ref": "#/$defs/SseEventStderr" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["event", "data"],
+          "additionalProperties": false,
+          "properties": {
+            "event": { "const": "progress" },
+            "data": { "$ref": "#/$defs/SseEventProgress" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["event", "data"],
+          "additionalProperties": false,
+          "properties": {
+            "event": { "const": "finished" },
+            "data": { "$ref": "#/$defs/SseEventFinished" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["event", "data"],
+          "additionalProperties": false,
+          "properties": {
+            "event": { "const": "error" },
+            "data": { "$ref": "#/$defs/SseEventError" }
+          }
+        }
+      ]
+    }
+  },
+
+  "endpoints": {
+    "createJob": {
+      "method": "POST",
+      "path": "/api/control/jobs",
+      "auth": "Bearer <control-plane JWT>",
+      "request": { "$ref": "#/$defs/CreateJobRequest" },
+      "responses": {
+        "200": { "$ref": "#/$defs/CreateJobResponse" },
+        "202": { "$ref": "#/$defs/CreateJobResponse" },
+        "4xx": { "$ref": "#/$defs/ErrorEnvelope" },
+        "5xx": { "$ref": "#/$defs/ErrorEnvelope" }
+      }
+    },
+    "streamJob": {
+      "method": "GET",
+      "path": "/api/control/jobs/{jobId}/stream",
+      "auth": "Bearer <control-plane JWT>",
+      "responses": {
+        "200": {
+          "contentType": "text/event-stream",
+          "events": { "$ref": "#/$defs/SseEventByName" }
+        },
+        "4xx": { "$ref": "#/$defs/ErrorEnvelope" }
+      }
+    },
+    "cancelJob": {
+      "method": "POST",
+      "path": "/api/control/jobs/{jobId}/cancel",
+      "auth": "Bearer <control-plane JWT>",
+      "responses": {
+        "202": { "noBody": true },
+        "4xx": { "$ref": "#/$defs/ErrorEnvelope" }
+      }
+    }
+  }
+}

--- a/contracts/hub-webhook.json
+++ b/contracts/hub-webhook.json
@@ -36,7 +36,10 @@
 
   "allOf": [
     {
-      "if": { "properties": { "eventType": { "const": "device.heartbeat" } } },
+      "if": {
+        "properties": { "eventType": { "const": "device.heartbeat" } },
+        "required": ["eventType"]
+      },
       "then": {
         "properties": {
           "data": { "$ref": "#/$defs/HeartbeatData" }
@@ -54,7 +57,8 @@
               "device.revoked"
             ]
           }
-        }
+        },
+        "required": ["eventType"]
       },
       "then": {
         "properties": {

--- a/contracts/hub-webhook.json
+++ b/contracts/hub-webhook.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ahand.team9.ai/contracts/hub-webhook.json",
+  "title": "Hub outbound webhook envelope",
+  "description": "Canonical wire format for the JSON body the ahand-hub POSTs to a downstream gateway (e.g. team9 `/api/v1/ahand/hub-webhook`). Source of truth: `crates/ahand-hub/src/webhook/mod.rs::WebhookPayload`. Field order in the Rust serde struct is load-bearing for HMAC signature stability; the schema is order-agnostic, but the canonical payload generator MUST emit fields in the order eventId → eventType → deviceId → externalUserId → occurredAt → data.",
+
+  "type": "object",
+  "required": ["eventId", "eventType", "deviceId", "occurredAt", "data"],
+  "additionalProperties": false,
+
+  "properties": {
+    "eventId": {
+      "$ref": "#/$defs/EventId"
+    },
+    "eventType": {
+      "$ref": "#/$defs/EventType"
+    },
+    "deviceId": {
+      "$ref": "#/$defs/DeviceId"
+    },
+    "externalUserId": {
+      "description": "team9 user id the device is attributed to. Hub omits this field on events where it's unknown — `skip_serializing_if = Option::is_none` in the Rust struct — so the schema marks it optional. Gateway handlers look up the owner server-side by deviceId for non-registered events.",
+      "type": "string",
+      "minLength": 1
+    },
+    "occurredAt": {
+      "description": "RFC3339 / ISO-8601 timestamp the hub stamped when it enqueued the event.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "data": {
+      "description": "Event-specific payload. Empty object for online/offline/registered/revoked; carries cadence telemetry for heartbeat.",
+      "type": "object"
+    }
+  },
+
+  "allOf": [
+    {
+      "if": { "properties": { "eventType": { "const": "device.heartbeat" } } },
+      "then": {
+        "properties": {
+          "data": { "$ref": "#/$defs/HeartbeatData" }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "eventType": {
+            "enum": [
+              "device.online",
+              "device.offline",
+              "device.registered",
+              "device.revoked"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "data": { "$ref": "#/$defs/EmptyData" }
+        }
+      }
+    }
+  ],
+
+  "$defs": {
+    "EventId": {
+      "description": "ULID (26 Crockford base32 characters), optionally prefixed with `evt_`. The hub emits bare ULIDs via `ulid::Ulid::new()`; the team9 gateway DTO accepts both shapes for backwards compat with earlier designs that used the `evt_` prefix.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^(evt_)?[A-Za-z0-9_]+$"
+    },
+
+    "EventType": {
+      "description": "Closed enum of device lifecycle event types. Adding a new value is a breaking change for downstream gateways.",
+      "type": "string",
+      "enum": [
+        "device.registered",
+        "device.online",
+        "device.heartbeat",
+        "device.offline",
+        "device.revoked"
+      ]
+    },
+
+    "DeviceId": {
+      "description": "Lowercase hex encoding of the daemon's 32-byte ed25519 public key. Hub-side validation enforces 64 lowercase hex chars; the gateway DTO mirrors this.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+
+    "EmptyData": {
+      "description": "Empty object — emitted for non-heartbeat lifecycle events. Schema is `{}` (no properties allowed).",
+      "type": "object",
+      "additionalProperties": false
+    },
+
+    "HeartbeatData": {
+      "description": "Heartbeat telemetry. `sentAtMs` is the daemon-stamped epoch-ms when the heartbeat was sent (used for clock skew + RTT tracking). `presenceTtlSeconds` is the hub's hint (cadence × 3) so consumers can decide a device is offline without tracking cadence themselves. Both are REQUIRED — the hub always emits them (`crates/ahand-hub/src/webhook/mod.rs::enqueue_heartbeat`); pinning them required is what catches a regression where the hub silently drops one. `nickname` is preserved for legacy callers; new code SHOULD ignore it. `additionalProperties: true` so future cadence-related fields don't break existing consumers.",
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["sentAtMs", "presenceTtlSeconds"],
+      "properties": {
+        "sentAtMs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "presenceTtlSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "nickname": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Publishes the canonical wire-format schemas for the cross-repo seams to land Phase 9 / Task 9.5.

- `contracts/hub-webhook.json` — envelope the hub POSTs to a downstream gateway on device lifecycle events. Mirrors `crates/ahand-hub/src/webhook/mod.rs::WebhookPayload`, including the per-`eventType` data shapes (heartbeat carries `sentAtMs` + `presenceTtlSeconds`; online/offline/registered/revoked carry empty data).
- `contracts/hub-control-plane.json` — request/response bodies, error envelope, and SSE event payloads for `/api/control/jobs*`. Mirrors `crates/ahand-hub/src/http/control_plane.rs` and tracks the field names the camelCase serde rename produces (`tool` not `command`).
- `contracts/README.md` — stability rules + downstream consumer map.

The schemas are vendored into `team9` and `team9-agent-pi`. Their respective contract tests are the freshness gate — when a hub-side schema change goes out, the downstream test fails before the gateway DTO / SDK consumer drifts.

Field-order in the Rust serde struct is load-bearing for HMAC signature stability; the schema is order-agnostic but the README documents the canonical emit order.

## Test plan

- [x] Both schemas parse as valid JSON.
- [x] team9 `pnpm -F @team9/gateway test:contracts` passes against the vendored copy (26 tests, including 5 controller round-trip cases through `AhandHubWebhookController`).
- [x] team9 k6 `gen-webhook-payloads.mjs` emits payloads that satisfy `hub-webhook.json` (3 sample payloads, signatures verify, schema-pass on all 3).
- [x] team9-agent-pi `@team9claw/sdk-contracts` `tsd` passes — locks `CloudClient.spawn` / `.cancel` against the control-plane schema's TypeScript shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)