### PR TITLE
feat(hub): outbox persistence — durable hub→device buffer + multi-replica fencing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "subtle",
+ "testcontainers",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.28.0",

--- a/crates/ahand-hub-core/Cargo.toml
+++ b/crates/ahand-hub-core/Cargo.toml
@@ -15,6 +15,7 @@ jsonwebtoken.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/ahand-hub-core/src/error.rs
+++ b/crates/ahand-hub-core/src/error.rs
@@ -34,6 +34,8 @@ pub enum HubError {
     InvalidSignature,
     #[error("invalid peer ack {ack}, max issued seq is {max}")]
     InvalidPeerAck { ack: u64, max: u64 },
+    #[error("outbox lock contention for device {0}")]
+    OutboxLockContention(String),
     #[error("internal: {0}")]
     Internal(String),
 }

--- a/crates/ahand-hub-core/src/traits.rs
+++ b/crates/ahand-hub-core/src/traits.rs
@@ -74,3 +74,89 @@ pub trait AuditStore: Send + Sync {
         Ok(0)
     }
 }
+
+// ── Outbox persistence (hub→device durable buffer + multi-replica fencing) ──
+
+/// Subscription handle returned by [`OutboxStore::subscribe_kick`]. The
+/// receiver value increments whenever a kick is published on the device's
+/// channel. Drop releases the underlying Pub/Sub connection and aborts the
+/// background reader task.
+pub struct KickSubscription {
+    pub recv: tokio::sync::watch::Receiver<u64>,
+    pub _drop_guard: tokio::task::JoinHandle<()>,
+}
+
+/// Per-device durable outbox.
+///
+/// Implementations:
+/// * `RedisOutboxStore` (production) — Redis Streams + Lua scripts + Pub/Sub.
+/// * `InMemoryOutboxStore` (tests, `StoreConfig::Memory`) — in-process state.
+///
+/// All methods are `&self` and async; implementations are expected to be
+/// `Arc`-shared across tasks. `session_id` is a UUID generated per WS
+/// connection and acts as the fencing token: every fenced operation aborts
+/// with [`HubError::Unauthorized`] if the lock value does not match.
+#[async_trait]
+pub trait OutboxStore: Send + Sync + 'static {
+    /// Atomically `SET lock:device:{id} {session_id} NX EX <ttl>`. Returns
+    /// `true` on success, `false` if another session already holds the lock.
+    async fn try_acquire_lock(&self, device_id: &str, session_id: &str) -> Result<bool>;
+
+    /// Best-effort `PUBLISH kick:{device_id} <new_session_id>`. Failures
+    /// are logged but not propagated; the lease will eventually expire.
+    async fn kick(&self, device_id: &str, new_session_id: &str) -> Result<()>;
+
+    /// Subscribe to `kick:{device_id}`. The returned watch receiver ticks
+    /// (value increments) each time a kick arrives.
+    async fn subscribe_kick(&self, device_id: &str) -> Result<KickSubscription>;
+
+    /// Renew lease: Lua-checked `EXPIRE` — only renews if the current value
+    /// equals `session_id`. Returns `false` if the lock was lost.
+    async fn renew_lock(&self, device_id: &str, session_id: &str) -> Result<bool>;
+
+    /// Release lock: Lua-checked `DEL` — only deletes if value matches.
+    /// Idempotent.
+    async fn release_lock(&self, device_id: &str, session_id: &str) -> Result<()>;
+
+    /// Reconcile the per-device seq counter against the device's
+    /// `Hello.last_ack`:
+    ///
+    /// * If `seq:{id} >= last_ack`: trim acked entries with
+    ///   `XTRIM outbox:{id} MINID 0-{last_ack+1}` and return `current_seq`.
+    /// * If `seq:{id} < last_ack`: **bootstrap path** — the device has a
+    ///   higher last_ack than anything the store has ever seen, which is
+    ///   exactly the wedged-after-restart case for fresh deploys carrying
+    ///   this code. Set `seq:{id} = last_ack`, `DEL outbox:{id}`, return
+    ///   `last_ack`.
+    ///
+    /// Both branches keep the keys alive for 30d via `EXPIRE`. The fence
+    /// is checked via the lock script; callers must hold the lock.
+    async fn reconcile_on_hello(
+        &self,
+        device_id: &str,
+        session_id: &str,
+        last_ack: u64,
+    ) -> Result<u64>;
+
+    /// Read all unacked frames for replay: `XRANGE outbox:{id} (0-{last_ack} +`.
+    async fn unacked_frames(&self, device_id: &str, last_ack: u64) -> Result<Vec<Vec<u8>>>;
+
+    /// Reserve the next seq atomically: fence + `INCR seq:{id}`. Returns
+    /// the assigned seq. Callers then mutate `envelope.seq`, encode, and
+    /// call [`Self::xadd_frame`].
+    async fn fenced_incr_seq(&self, device_id: &str, session_id: &str) -> Result<u64>;
+
+    /// Append the encoded frame to the stream: fence + `XADD outbox:{id}
+    /// 0-{seq} frame <bytes>` + `MAXLEN ~ 10000` + `EXPIRE 30d`.
+    async fn xadd_frame(
+        &self,
+        device_id: &str,
+        session_id: &str,
+        seq: u64,
+        frame: Vec<u8>,
+    ) -> Result<()>;
+
+    /// Trim acked frames: `XTRIM outbox:{id} MINID 0-{ack+1}`. Fire-and-forget
+    /// from the caller's perspective; failure is logged but not surfaced.
+    async fn observe_ack(&self, device_id: &str, ack: u64) -> Result<()>;
+}

--- a/crates/ahand-hub-core/src/traits.rs
+++ b/crates/ahand-hub-core/src/traits.rs
@@ -77,13 +77,30 @@ pub trait AuditStore: Send + Sync {
 
 // ── Outbox persistence (hub→device durable buffer + multi-replica fencing) ──
 
+/// Wrapper around a [`tokio::task::JoinHandle`] that aborts the underlying
+/// task when dropped. Used by [`KickSubscription`] so downstream impls
+/// don't each have to remember to abort their background reader task.
+pub struct AbortOnDropHandle(tokio::task::JoinHandle<()>);
+
+impl AbortOnDropHandle {
+    pub fn new(handle: tokio::task::JoinHandle<()>) -> Self {
+        Self(handle)
+    }
+}
+
+impl Drop for AbortOnDropHandle {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
 /// Subscription handle returned by [`OutboxStore::subscribe_kick`]. The
 /// receiver value increments whenever a kick is published on the device's
 /// channel. Drop releases the underlying Pub/Sub connection and aborts the
 /// background reader task.
 pub struct KickSubscription {
     pub recv: tokio::sync::watch::Receiver<u64>,
-    pub _drop_guard: tokio::task::JoinHandle<()>,
+    pub _drop_guard: AbortOnDropHandle,
 }
 
 /// Per-device durable outbox.

--- a/crates/ahand-hub-store/src/lib.rs
+++ b/crates/ahand-hub-store/src/lib.rs
@@ -4,6 +4,7 @@ pub mod device_store;
 pub mod event_fanout;
 pub mod job_output_store;
 pub mod job_store;
+pub mod outbox_lua;
 pub mod postgres;
 pub mod presence_store;
 pub mod redis;

--- a/crates/ahand-hub-store/src/lib.rs
+++ b/crates/ahand-hub-store/src/lib.rs
@@ -5,6 +5,7 @@ pub mod event_fanout;
 pub mod job_output_store;
 pub mod job_store;
 pub mod outbox_lua;
+pub mod outbox_store;
 pub mod postgres;
 pub mod presence_store;
 pub mod redis;

--- a/crates/ahand-hub-store/src/outbox_lua.rs
+++ b/crates/ahand-hub-store/src/outbox_lua.rs
@@ -94,6 +94,25 @@ redis.call('EXPIRE', KEYS[2], ARGV[5])
 return 1
 "#;
 
+pub const BOUNDED_OBSERVE_ACK: &str = r#"
+-- KEYS[1] = seq:{id}
+-- KEYS[2] = outbox:{id}
+-- ARGV[1] = ack (decimal)
+-- Trim acked entries only if the device's claimed ack is at most the
+-- max seq we have ever issued. An invalid ack (claim > issued) is
+-- ignored — defense against buggy/compromised clients that would
+-- otherwise wipe their own legitimate replay buffer.
+local current = tonumber(redis.call('GET', KEYS[1])) or 0
+local ack = tonumber(ARGV[1])
+if ack > current then
+  return -1
+end
+if ack > 0 then
+  redis.call('XTRIM', KEYS[2], 'MINID', '0-' .. (ack + 1))
+end
+return current
+"#;
+
 /// Pre-built [`redis::Script`] handles. `redis::Script` itself caches the
 /// SHA1 internally and uses `EVALSHA`-then-`EVAL` automatically, so this
 /// type is mostly a named bundle so callers do not have to repeat the raw
@@ -105,6 +124,7 @@ pub struct OutboxScripts {
     pub reconcile_on_hello: Script,
     pub fenced_incr_seq: Script,
     pub fenced_xadd: Script,
+    pub bounded_observe_ack: Script,
 }
 
 impl OutboxScripts {
@@ -116,6 +136,7 @@ impl OutboxScripts {
             reconcile_on_hello: Script::new(RECONCILE_ON_HELLO),
             fenced_incr_seq: Script::new(FENCED_INCR_SEQ),
             fenced_xadd: Script::new(FENCED_XADD),
+            bounded_observe_ack: Script::new(BOUNDED_OBSERVE_ACK),
         }
     }
 }

--- a/crates/ahand-hub-store/src/outbox_lua.rs
+++ b/crates/ahand-hub-store/src/outbox_lua.rs
@@ -1,0 +1,121 @@
+//! Lua scripts for the per-device outbox protocol on the hub side.
+//!
+//! All scripts are loaded once at construction (`SCRIPT LOAD`) and invoked
+//! via `EVALSHA`. On `NOSCRIPT` (Redis restart, FLUSHALL), `redis::Script`
+//! transparently falls back to `EVAL` and re-caches the SHA. Callers do
+//! not need to handle script loading or SHA management.
+//!
+//! The scripts are designed to be the unit of atomicity. The Rust caller
+//! is responsible for ordering the two-step send (`fenced_incr_seq` →
+//! encode envelope with assigned seq → `fenced_xadd`); see the design doc
+//! for the rationale.
+
+use redis::Script;
+
+pub const ACQUIRE_LOCK: &str = r#"
+-- KEYS[1] = lock:device:{id}
+-- ARGV[1] = session_id
+-- ARGV[2] = ttl_secs
+local ok = redis.call('SET', KEYS[1], ARGV[1], 'NX', 'EX', ARGV[2])
+if ok then return 1 else return 0 end
+"#;
+
+pub const RENEW_LOCK: &str = r#"
+-- KEYS[1] = lock:device:{id}
+-- ARGV[1] = session_id
+-- ARGV[2] = ttl_secs
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  redis.call('EXPIRE', KEYS[1], ARGV[2])
+  return 1
+end
+return 0
+"#;
+
+pub const RELEASE_LOCK: &str = r#"
+-- KEYS[1] = lock:device:{id}
+-- ARGV[1] = session_id
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('DEL', KEYS[1])
+end
+return 0
+"#;
+
+pub const RECONCILE_ON_HELLO: &str = r#"
+-- KEYS[1] = lock:device:{id}
+-- KEYS[2] = seq:{id}
+-- KEYS[3] = outbox:{id}
+-- ARGV[1] = session_id
+-- ARGV[2] = last_ack (decimal)
+-- ARGV[3] = retention_secs
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then
+  return redis.error_reply('NOT_OWNER')
+end
+local current = tonumber(redis.call('GET', KEYS[2])) or 0
+local last_ack = tonumber(ARGV[2])
+if last_ack > current then
+  redis.call('SET', KEYS[2], last_ack)
+  redis.call('DEL', KEYS[3])
+  redis.call('EXPIRE', KEYS[2], ARGV[3])
+  return last_ack
+end
+if last_ack > 0 then
+  redis.call('XTRIM', KEYS[3], 'MINID', '0-' .. (last_ack + 1))
+end
+return current
+"#;
+
+pub const FENCED_INCR_SEQ: &str = r#"
+-- KEYS[1] = lock:device:{id}
+-- KEYS[2] = seq:{id}
+-- ARGV[1] = session_id
+-- ARGV[2] = retention_secs
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then
+  return redis.error_reply('NOT_OWNER')
+end
+local seq = redis.call('INCR', KEYS[2])
+redis.call('EXPIRE', KEYS[2], ARGV[2])
+return seq
+"#;
+
+pub const FENCED_XADD: &str = r#"
+-- KEYS[1] = lock:device:{id}
+-- KEYS[2] = outbox:{id}
+-- ARGV[1] = session_id
+-- ARGV[2] = seq (decimal)
+-- ARGV[3] = frame (binary)
+-- ARGV[4] = max_buffer (decimal)
+-- ARGV[5] = retention_secs
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then
+  return redis.error_reply('NOT_OWNER')
+end
+local id = '0-' .. ARGV[2]
+redis.call('XADD', KEYS[2], 'MAXLEN', '~', ARGV[4], id, 'frame', ARGV[3])
+redis.call('EXPIRE', KEYS[2], ARGV[5])
+return 1
+"#;
+
+/// Pre-built [`redis::Script`] handles. `redis::Script` itself caches the
+/// SHA1 internally and uses `EVALSHA`-then-`EVAL` automatically, so this
+/// type is mostly a named bundle so callers do not have to repeat the raw
+/// strings everywhere.
+pub struct OutboxScripts {
+    pub acquire_lock: Script,
+    pub renew_lock: Script,
+    pub release_lock: Script,
+    pub reconcile_on_hello: Script,
+    pub fenced_incr_seq: Script,
+    pub fenced_xadd: Script,
+}
+
+impl OutboxScripts {
+    pub fn load() -> Self {
+        Self {
+            acquire_lock: Script::new(ACQUIRE_LOCK),
+            renew_lock: Script::new(RENEW_LOCK),
+            release_lock: Script::new(RELEASE_LOCK),
+            reconcile_on_hello: Script::new(RECONCILE_ON_HELLO),
+            fenced_incr_seq: Script::new(FENCED_INCR_SEQ),
+            fenced_xadd: Script::new(FENCED_XADD),
+        }
+    }
+}

--- a/crates/ahand-hub-store/src/outbox_store.rs
+++ b/crates/ahand-hub-store/src/outbox_store.rs
@@ -1,10 +1,11 @@
 //! Redis-backed [`OutboxStore`] implementation.
 //!
-//! This module currently ships the lock-related primitives (acquire / kick /
-//! subscribe / renew / release). The data-path methods
-//! (`reconcile_on_hello`, `unacked_frames`, `fenced_incr_seq`, `xadd_frame`,
-//! `observe_ack`) are stubbed and return [`HubError::Internal`] — they will
-//! land in Task 4.
+//! Ships both the lock-related primitives (acquire / kick / subscribe /
+//! renew / release) and the data-path methods (`reconcile_on_hello`,
+//! `unacked_frames`, `fenced_incr_seq`, `xadd_frame`, `observe_ack`).
+//! The data-path methods rely on fenced Lua scripts so a stale session
+//! cannot bump the seq counter or write into the stream after a newer
+//! session has taken the lock.
 
 use std::sync::Arc;
 
@@ -19,6 +20,8 @@ use tokio::sync::{Mutex, watch};
 use crate::outbox_lua::OutboxScripts;
 
 const LOCK_TTL_SECS: u64 = 30;
+const RETENTION_SECS: u64 = 30 * 24 * 60 * 60; // 30 days
+const STREAM_MAXLEN: u64 = 10_000;
 
 #[derive(Clone)]
 pub struct RedisOutboxStore {
@@ -45,10 +48,26 @@ impl RedisOutboxStore {
     fn kick_channel(device_id: &str) -> String {
         format!("kick:{device_id}")
     }
+
+    fn seq_key(device_id: &str) -> String {
+        format!("seq:{device_id}")
+    }
+
+    fn outbox_key(device_id: &str) -> String {
+        format!("outbox:{device_id}")
+    }
 }
 
 fn redis_err(err: redis::RedisError) -> HubError {
     HubError::Internal(err.to_string())
+}
+
+fn map_redis_err(err: redis::RedisError) -> HubError {
+    if err.code() == Some("NOT_OWNER") {
+        HubError::Unauthorized
+    } else {
+        HubError::Internal(err.to_string())
+    }
 }
 
 #[async_trait]
@@ -136,46 +155,103 @@ impl OutboxStore for RedisOutboxStore {
         Ok(())
     }
 
-    // ── stub implementations of the rest; filled in by Task 4 ──
-
     async fn reconcile_on_hello(
         &self,
-        _device_id: &str,
-        _session_id: &str,
-        _last_ack: u64,
+        device_id: &str,
+        session_id: &str,
+        last_ack: u64,
     ) -> Result<u64> {
-        Err(HubError::Internal(
-            "reconcile_on_hello not implemented (Task 4)".into(),
-        ))
+        let mut conn = self.conn.lock().await;
+        let returned: u64 = self
+            .scripts
+            .reconcile_on_hello
+            .key(Self::lock_key(device_id))
+            .key(Self::seq_key(device_id))
+            .key(Self::outbox_key(device_id))
+            .arg(session_id)
+            .arg(last_ack.to_string())
+            .arg(RETENTION_SECS)
+            .invoke_async(&mut *conn)
+            .await
+            .map_err(map_redis_err)?;
+        Ok(returned)
     }
 
-    async fn unacked_frames(&self, _device_id: &str, _last_ack: u64) -> Result<Vec<Vec<u8>>> {
-        Err(HubError::Internal(
-            "unacked_frames not implemented (Task 4)".into(),
-        ))
+    async fn unacked_frames(&self, device_id: &str, last_ack: u64) -> Result<Vec<Vec<u8>>> {
+        use redis::streams::StreamRangeReply;
+        let mut conn = self.conn.lock().await;
+        // XRANGE expects exclusive start prefixed with '('. last_ack=0 means
+        // "everything"; encode that as start='-' so we don't synthesize 0-0.
+        let start = if last_ack == 0 {
+            "-".to_string()
+        } else {
+            format!("(0-{last_ack}")
+        };
+        let reply: StreamRangeReply = conn
+            .xrange(Self::outbox_key(device_id), start, "+")
+            .await
+            .map_err(redis_err)?;
+        let mut frames = Vec::with_capacity(reply.ids.len());
+        for entry in reply.ids {
+            if let Some(bytes) = entry.get::<Vec<u8>>("frame") {
+                frames.push(bytes);
+            }
+        }
+        Ok(frames)
     }
 
-    async fn fenced_incr_seq(&self, _device_id: &str, _session_id: &str) -> Result<u64> {
-        Err(HubError::Internal(
-            "fenced_incr_seq not implemented (Task 4)".into(),
-        ))
+    async fn fenced_incr_seq(&self, device_id: &str, session_id: &str) -> Result<u64> {
+        let mut conn = self.conn.lock().await;
+        let seq: u64 = self
+            .scripts
+            .fenced_incr_seq
+            .key(Self::lock_key(device_id))
+            .key(Self::seq_key(device_id))
+            .arg(session_id)
+            .arg(RETENTION_SECS)
+            .invoke_async(&mut *conn)
+            .await
+            .map_err(map_redis_err)?;
+        Ok(seq)
     }
 
     async fn xadd_frame(
         &self,
-        _device_id: &str,
-        _session_id: &str,
-        _seq: u64,
-        _frame: Vec<u8>,
+        device_id: &str,
+        session_id: &str,
+        seq: u64,
+        frame: Vec<u8>,
     ) -> Result<()> {
-        Err(HubError::Internal(
-            "xadd_frame not implemented (Task 4)".into(),
-        ))
+        let mut conn = self.conn.lock().await;
+        let _: i64 = self
+            .scripts
+            .fenced_xadd
+            .key(Self::lock_key(device_id))
+            .key(Self::outbox_key(device_id))
+            .arg(session_id)
+            .arg(seq.to_string())
+            .arg(frame)
+            .arg(STREAM_MAXLEN)
+            .arg(RETENTION_SECS)
+            .invoke_async(&mut *conn)
+            .await
+            .map_err(map_redis_err)?;
+        Ok(())
     }
 
-    async fn observe_ack(&self, _device_id: &str, _ack: u64) -> Result<()> {
-        Err(HubError::Internal(
-            "observe_ack not implemented (Task 4)".into(),
-        ))
+    async fn observe_ack(&self, device_id: &str, ack: u64) -> Result<()> {
+        if ack == 0 {
+            return Ok(());
+        }
+        let mut conn = self.conn.lock().await;
+        let minid = format!("0-{}", ack + 1);
+        let _: i64 = redis::cmd("XTRIM")
+            .arg(Self::outbox_key(device_id))
+            .arg("MINID")
+            .arg(minid)
+            .query_async(&mut *conn)
+            .await
+            .map_err(redis_err)?;
+        Ok(())
     }
 }

--- a/crates/ahand-hub-store/src/outbox_store.rs
+++ b/crates/ahand-hub-store/src/outbox_store.rs
@@ -1,0 +1,183 @@
+//! Redis-backed [`OutboxStore`] implementation.
+//!
+//! This module currently ships the lock-related primitives (acquire / kick /
+//! subscribe / renew / release). The data-path methods
+//! (`reconcile_on_hello`, `unacked_frames`, `fenced_incr_seq`, `xadd_frame`,
+//! `observe_ack`) are stubbed and return [`HubError::Internal`] — they will
+//! land in Task 4.
+
+use std::sync::Arc;
+
+use ahand_hub_core::traits::{AbortOnDropHandle, KickSubscription, OutboxStore};
+use ahand_hub_core::{HubError, Result};
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use redis::aio::ConnectionManager;
+use redis::{AsyncCommands, Client};
+use tokio::sync::{Mutex, watch};
+
+use crate::outbox_lua::OutboxScripts;
+
+const LOCK_TTL_SECS: u64 = 30;
+
+#[derive(Clone)]
+pub struct RedisOutboxStore {
+    client: Client,
+    conn: Arc<Mutex<ConnectionManager>>,
+    scripts: Arc<OutboxScripts>,
+}
+
+impl RedisOutboxStore {
+    pub async fn new(redis_url: &str) -> anyhow::Result<Self> {
+        let client = Client::open(redis_url)?;
+        let conn = crate::redis::connect_redis(redis_url).await?;
+        Ok(Self {
+            client,
+            conn: Arc::new(Mutex::new(conn)),
+            scripts: Arc::new(OutboxScripts::load()),
+        })
+    }
+
+    fn lock_key(device_id: &str) -> String {
+        format!("lock:device:{device_id}")
+    }
+
+    fn kick_channel(device_id: &str) -> String {
+        format!("kick:{device_id}")
+    }
+}
+
+fn redis_err(err: redis::RedisError) -> HubError {
+    HubError::Internal(err.to_string())
+}
+
+#[async_trait]
+impl OutboxStore for RedisOutboxStore {
+    async fn try_acquire_lock(&self, device_id: &str, session_id: &str) -> Result<bool> {
+        let mut conn = self.conn.lock().await;
+        let lock_key = Self::lock_key(device_id);
+        let result: i64 = self
+            .scripts
+            .acquire_lock
+            .key(lock_key)
+            .arg(session_id)
+            .arg(LOCK_TTL_SECS)
+            .invoke_async(&mut *conn)
+            .await
+            .map_err(redis_err)?;
+        Ok(result == 1)
+    }
+
+    async fn kick(&self, device_id: &str, new_session_id: &str) -> Result<()> {
+        let mut conn = self.conn.lock().await;
+        let _: i64 = conn
+            .publish(Self::kick_channel(device_id), new_session_id)
+            .await
+            .map_err(redis_err)?;
+        Ok(())
+    }
+
+    async fn subscribe_kick(&self, device_id: &str) -> Result<KickSubscription> {
+        let channel = Self::kick_channel(device_id);
+        let (tx, rx) = watch::channel(0u64);
+        let client = self.client.clone();
+
+        // Long-lived background task: subscribes to the kick channel and
+        // bumps the watch counter on each PUBLISH. The subscription
+        // PubSub connection is owned by the task; it lives until the
+        // task is aborted (via AbortOnDropHandle on KickSubscription drop)
+        // or the channel sender side is dropped.
+        let join = tokio::spawn(async move {
+            let mut pubsub = match client.get_async_pubsub().await {
+                Ok(p) => p,
+                Err(_) => return,
+            };
+            if pubsub.subscribe(channel.as_str()).await.is_err() {
+                return;
+            }
+            let mut stream = pubsub.on_message();
+            let mut counter: u64 = 0;
+            while let Some(_msg) = stream.next().await {
+                counter = counter.wrapping_add(1);
+                if tx.send(counter).is_err() {
+                    break;
+                }
+            }
+        });
+
+        Ok(KickSubscription {
+            recv: rx,
+            _drop_guard: AbortOnDropHandle::new(join),
+        })
+    }
+
+    async fn renew_lock(&self, device_id: &str, session_id: &str) -> Result<bool> {
+        let mut conn = self.conn.lock().await;
+        let result: i64 = self
+            .scripts
+            .renew_lock
+            .key(Self::lock_key(device_id))
+            .arg(session_id)
+            .arg(LOCK_TTL_SECS)
+            .invoke_async(&mut *conn)
+            .await
+            .map_err(redis_err)?;
+        Ok(result == 1)
+    }
+
+    async fn release_lock(&self, device_id: &str, session_id: &str) -> Result<()> {
+        let mut conn = self.conn.lock().await;
+        let _: i64 = self
+            .scripts
+            .release_lock
+            .key(Self::lock_key(device_id))
+            .arg(session_id)
+            .invoke_async(&mut *conn)
+            .await
+            .map_err(redis_err)?;
+        Ok(())
+    }
+
+    // ── stub implementations of the rest; filled in by Task 4 ──
+
+    async fn reconcile_on_hello(
+        &self,
+        _device_id: &str,
+        _session_id: &str,
+        _last_ack: u64,
+    ) -> Result<u64> {
+        Err(HubError::Internal(
+            "reconcile_on_hello not implemented (Task 4)".into(),
+        ))
+    }
+
+    async fn unacked_frames(&self, _device_id: &str, _last_ack: u64) -> Result<Vec<Vec<u8>>> {
+        Err(HubError::Internal(
+            "unacked_frames not implemented (Task 4)".into(),
+        ))
+    }
+
+    async fn fenced_incr_seq(&self, _device_id: &str, _session_id: &str) -> Result<u64> {
+        Err(HubError::Internal(
+            "fenced_incr_seq not implemented (Task 4)".into(),
+        ))
+    }
+
+    async fn xadd_frame(
+        &self,
+        _device_id: &str,
+        _session_id: &str,
+        _seq: u64,
+        _frame: Vec<u8>,
+    ) -> Result<()> {
+        Err(HubError::Internal(
+            "xadd_frame not implemented (Task 4)".into(),
+        ))
+    }
+
+    async fn observe_ack(&self, _device_id: &str, _ack: u64) -> Result<()> {
+        Err(HubError::Internal(
+            "observe_ack not implemented (Task 4)".into(),
+        ))
+    }
+}

--- a/crates/ahand-hub-store/src/outbox_store.rs
+++ b/crates/ahand-hub-store/src/outbox_store.rs
@@ -79,22 +79,20 @@ impl OutboxStore for RedisOutboxStore {
 
     async fn subscribe_kick(&self, device_id: &str) -> Result<KickSubscription> {
         let channel = Self::kick_channel(device_id);
-        let (tx, rx) = watch::channel(0u64);
-        let client = self.client.clone();
+        let mut pubsub = self.client.get_async_pubsub().await.map_err(redis_err)?;
+        pubsub
+            .subscribe(channel.as_str())
+            .await
+            .map_err(redis_err)?;
 
-        // Long-lived background task: subscribes to the kick channel and
-        // bumps the watch counter on each PUBLISH. The subscription
-        // PubSub connection is owned by the task; it lives until the
-        // task is aborted (via AbortOnDropHandle on KickSubscription drop)
-        // or the channel sender side is dropped.
+        let (tx, rx) = watch::channel(0u64);
+
+        // The subscribe call has already landed by the time we spawn this
+        // task; any kick PUBLISHed from now on will be delivered. The task
+        // owns the pubsub connection and lives until either:
+        //   - the watch receiver is dropped (we exit the loop on send error)
+        //   - AbortOnDropHandle::drop fires when KickSubscription is dropped
         let join = tokio::spawn(async move {
-            let mut pubsub = match client.get_async_pubsub().await {
-                Ok(p) => p,
-                Err(_) => return,
-            };
-            if pubsub.subscribe(channel.as_str()).await.is_err() {
-                return;
-            }
             let mut stream = pubsub.on_message();
             let mut counter: u64 = 0;
             while let Some(_msg) = stream.next().await {

--- a/crates/ahand-hub-store/src/outbox_store.rs
+++ b/crates/ahand-hub-store/src/outbox_store.rs
@@ -244,12 +244,17 @@ impl OutboxStore for RedisOutboxStore {
             return Ok(());
         }
         let mut conn = self.conn.lock().await;
-        let minid = format!("0-{}", ack + 1);
-        let _: i64 = redis::cmd("XTRIM")
-            .arg(Self::outbox_key(device_id))
-            .arg("MINID")
-            .arg(minid)
-            .query_async(&mut *conn)
+        // Lua-atomic: trim the stream only if the claimed ack is within
+        // the range of seqs we have actually issued. An invalid ack
+        // (claim > issued) is ignored to protect the legitimate replay
+        // buffer from a buggy/compromised client.
+        let _: i64 = self
+            .scripts
+            .bounded_observe_ack
+            .key(Self::seq_key(device_id))
+            .key(Self::outbox_key(device_id))
+            .arg(ack.to_string())
+            .invoke_async(&mut *conn)
             .await
             .map_err(redis_err)?;
         Ok(())

--- a/crates/ahand-hub-store/tests/store_roundtrip.rs
+++ b/crates/ahand-hub-store/tests/store_roundtrip.rs
@@ -8,7 +8,7 @@ use ahand_hub_core::audit::{AuditEntry, AuditFilter};
 use ahand_hub_core::device::NewDevice;
 use ahand_hub_core::job::{JobFilter, JobStatus, NewJob};
 use ahand_hub_core::services::job_dispatcher::JobDispatcher;
-use ahand_hub_core::traits::{AuditStore, DeviceStore, JobStore};
+use ahand_hub_core::traits::{AuditStore, DeviceStore, JobStore, OutboxStore};
 use ahand_hub_store::bootstrap_store::RedisBootstrapStore;
 use ahand_hub_store::job_output_store::{JobOutputRecord, RedisJobOutputStore};
 use chrono::{Duration as ChronoDuration, Utc};
@@ -508,5 +508,48 @@ async fn audit_store_prunes_entries_older_than_cutoff() -> anyhow::Result<()> {
     assert_eq!(remaining.len(), 1);
     assert_eq!(remaining[0].resource_id, "recent-job");
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn outbox_lock_acquire_and_release() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    assert!(stack.outbox.try_acquire_lock("dev-lock-1", "sess-a").await?);
+    assert!(!stack.outbox.try_acquire_lock("dev-lock-1", "sess-b").await?);
+    stack.outbox.release_lock("dev-lock-1", "sess-a").await?;
+    assert!(stack.outbox.try_acquire_lock("dev-lock-1", "sess-b").await?);
+    Ok(())
+}
+
+#[tokio::test]
+async fn outbox_lock_release_with_wrong_session_is_noop() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    assert!(stack.outbox.try_acquire_lock("dev-lock-2", "sess-a").await?);
+    stack.outbox.release_lock("dev-lock-2", "sess-other").await?;
+    assert!(!stack.outbox.try_acquire_lock("dev-lock-2", "sess-b").await?);
+    Ok(())
+}
+
+#[tokio::test]
+async fn outbox_lock_renew_extends_ttl_for_owner_only() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    stack.outbox.try_acquire_lock("dev-lock-3", "sess-a").await?;
+    assert!(stack.outbox.renew_lock("dev-lock-3", "sess-a").await?);
+    assert!(!stack.outbox.renew_lock("dev-lock-3", "sess-b").await?);
+    Ok(())
+}
+
+#[tokio::test]
+async fn outbox_kick_delivers_to_subscriber() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    let mut sub = stack.outbox.subscribe_kick("dev-kick-1").await?;
+    // Subscriber must be ready before publish; sleep briefly to let the
+    // background task complete its SUBSCRIBE.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    stack.outbox.kick("dev-kick-1", "new-sess").await?;
+    tokio::time::timeout(std::time::Duration::from_secs(2), sub.recv.changed())
+        .await
+        .expect("kick should arrive within 2s")?;
+    assert!(*sub.recv.borrow() >= 1);
     Ok(())
 }

--- a/crates/ahand-hub-store/tests/store_roundtrip.rs
+++ b/crates/ahand-hub-store/tests/store_roundtrip.rs
@@ -543,9 +543,9 @@ async fn outbox_lock_renew_extends_ttl_for_owner_only() -> anyhow::Result<()> {
 async fn outbox_kick_delivers_to_subscriber() -> anyhow::Result<()> {
     let stack = TestStack::start().await?;
     let mut sub = stack.outbox.subscribe_kick("dev-kick-1").await?;
-    // Subscriber must be ready before publish; sleep briefly to let the
-    // background task complete its SUBSCRIBE.
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    // No sleep needed: subscribe_kick returns only after SUBSCRIBE has
+    // landed, so any kick published from this point is guaranteed to
+    // be delivered to the watch channel.
     stack.outbox.kick("dev-kick-1", "new-sess").await?;
     tokio::time::timeout(std::time::Duration::from_secs(2), sub.recv.changed())
         .await

--- a/crates/ahand-hub-store/tests/store_roundtrip.rs
+++ b/crates/ahand-hub-store/tests/store_roundtrip.rs
@@ -8,6 +8,7 @@ use ahand_hub_core::audit::{AuditEntry, AuditFilter};
 use ahand_hub_core::device::NewDevice;
 use ahand_hub_core::job::{JobFilter, JobStatus, NewJob};
 use ahand_hub_core::services::job_dispatcher::JobDispatcher;
+use ahand_hub_core::HubError;
 use ahand_hub_core::traits::{AuditStore, DeviceStore, JobStore, OutboxStore};
 use ahand_hub_store::bootstrap_store::RedisBootstrapStore;
 use ahand_hub_store::job_output_store::{JobOutputRecord, RedisJobOutputStore};
@@ -551,5 +552,96 @@ async fn outbox_kick_delivers_to_subscriber() -> anyhow::Result<()> {
         .await
         .expect("kick should arrive within 2s")?;
     assert!(*sub.recv.borrow() >= 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn outbox_send_and_replay_roundtrip() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    let dev = "dev-send-1";
+    let sess = "sess-a";
+    stack.outbox.try_acquire_lock(dev, sess).await?;
+
+    let mut seqs = Vec::new();
+    for i in 0..5u8 {
+        let seq = stack.outbox.fenced_incr_seq(dev, sess).await?;
+        stack.outbox.xadd_frame(dev, sess, seq, vec![i]).await?;
+        seqs.push(seq);
+    }
+    assert_eq!(seqs, vec![1, 2, 3, 4, 5]);
+
+    let frames = stack.outbox.unacked_frames(dev, 0).await?;
+    assert_eq!(
+        frames,
+        vec![vec![0u8], vec![1u8], vec![2u8], vec![3u8], vec![4u8]]
+    );
+
+    let frames = stack.outbox.unacked_frames(dev, 2).await?;
+    assert_eq!(frames, vec![vec![2u8], vec![3u8], vec![4u8]]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn outbox_observe_ack_trims() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    let dev = "dev-ack-1";
+    let sess = "sess-a";
+    stack.outbox.try_acquire_lock(dev, sess).await?;
+
+    for i in 0..3u8 {
+        let seq = stack.outbox.fenced_incr_seq(dev, sess).await?;
+        stack.outbox.xadd_frame(dev, sess, seq, vec![i]).await?;
+    }
+    stack.outbox.observe_ack(dev, 2).await?;
+    let frames = stack.outbox.unacked_frames(dev, 0).await?;
+    assert_eq!(frames, vec![vec![2u8]]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn outbox_reconcile_normal_path_returns_current_seq() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    let dev = "dev-rec-normal";
+    let sess = "sess-a";
+    stack.outbox.try_acquire_lock(dev, sess).await?;
+    for _ in 0..5 {
+        let seq = stack.outbox.fenced_incr_seq(dev, sess).await?;
+        stack.outbox.xadd_frame(dev, sess, seq, vec![]).await?;
+    }
+    let current = stack.outbox.reconcile_on_hello(dev, sess, 3).await?;
+    assert_eq!(current, 5);
+    let frames = stack.outbox.unacked_frames(dev, 0).await?;
+    // 1..=3 trimmed; 4..=5 remain
+    assert_eq!(frames.len(), 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn outbox_reconcile_bootstrap_path_seeds_and_clears() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    let dev = "dev-rec-bootstrap";
+    let sess = "sess-a";
+    stack.outbox.try_acquire_lock(dev, sess).await?;
+    // Fresh device, last_ack=9 — the wedged-after-restart case.
+    let returned = stack.outbox.reconcile_on_hello(dev, sess, 9).await?;
+    assert_eq!(returned, 9);
+    let next = stack.outbox.fenced_incr_seq(dev, sess).await?;
+    assert_eq!(next, 10);
+    let frames = stack.outbox.unacked_frames(dev, 9).await?;
+    assert!(frames.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn outbox_send_rejects_non_owner() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    let dev = "dev-fence";
+    stack.outbox.try_acquire_lock(dev, "sess-a").await?;
+    let err = stack
+        .outbox
+        .fenced_incr_seq(dev, "sess-b")
+        .await
+        .unwrap_err();
+    assert!(matches!(err, HubError::Unauthorized));
     Ok(())
 }

--- a/crates/ahand-hub-store/tests/store_roundtrip.rs
+++ b/crates/ahand-hub-store/tests/store_roundtrip.rs
@@ -4,11 +4,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use ahand_hub_core::HubError;
 use ahand_hub_core::audit::{AuditEntry, AuditFilter};
 use ahand_hub_core::device::NewDevice;
 use ahand_hub_core::job::{JobFilter, JobStatus, NewJob};
 use ahand_hub_core::services::job_dispatcher::JobDispatcher;
-use ahand_hub_core::HubError;
 use ahand_hub_core::traits::{AuditStore, DeviceStore, JobStore, OutboxStore};
 use ahand_hub_store::bootstrap_store::RedisBootstrapStore;
 use ahand_hub_store::job_output_store::{JobOutputRecord, RedisJobOutputStore};
@@ -515,26 +515,57 @@ async fn audit_store_prunes_entries_older_than_cutoff() -> anyhow::Result<()> {
 #[tokio::test]
 async fn outbox_lock_acquire_and_release() -> anyhow::Result<()> {
     let stack = TestStack::start().await?;
-    assert!(stack.outbox.try_acquire_lock("dev-lock-1", "sess-a").await?);
-    assert!(!stack.outbox.try_acquire_lock("dev-lock-1", "sess-b").await?);
+    assert!(
+        stack
+            .outbox
+            .try_acquire_lock("dev-lock-1", "sess-a")
+            .await?
+    );
+    assert!(
+        !stack
+            .outbox
+            .try_acquire_lock("dev-lock-1", "sess-b")
+            .await?
+    );
     stack.outbox.release_lock("dev-lock-1", "sess-a").await?;
-    assert!(stack.outbox.try_acquire_lock("dev-lock-1", "sess-b").await?);
+    assert!(
+        stack
+            .outbox
+            .try_acquire_lock("dev-lock-1", "sess-b")
+            .await?
+    );
     Ok(())
 }
 
 #[tokio::test]
 async fn outbox_lock_release_with_wrong_session_is_noop() -> anyhow::Result<()> {
     let stack = TestStack::start().await?;
-    assert!(stack.outbox.try_acquire_lock("dev-lock-2", "sess-a").await?);
-    stack.outbox.release_lock("dev-lock-2", "sess-other").await?;
-    assert!(!stack.outbox.try_acquire_lock("dev-lock-2", "sess-b").await?);
+    assert!(
+        stack
+            .outbox
+            .try_acquire_lock("dev-lock-2", "sess-a")
+            .await?
+    );
+    stack
+        .outbox
+        .release_lock("dev-lock-2", "sess-other")
+        .await?;
+    assert!(
+        !stack
+            .outbox
+            .try_acquire_lock("dev-lock-2", "sess-b")
+            .await?
+    );
     Ok(())
 }
 
 #[tokio::test]
 async fn outbox_lock_renew_extends_ttl_for_owner_only() -> anyhow::Result<()> {
     let stack = TestStack::start().await?;
-    stack.outbox.try_acquire_lock("dev-lock-3", "sess-a").await?;
+    stack
+        .outbox
+        .try_acquire_lock("dev-lock-3", "sess-a")
+        .await?;
     assert!(stack.outbox.renew_lock("dev-lock-3", "sess-a").await?);
     assert!(!stack.outbox.renew_lock("dev-lock-3", "sess-b").await?);
     Ok(())

--- a/crates/ahand-hub-store/tests/support/mod.rs
+++ b/crates/ahand-hub-store/tests/support/mod.rs
@@ -12,6 +12,7 @@ pub struct TestStack {
     pub jobs: ahand_hub_store::job_store::PgJobStore,
     pub audit: ahand_hub_store::audit_store::PgAuditStore,
     pub presence: ahand_hub_store::presence_store::RedisPresenceStore,
+    pub outbox: ahand_hub_store::outbox_store::RedisOutboxStore,
     database_url: String,
     redis_url: String,
     _postgres: ManagedContainer,
@@ -52,6 +53,7 @@ impl TestStack {
         let redis_url = format!("redis://127.0.0.1:{redis_port}");
         let redis_connection = ahand_hub_store::redis::connect_redis(&redis_url).await?;
         let presence = ahand_hub_store::presence_store::RedisPresenceStore::new(redis_connection);
+        let outbox = ahand_hub_store::outbox_store::RedisOutboxStore::new(&redis_url).await?;
 
         Ok(Self {
             devices: ahand_hub_store::device_store::PgDeviceStore::with_presence(
@@ -61,6 +63,7 @@ impl TestStack {
             jobs: ahand_hub_store::job_store::PgJobStore::new(postgres_pool.clone()),
             audit: ahand_hub_store::audit_store::PgAuditStore::new(postgres_pool),
             presence,
+            outbox,
             database_url,
             redis_url,
             _postgres: postgres,

--- a/crates/ahand-hub/Cargo.toml
+++ b/crates/ahand-hub/Cargo.toml
@@ -43,4 +43,5 @@ ed25519-dalek = { version = "2", features = ["rand_core"] }
 futures-util = "0.3"
 prost.workspace = true
 reqwest = { version = "0.12", features = ["json", "stream"] }
+testcontainers.workspace = true
 tokio-tungstenite = "0.28"

--- a/crates/ahand-hub/src/http/api_error.rs
+++ b/crates/ahand-hub/src/http/api_error.rs
@@ -149,9 +149,7 @@ impl From<HubError> for ApiError {
             HubError::OutboxLockContention(device_id) => Self::new(
                 StatusCode::SERVICE_UNAVAILABLE,
                 "OUTBOX_LOCK_CONTENTION",
-                format!(
-                    "Device {device_id} session lock is contended; retry shortly"
-                ),
+                format!("Device {device_id} session lock is contended; retry shortly"),
             ),
             HubError::Internal(_) => Self::internal("Internal server error"),
         }

--- a/crates/ahand-hub/src/http/api_error.rs
+++ b/crates/ahand-hub/src/http/api_error.rs
@@ -146,6 +146,13 @@ impl From<HubError> for ApiError {
                 "VALIDATION_ERROR",
                 format!("Invalid peer ack {ack}; max issued seq is {max}"),
             ),
+            HubError::OutboxLockContention(device_id) => Self::new(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "OUTBOX_LOCK_CONTENTION",
+                format!(
+                    "Device {device_id} session lock is contended; retry shortly"
+                ),
+            ),
             HubError::Internal(_) => Self::internal("Internal server error"),
         }
     }

--- a/crates/ahand-hub/src/http/jobs.rs
+++ b/crates/ahand-hub/src/http/jobs.rs
@@ -182,7 +182,7 @@ impl JobRuntime {
     pub async fn handle_device_frame(&self, device_id: &str, frame: &[u8]) -> anyhow::Result<()> {
         let envelope = ahand_protocol::Envelope::decode(frame)?;
         if self.connections.has_seen_inbound(device_id, envelope.seq) {
-            self.connections.observe_ack(device_id, envelope.ack)?;
+            self.connections.observe_ack(device_id, envelope.ack).await?;
             return Ok(());
         }
 
@@ -195,7 +195,7 @@ impl JobRuntime {
                 };
                 self.clear_disconnect_task(&event.job_id);
                 if is_terminal_status(job.status) {
-                    self.connections.observe_inbound(device_id, seq, ack)?;
+                    self.connections.observe_inbound(device_id, seq, ack).await?;
                     return Ok(());
                 }
                 if let Some(event_kind) = event.event {
@@ -210,7 +210,8 @@ impl JobRuntime {
                                 .await
                             {
                                 return self
-                                    .handle_stale_device_frame_error(device_id, seq, ack, err);
+                                    .handle_stale_device_frame_error(device_id, seq, ack, err)
+                                    .await;
                             }
                             self.output_stream.push_stdout(&event.job_id, chunk).await?;
                         }
@@ -224,7 +225,8 @@ impl JobRuntime {
                                 .await
                             {
                                 return self
-                                    .handle_stale_device_frame_error(device_id, seq, ack, err);
+                                    .handle_stale_device_frame_error(device_id, seq, ack, err)
+                                    .await;
                             }
                             self.output_stream.push_stderr(&event.job_id, chunk).await?;
                         }
@@ -238,7 +240,8 @@ impl JobRuntime {
                                 .await
                             {
                                 return self
-                                    .handle_stale_device_frame_error(device_id, seq, ack, err);
+                                    .handle_stale_device_frame_error(device_id, seq, ack, err)
+                                    .await;
                             }
                             self.output_stream
                                 .push_progress(&event.job_id, progress)
@@ -253,7 +256,7 @@ impl JobRuntime {
                 };
                 self.clear_disconnect_task(&finished.job_id);
                 if is_terminal_status(job.status) {
-                    self.connections.observe_inbound(device_id, seq, ack)?;
+                    self.connections.observe_inbound(device_id, seq, ack).await?;
                     return Ok(());
                 }
                 if job.status != JobStatus::Running
@@ -265,7 +268,7 @@ impl JobRuntime {
                         )
                         .await
                 {
-                    return self.handle_stale_device_frame_error(device_id, seq, ack, err);
+                    return self.handle_stale_device_frame_error(device_id, seq, ack, err).await;
                 }
                 let status = if finished.error == "cancelled" {
                     JobStatus::Cancelled
@@ -284,7 +287,7 @@ impl JobRuntime {
                     )
                     .await
                 {
-                    return self.handle_stale_device_frame_error(device_id, seq, ack, err);
+                    return self.handle_stale_device_frame_error(device_id, seq, ack, err).await;
                 }
             }
             Some(ahand_protocol::envelope::Payload::JobRejected(rejected)) => {
@@ -293,7 +296,7 @@ impl JobRuntime {
                 };
                 self.clear_disconnect_task(&rejected.job_id);
                 if is_terminal_status(job.status) {
-                    self.connections.observe_inbound(device_id, seq, ack)?;
+                    self.connections.observe_inbound(device_id, seq, ack).await?;
                     return Ok(());
                 }
                 if let Err(err) = self
@@ -306,13 +309,13 @@ impl JobRuntime {
                     )
                     .await
                 {
-                    return self.handle_stale_device_frame_error(device_id, seq, ack, err);
+                    return self.handle_stale_device_frame_error(device_id, seq, ack, err).await;
                 }
             }
             _ => {}
         }
 
-        self.connections.observe_inbound(device_id, seq, ack)?;
+        self.connections.observe_inbound(device_id, seq, ack).await?;
         Ok(())
     }
 
@@ -535,7 +538,7 @@ impl JobRuntime {
             .await
     }
 
-    fn handle_stale_device_frame_error(
+    async fn handle_stale_device_frame_error(
         &self,
         device_id: &str,
         seq: u64,
@@ -546,7 +549,7 @@ impl JobRuntime {
             err.downcast_ref::<HubError>(),
             Some(HubError::IllegalJobTransition { current, .. }) if is_terminal_status(*current)
         ) {
-            self.connections.observe_inbound(device_id, seq, ack)?;
+            self.connections.observe_inbound(device_id, seq, ack).await?;
             return Ok(());
         }
         Err(err)
@@ -1011,7 +1014,9 @@ mod tests {
 
         let jobs = Arc::new(MemoryJobStore::default());
         let audit = Arc::new(MemoryAuditStore::default());
-        let connections = Arc::new(ConnectionRegistry::default());
+        let connections = Arc::new(ConnectionRegistry::new(Arc::new(
+            crate::ws::in_memory_outbox::InMemoryOutboxStore::new(),
+        )));
         let events = Arc::new(EventBus::new(audit.clone()));
         let output_stream = Arc::new(crate::output_stream::OutputStream::default());
         let dispatcher = Arc::new(JobDispatcher::new(devices, jobs.clone(), audit.clone()));
@@ -1040,7 +1045,9 @@ mod tests {
         insert_online_device(&devices, "device-2").await;
 
         let audit = Arc::new(MemoryAuditStore::default());
-        let connections = Arc::new(ConnectionRegistry::default());
+        let connections = Arc::new(ConnectionRegistry::new(Arc::new(
+            crate::ws::in_memory_outbox::InMemoryOutboxStore::new(),
+        )));
         let events = Arc::new(EventBus::new(audit.clone()));
         let output_stream = Arc::new(crate::output_stream::OutputStream::default());
         let dispatcher = Arc::new(JobDispatcher::new(devices, jobs.clone(), audit.clone()));
@@ -1083,12 +1090,12 @@ mod tests {
         }
     }
 
-    fn attach_live_connection(
+    async fn attach_live_connection(
         connections: &Arc<ConnectionRegistry>,
         device_id: &str,
     ) -> tokio::task::JoinHandle<()> {
         let (_connection_id, mut rx, _close_rx) =
-            connections.register(device_id.into(), 0).unwrap();
+            connections.register(device_id.into(), 0).await.unwrap();
         tokio::spawn(async move {
             while let Some(outbound) = rx.recv().await {
                 let _ = outbound;
@@ -1099,7 +1106,8 @@ mod tests {
     #[tokio::test]
     async fn create_job_marks_failed_and_emits_terminal_output_when_dispatch_fails() {
         let (runtime, connections, jobs, audit) = build_runtime().await;
-        let (_connection_id, rx, _close_rx) = connections.register("device-1".into(), 0).unwrap();
+        let (_connection_id, rx, _close_rx) =
+            connections.register("device-1".into(), 0).await.unwrap();
         drop(rx);
 
         let err = runtime
@@ -1166,7 +1174,7 @@ mod tests {
     #[tokio::test]
     async fn handle_device_frame_rejects_job_updates_for_other_devices() {
         let (runtime, connections, _jobs, _audit) = build_runtime().await;
-        let _transport = attach_live_connection(&connections, "device-2");
+        let _transport = attach_live_connection(&connections, "device-2").await;
         let job = runtime
             .create_job(NewJob {
                 device_id: "device-2".into(),
@@ -1215,7 +1223,7 @@ mod tests {
     #[tokio::test]
     async fn progress_event_moves_job_to_running_and_writes_audit() {
         let (runtime, connections, jobs, audit) = build_runtime().await;
-        let _transport = attach_live_connection(&connections, "device-1");
+        let _transport = attach_live_connection(&connections, "device-1").await;
         let job = runtime
             .create_job(NewJob {
                 device_id: "device-1".into(),
@@ -1261,7 +1269,7 @@ mod tests {
             fail_next_running_transition: Arc::new(AtomicBool::new(true)),
         });
         let (runtime, connections, _audit) = build_runtime_with_jobs(jobs.clone()).await;
-        let _transport = attach_live_connection(&connections, "device-1");
+        let _transport = attach_live_connection(&connections, "device-1").await;
         let job = runtime
             .create_job(NewJob {
                 device_id: "device-1".into(),
@@ -1300,7 +1308,7 @@ mod tests {
     #[tokio::test]
     async fn cancelled_finish_event_marks_job_cancelled_and_writes_audit() {
         let (runtime, connections, jobs, audit) = build_runtime().await;
-        let _transport = attach_live_connection(&connections, "device-1");
+        let _transport = attach_live_connection(&connections, "device-1").await;
         let job = runtime
             .create_job(NewJob {
                 device_id: "device-1".into(),
@@ -1347,7 +1355,7 @@ mod tests {
     #[tokio::test]
     async fn successful_finish_event_marks_job_finished_and_writes_audit() {
         let (runtime, connections, jobs, audit) = build_runtime().await;
-        let _transport = attach_live_connection(&connections, "device-1");
+        let _transport = attach_live_connection(&connections, "device-1").await;
         let job = runtime
             .create_job(NewJob {
                 device_id: "device-1".into(),

--- a/crates/ahand-hub/src/http/jobs.rs
+++ b/crates/ahand-hub/src/http/jobs.rs
@@ -182,7 +182,9 @@ impl JobRuntime {
     pub async fn handle_device_frame(&self, device_id: &str, frame: &[u8]) -> anyhow::Result<()> {
         let envelope = ahand_protocol::Envelope::decode(frame)?;
         if self.connections.has_seen_inbound(device_id, envelope.seq) {
-            self.connections.observe_ack(device_id, envelope.ack).await?;
+            self.connections
+                .observe_ack(device_id, envelope.ack)
+                .await?;
             return Ok(());
         }
 
@@ -195,7 +197,9 @@ impl JobRuntime {
                 };
                 self.clear_disconnect_task(&event.job_id);
                 if is_terminal_status(job.status) {
-                    self.connections.observe_inbound(device_id, seq, ack).await?;
+                    self.connections
+                        .observe_inbound(device_id, seq, ack)
+                        .await?;
                     return Ok(());
                 }
                 if let Some(event_kind) = event.event {
@@ -256,7 +260,9 @@ impl JobRuntime {
                 };
                 self.clear_disconnect_task(&finished.job_id);
                 if is_terminal_status(job.status) {
-                    self.connections.observe_inbound(device_id, seq, ack).await?;
+                    self.connections
+                        .observe_inbound(device_id, seq, ack)
+                        .await?;
                     return Ok(());
                 }
                 if job.status != JobStatus::Running
@@ -268,7 +274,9 @@ impl JobRuntime {
                         )
                         .await
                 {
-                    return self.handle_stale_device_frame_error(device_id, seq, ack, err).await;
+                    return self
+                        .handle_stale_device_frame_error(device_id, seq, ack, err)
+                        .await;
                 }
                 let status = if finished.error == "cancelled" {
                     JobStatus::Cancelled
@@ -287,7 +295,9 @@ impl JobRuntime {
                     )
                     .await
                 {
-                    return self.handle_stale_device_frame_error(device_id, seq, ack, err).await;
+                    return self
+                        .handle_stale_device_frame_error(device_id, seq, ack, err)
+                        .await;
                 }
             }
             Some(ahand_protocol::envelope::Payload::JobRejected(rejected)) => {
@@ -296,7 +306,9 @@ impl JobRuntime {
                 };
                 self.clear_disconnect_task(&rejected.job_id);
                 if is_terminal_status(job.status) {
-                    self.connections.observe_inbound(device_id, seq, ack).await?;
+                    self.connections
+                        .observe_inbound(device_id, seq, ack)
+                        .await?;
                     return Ok(());
                 }
                 if let Err(err) = self
@@ -309,13 +321,17 @@ impl JobRuntime {
                     )
                     .await
                 {
-                    return self.handle_stale_device_frame_error(device_id, seq, ack, err).await;
+                    return self
+                        .handle_stale_device_frame_error(device_id, seq, ack, err)
+                        .await;
                 }
             }
             _ => {}
         }
 
-        self.connections.observe_inbound(device_id, seq, ack).await?;
+        self.connections
+            .observe_inbound(device_id, seq, ack)
+            .await?;
         Ok(())
     }
 
@@ -549,7 +565,9 @@ impl JobRuntime {
             err.downcast_ref::<HubError>(),
             Some(HubError::IllegalJobTransition { current, .. }) if is_terminal_status(*current)
         ) {
-            self.connections.observe_inbound(device_id, seq, ack).await?;
+            self.connections
+                .observe_inbound(device_id, seq, ack)
+                .await?;
             return Ok(());
         }
         Err(err)

--- a/crates/ahand-hub/src/state.rs
+++ b/crates/ahand-hub/src/state.rs
@@ -149,7 +149,13 @@ impl AppState {
             Some(store) => crate::output_stream::OutputStream::persistent(store),
             None => crate::output_stream::OutputStream::new(finished_retention, 256),
         });
-        let connections = Arc::new(crate::ws::device_gateway::ConnectionRegistry::default());
+        // Task 5 wires the registry to an in-memory OutboxStore so the
+        // refactored fencing/replay/lock paths exercise the trait. Task 6
+        // will branch on `StoreConfig::Persistent` to plug in
+        // `RedisOutboxStore` instead.
+        let outbox: Arc<dyn ahand_hub_core::traits::OutboxStore> =
+            Arc::new(crate::ws::in_memory_outbox::InMemoryOutboxStore::new());
+        let connections = Arc::new(crate::ws::device_gateway::ConnectionRegistry::new(outbox));
         let events = Arc::new(match persistent_fanout {
             Some(fanout) => crate::events::EventBus::new_with_fanout(audit_store.clone(), fanout),
             None => crate::events::EventBus::new(audit_store.clone()),

--- a/crates/ahand-hub/src/state.rs
+++ b/crates/ahand-hub/src/state.rs
@@ -100,6 +100,7 @@ impl AppState {
             persistent_fanout,
             bootstrap_tokens,
             webhook_delivery_store,
+            outbox,
         ) = match &config.store {
             crate::config::StoreConfig::Memory => (
                 Arc::new(MemoryDeviceStore::default()),
@@ -109,6 +110,8 @@ impl AppState {
                 None,
                 crate::bootstrap::BootstrapCredentials::memory(),
                 Arc::new(MemoryWebhookDeliveryStore::new()) as Arc<dyn WebhookDeliveryStore>,
+                Arc::new(crate::ws::in_memory_outbox::InMemoryOutboxStore::new())
+                    as Arc<dyn ahand_hub_core::traits::OutboxStore>,
             ),
             crate::config::StoreConfig::Persistent {
                 database_url,
@@ -121,6 +124,8 @@ impl AppState {
                     presence_redis,
                     config.device_presence_ttl_secs,
                 );
+                let outbox_store =
+                    ahand_hub_store::outbox_store::RedisOutboxStore::new(redis_url).await?;
                 (
                     Arc::new(MemoryDeviceStore::with_persistent(
                         PgDeviceStore::with_presence(pool.clone(), presence),
@@ -134,6 +139,7 @@ impl AppState {
                         bootstrap_reservation_ttl,
                     )),
                     Arc::new(PgWebhookDeliveryStore::new(pool)) as Arc<dyn WebhookDeliveryStore>,
+                    Arc::new(outbox_store) as Arc<dyn ahand_hub_core::traits::OutboxStore>,
                 )
             }
         };
@@ -149,12 +155,6 @@ impl AppState {
             Some(store) => crate::output_stream::OutputStream::persistent(store),
             None => crate::output_stream::OutputStream::new(finished_retention, 256),
         });
-        // Task 5 wires the registry to an in-memory OutboxStore so the
-        // refactored fencing/replay/lock paths exercise the trait. Task 6
-        // will branch on `StoreConfig::Persistent` to plug in
-        // `RedisOutboxStore` instead.
-        let outbox: Arc<dyn ahand_hub_core::traits::OutboxStore> =
-            Arc::new(crate::ws::in_memory_outbox::InMemoryOutboxStore::new());
         let connections = Arc::new(crate::ws::device_gateway::ConnectionRegistry::new(outbox));
         let events = Arc::new(match persistent_fanout {
             Some(fanout) => crate::events::EventBus::new_with_fanout(audit_store.clone(), fanout),

--- a/crates/ahand-hub/src/ws/device_gateway.rs
+++ b/crates/ahand-hub/src/ws/device_gateway.rs
@@ -1068,7 +1068,10 @@ mod tests {
         // Send 5 envelopes; drain each from the mpsc to confirm delivery.
         for i in 1..=5u8 {
             registry
-                .send("device-1", job_envelope(&format!("job-{i}"), &format!("job-{i}"), "x"))
+                .send(
+                    "device-1",
+                    job_envelope(&format!("job-{i}"), &format!("job-{i}"), "x"),
+                )
                 .await
                 .unwrap();
             let frame = rx_a.recv().await.expect("frame delivered");
@@ -1081,8 +1084,7 @@ mod tests {
         registry.unregister("device-1", conn_a).await.unwrap();
 
         // Re-register with last_ack=2 — only seqs 3..=5 should replay.
-        let (_conn_b, mut rx_b, _close_b) =
-            registry.register("device-1".into(), 2).await.unwrap();
+        let (_conn_b, mut rx_b, _close_b) = registry.register("device-1".into(), 2).await.unwrap();
         let mut replayed = Vec::new();
         while let Ok(Some(frame)) =
             tokio::time::timeout(Duration::from_millis(50), rx_b.recv()).await
@@ -1121,8 +1123,7 @@ mod tests {
     #[tokio::test]
     async fn unregister_removes_idle_entries() {
         let registry = ConnectionRegistry::new(Arc::new(InMemoryOutboxStore::new()));
-        let (connection_id, rx, _close_rx) =
-            registry.register("device-1".into(), 0).await.unwrap();
+        let (connection_id, rx, _close_rx) = registry.register("device-1".into(), 0).await.unwrap();
         drop(rx);
 
         let removed = registry
@@ -1161,8 +1162,7 @@ mod tests {
         // worst-case behavior. Once the holder unregisters, the next
         // register succeeds.
         let registry = ConnectionRegistry::new(Arc::new(InMemoryOutboxStore::new()));
-        let (conn_a, _rx_a, _close_a) =
-            registry.register("device-1".into(), 0).await.unwrap();
+        let (conn_a, _rx_a, _close_a) = registry.register("device-1".into(), 0).await.unwrap();
 
         let err = registry
             .register("device-1".into(), 0)
@@ -1175,7 +1175,6 @@ mod tests {
 
         registry.unregister("device-1", conn_a).await.unwrap();
         // After the holder releases, a fresh register succeeds.
-        let (_conn_b, _rx_b, _close_b) =
-            registry.register("device-1".into(), 0).await.unwrap();
+        let (_conn_b, _rx_b, _close_b) = registry.register("device-1".into(), 0).await.unwrap();
     }
 }

--- a/crates/ahand-hub/src/ws/device_gateway.rs
+++ b/crates/ahand-hub/src/ws/device_gateway.rs
@@ -575,6 +575,34 @@ async fn run_device_socket(socket: WebSocket, state: AppState) -> anyhow::Result
                 );
             }
         }
+        let device_id = envelope.device_id.clone();
+        let hostname = hello.hostname.clone();
+        // Register BEFORE sending HelloAccepted so the in-process
+        // DashMap entry is observable by the time the client sees the
+        // accepted frame and starts dispatching jobs. With the
+        // OutboxStore-backed registry, register involves Redis I/O —
+        // sending HelloAccepted first would let a fast client race the
+        // register completion and see is_online=false on its first
+        // request.
+        let (connection_id, mut outbound_rx, close_rx) = match state
+            .connections
+            .register(device_id.clone(), hello.last_ack)
+            .await
+        {
+            Ok(tuple) => tuple,
+            Err(HubError::OutboxLockContention(_)) => {
+                let _ = send_handshake_close(
+                    &mut sender,
+                    axum::extract::ws::close_code::AGAIN,
+                    "outbox-lock-contention",
+                )
+                .await;
+                return Err(anyhow::Error::from(HubError::OutboxLockContention(
+                    device_id.clone(),
+                )));
+            }
+            Err(err) => return Err(anyhow::Error::from(err)),
+        };
         sender
             .send(WsMessage::Binary(
                 ahand_protocol::Envelope {
@@ -596,27 +624,6 @@ async fn run_device_socket(socket: WebSocket, state: AppState) -> anyhow::Result
                 .into(),
             ))
             .await?;
-        let device_id = envelope.device_id.clone();
-        let hostname = hello.hostname.clone();
-        let (connection_id, mut outbound_rx, close_rx) = match state
-            .connections
-            .register(device_id.clone(), hello.last_ack)
-            .await
-        {
-            Ok(tuple) => tuple,
-            Err(HubError::OutboxLockContention(_)) => {
-                let _ = send_handshake_close(
-                    &mut sender,
-                    axum::extract::ws::close_code::AGAIN,
-                    "outbox-lock-contention",
-                )
-                .await;
-                return Err(anyhow::Error::from(HubError::OutboxLockContention(
-                    device_id.clone(),
-                )));
-            }
-            Err(err) => return Err(anyhow::Error::from(err)),
-        };
         let (control_tx, mut control_rx) = mpsc::unbounded_channel::<WsMessage>();
         let last_inbound_at = Arc::new(AsyncMutex::new(tokio::time::Instant::now()));
         active_connection = Some((device_id.clone(), connection_id));

--- a/crates/ahand-hub/src/ws/device_gateway.rs
+++ b/crates/ahand-hub/src/ws/device_gateway.rs
@@ -45,8 +45,17 @@ struct ActiveConnection {
     kick_task: Arc<AsyncMutex<Option<JoinHandle<()>>>>,
 }
 
-pub(crate) struct OutboundFrame {
-    pub(crate) frame: Vec<u8>,
+pub struct OutboundFrame {
+    pub frame: Vec<u8>,
+}
+
+impl OutboundFrame {
+    /// Borrow the frame bytes as a slice. Convenience helper for
+    /// integration tests that drain the receiver and want to decode
+    /// without poking at the field directly.
+    pub fn as_slice(&self) -> &[u8] {
+        self.frame.as_slice()
+    }
 }
 
 impl ConnectionRegistry {
@@ -57,7 +66,7 @@ impl ConnectionRegistry {
         }
     }
 
-    pub(crate) async fn register(
+    pub async fn register(
         &self,
         device_id: String,
         last_ack: u64,
@@ -344,7 +353,7 @@ impl ConnectionRegistry {
             .unwrap_or(false)
     }
 
-    pub(crate) async fn observe_ack(&self, device_id: &str, ack: u64) -> anyhow::Result<()> {
+    pub async fn observe_ack(&self, device_id: &str, ack: u64) -> anyhow::Result<()> {
         if ack == 0 {
             return Ok(());
         }
@@ -377,7 +386,7 @@ impl ConnectionRegistry {
         self.observe_ack(device_id, ack).await
     }
 
-    pub(crate) async fn unregister(
+    pub async fn unregister(
         &self,
         device_id: &str,
         connection_id: uuid::Uuid,

--- a/crates/ahand-hub/src/ws/device_gateway.rs
+++ b/crates/ahand-hub/src/ws/device_gateway.rs
@@ -106,11 +106,13 @@ impl ConnectionRegistry {
             let _ = self.outbox.release_lock(&device_id, &session_id).await;
             return Err(err);
         }
-        let replay = self
-            .outbox
-            .unacked_frames(&device_id, last_ack)
-            .await
-            .unwrap_or_default();
+        let replay = match self.outbox.unacked_frames(&device_id, last_ack).await {
+            Ok(frames) => frames,
+            Err(err) => {
+                let _ = self.outbox.release_lock(&device_id, &session_id).await;
+                return Err(err);
+            }
+        };
 
         // 3) Build per-connection state.
         let (tx, rx) = mpsc::unbounded_channel();
@@ -587,11 +589,25 @@ async fn run_device_socket(socket: WebSocket, state: AppState) -> anyhow::Result
             .await?;
         let device_id = envelope.device_id.clone();
         let hostname = hello.hostname.clone();
-        let (connection_id, mut outbound_rx, close_rx) = state
+        let (connection_id, mut outbound_rx, close_rx) = match state
             .connections
             .register(device_id.clone(), hello.last_ack)
             .await
-            .map_err(anyhow::Error::from)?;
+        {
+            Ok(tuple) => tuple,
+            Err(HubError::OutboxLockContention(_)) => {
+                let _ = send_handshake_close(
+                    &mut sender,
+                    axum::extract::ws::close_code::AGAIN,
+                    "outbox-lock-contention",
+                )
+                .await;
+                return Err(anyhow::Error::from(HubError::OutboxLockContention(
+                    device_id.clone(),
+                )));
+            }
+            Err(err) => return Err(anyhow::Error::from(err)),
+        };
         let (control_tx, mut control_rx) = mpsc::unbounded_channel::<WsMessage>();
         let last_inbound_at = Arc::new(AsyncMutex::new(tokio::time::Instant::now()));
         active_connection = Some((device_id.clone(), connection_id));

--- a/crates/ahand-hub/src/ws/device_gateway.rs
+++ b/crates/ahand-hub/src/ws/device_gateway.rs
@@ -155,26 +155,31 @@ impl ConnectionRegistry {
             })
         };
 
-        // 5) Spawn kick subscriber.
+        // 5) Subscribe to kicks BEFORE returning, so a kick that fires
+        //    moments after register completes (e.g., a sibling replica
+        //    racing for the same device) cannot slip through the window
+        //    while a spawned task hasn't yet issued SUBSCRIBE. The
+        //    subscribe_kick call awaits the underlying SUBSCRIBE; the
+        //    spawned task only owns the watch loop.
+        let mut kick_sub = match self.outbox.subscribe_kick(&device_id).await {
+            Ok(sub) => sub,
+            Err(err) => {
+                tracing::warn!(
+                    device_id = %device_id,
+                    error = %err,
+                    "failed to subscribe to kick channel; releasing lock",
+                );
+                let _ = self.outbox.release_lock(&device_id, &session_id).await;
+                return Err(err);
+            }
+        };
         let kick_task = {
-            let outbox = self.outbox.clone();
-            let device_id = device_id.clone();
+            let device_id_inner = device_id.clone();
             let close_tx = close_tx.clone();
             tokio::spawn(async move {
-                let mut sub = match outbox.subscribe_kick(&device_id).await {
-                    Ok(sub) => sub,
-                    Err(err) => {
-                        tracing::warn!(
-                            device_id = %device_id,
-                            error = %err,
-                            "failed to subscribe to kick channel",
-                        );
-                        return;
-                    }
-                };
-                if sub.recv.changed().await.is_ok() {
+                if kick_sub.recv.changed().await.is_ok() {
                     tracing::info!(
-                        device_id = %device_id,
+                        device_id = %device_id_inner,
                         "received kick, signalling close",
                     );
                     let _ = close_tx.send(true);

--- a/crates/ahand-hub/src/ws/device_gateway.rs
+++ b/crates/ahand-hub/src/ws/device_gateway.rs
@@ -1,33 +1,48 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use dashmap::DashMap;
 use futures_util::{SinkExt, StreamExt};
 use prost::Message;
 use tokio::sync::{Mutex as AsyncMutex, mpsc, watch};
+use tokio::task::JoinHandle;
 
 use ahand_hub_core::HubError;
-use ahand_hub_core::traits::DeviceStore;
+use ahand_hub_core::traits::{DeviceStore, OutboxStore};
 use axum::extract::State;
 use axum::extract::ws::{CloseFrame, Message as WsMessage, WebSocket, WebSocketUpgrade};
 use axum::response::Response;
 
 use crate::state::AppState;
 
-#[derive(Default)]
+const LEASE_RENEW_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+const LOCK_ACQUIRE_RETRIES: u32 = 5;
+const LOCK_ACQUIRE_BACKOFF: std::time::Duration = std::time::Duration::from_millis(200);
+
 pub struct ConnectionRegistry {
     senders: DashMap<String, ConnectionEntry>,
+    outbox: Arc<dyn OutboxStore>,
 }
 
 struct ConnectionEntry {
     active: Option<ActiveConnection>,
-    outbox: Mutex<ahand_hub_core::Outbox>,
 }
 
 #[derive(Clone)]
 struct ActiveConnection {
     connection_id: uuid::Uuid,
+    /// UUID acting as the fencing token in every OutboxStore call.
+    session_id: String,
     sender: mpsc::UnboundedSender<OutboundFrame>,
     close_tx: watch::Sender<bool>,
+    /// Highest inbound seq observed from this device on this connection.
+    /// Used both for dedup (`has_seen_inbound`) and to populate the `ack`
+    /// field on outbound envelopes so the daemon can trim its own outbox.
+    last_inbound_seq: Arc<AtomicU64>,
+    /// Aborted on close so the lease renewer stops attempting to renew.
+    lease_task: Arc<AsyncMutex<Option<JoinHandle<()>>>>,
+    /// Aborted on close so the kick subscriber stops listening.
+    kick_task: Arc<AsyncMutex<Option<JoinHandle<()>>>>,
 }
 
 pub(crate) struct OutboundFrame {
@@ -35,61 +50,154 @@ pub(crate) struct OutboundFrame {
 }
 
 impl ConnectionRegistry {
-    pub(crate) fn register(
+    pub fn new(outbox: Arc<dyn OutboxStore>) -> Self {
+        Self {
+            senders: DashMap::new(),
+            outbox,
+        }
+    }
+
+    pub(crate) async fn register(
         &self,
         device_id: String,
         last_ack: u64,
-    ) -> anyhow::Result<(
-        uuid::Uuid,
-        mpsc::UnboundedReceiver<OutboundFrame>,
-        watch::Receiver<bool>,
-    )> {
+    ) -> Result<
+        (
+            uuid::Uuid,
+            mpsc::UnboundedReceiver<OutboundFrame>,
+            watch::Receiver<bool>,
+        ),
+        HubError,
+    > {
+        let session_id = uuid::Uuid::new_v4().to_string();
+
+        // 1) Acquire the lock with a kick-then-retry dance. The kick is
+        //    addressed to the *previous* holder, but we publish ours as the
+        //    "new owner" payload so subscribers can decide whether to bail.
+        let mut acquired = self
+            .outbox
+            .try_acquire_lock(&device_id, &session_id)
+            .await?;
+        if !acquired {
+            self.outbox.kick(&device_id, &session_id).await?;
+            for _ in 0..LOCK_ACQUIRE_RETRIES {
+                tokio::time::sleep(LOCK_ACQUIRE_BACKOFF).await;
+                acquired = self
+                    .outbox
+                    .try_acquire_lock(&device_id, &session_id)
+                    .await?;
+                if acquired {
+                    break;
+                }
+            }
+        }
+        if !acquired {
+            return Err(HubError::OutboxLockContention(device_id));
+        }
+
+        // 2) Reconcile + read replay frames BEFORE we wire the in-process
+        //    state, so a failure during reconcile leaves the lock in a
+        //    clean state via the release_lock in the error arm.
+        if let Err(err) = self
+            .outbox
+            .reconcile_on_hello(&device_id, &session_id, last_ack)
+            .await
+        {
+            let _ = self.outbox.release_lock(&device_id, &session_id).await;
+            return Err(err);
+        }
+        let replay = self
+            .outbox
+            .unacked_frames(&device_id, last_ack)
+            .await
+            .unwrap_or_default();
+
+        // 3) Build per-connection state.
         let (tx, rx) = mpsc::unbounded_channel();
         let connection_id = uuid::Uuid::new_v4();
         let (close_tx, close_rx) = watch::channel(false);
-        let active = ActiveConnection {
-            connection_id,
-            sender: tx.clone(),
-            close_tx,
+
+        // 4) Spawn lease renewer.
+        let lease_task = {
+            let outbox = self.outbox.clone();
+            let device_id = device_id.clone();
+            let session_id = session_id.clone();
+            let close_tx = close_tx.clone();
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(LEASE_RENEW_INTERVAL);
+                interval.tick().await; // first tick is immediate; skip
+                loop {
+                    interval.tick().await;
+                    match outbox.renew_lock(&device_id, &session_id).await {
+                        Ok(true) => continue,
+                        Ok(false) | Err(_) => {
+                            tracing::warn!(
+                                device_id = %device_id,
+                                session_id = %session_id,
+                                "lease lost, signalling close",
+                            );
+                            let _ = close_tx.send(true);
+                            break;
+                        }
+                    }
+                }
+            })
         };
 
+        // 5) Spawn kick subscriber.
+        let kick_task = {
+            let outbox = self.outbox.clone();
+            let device_id = device_id.clone();
+            let close_tx = close_tx.clone();
+            tokio::spawn(async move {
+                let mut sub = match outbox.subscribe_kick(&device_id).await {
+                    Ok(sub) => sub,
+                    Err(err) => {
+                        tracing::warn!(
+                            device_id = %device_id,
+                            error = %err,
+                            "failed to subscribe to kick channel",
+                        );
+                        return;
+                    }
+                };
+                if sub.recv.changed().await.is_ok() {
+                    tracing::info!(
+                        device_id = %device_id,
+                        "received kick, signalling close",
+                    );
+                    let _ = close_tx.send(true);
+                }
+            })
+        };
+
+        let active = ActiveConnection {
+            connection_id,
+            session_id: session_id.clone(),
+            sender: tx.clone(),
+            close_tx: close_tx.clone(),
+            last_inbound_seq: Arc::new(AtomicU64::new(0)),
+            lease_task: Arc::new(AsyncMutex::new(Some(lease_task))),
+            kick_task: Arc::new(AsyncMutex::new(Some(kick_task))),
+        };
+
+        // 6) Push replay frames first, then publish the active connection.
+        for frame in replay {
+            let _ = tx.send(OutboundFrame { frame });
+        }
         match self.senders.entry(device_id) {
             dashmap::mapref::entry::Entry::Occupied(mut entry) => {
                 let entry = entry.get_mut();
-                let replay = {
-                    let mut outbox = entry.outbox.lock().expect("outbox mutex poisoned");
-                    if !outbox.try_on_peer_ack(last_ack) {
-                        return Err(HubError::InvalidPeerAck {
-                            ack: last_ack,
-                            max: outbox.last_issued_seq(),
-                        }
-                        .into());
-                    }
-                    outbox.replay_from(0)
-                };
-                if let Some(previous) = entry.active.replace(active.clone()) {
-                    let _ = previous.close_tx.send(true);
-                }
-                for frame in replay {
-                    let _ = tx.send(OutboundFrame { frame });
+                if let Some(prev) = entry.active.replace(active) {
+                    let _ = prev.close_tx.send(true);
                 }
             }
             dashmap::mapref::entry::Entry::Vacant(entry) => {
-                let mut outbox = ahand_hub_core::Outbox::new(10_000);
-                if !outbox.try_on_peer_ack(last_ack) {
-                    return Err(HubError::InvalidPeerAck {
-                        ack: last_ack,
-                        max: outbox.last_issued_seq(),
-                    }
-                    .into());
-                }
                 entry.insert(ConnectionEntry {
                     active: Some(active),
-                    outbox: Mutex::new(outbox),
                 });
             }
         }
-
         Ok((connection_id, rx, close_rx))
     }
 
@@ -98,49 +206,70 @@ impl ConnectionRegistry {
         device_id: &str,
         mut envelope: ahand_protocol::Envelope,
     ) -> anyhow::Result<()> {
-        let (seq, frame) = {
+        let (sender, session_id, connection_id, last_inbound_seq) = {
             let entry = self
                 .senders
-                .get_mut(device_id)
+                .get(device_id)
                 .ok_or_else(|| HubError::DeviceOffline(device_id.into()))?;
-            let mut outbox = entry.outbox.lock().expect("outbox mutex poisoned");
-            let seq = outbox.reserve_seq();
-            envelope.seq = seq;
-            envelope.ack = outbox.local_ack();
-            let frame = envelope.encode_to_vec();
-            outbox.store(seq, frame.clone());
-            (seq, frame)
+            let active = entry
+                .active
+                .as_ref()
+                .ok_or_else(|| HubError::DeviceOffline(device_id.into()))?;
+            (
+                active.sender.clone(),
+                active.session_id.clone(),
+                active.connection_id,
+                active.last_inbound_seq.clone(),
+            )
         };
 
-        loop {
-            let (sender, connection_id) = {
-                let entry = self
-                    .senders
-                    .get(device_id)
-                    .ok_or_else(|| HubError::DeviceOffline(device_id.into()))?;
-                let active = entry
-                    .active
-                    .as_ref()
-                    .ok_or_else(|| HubError::DeviceOffline(device_id.into()))?;
-                (active.sender.clone(), active.connection_id)
-            };
-            if sender
-                .send(OutboundFrame {
-                    frame: frame.clone(),
-                })
-                .is_err()
-            {
-                self.clear_current_sender(device_id, connection_id);
-                if !self.has_active(device_id) {
-                    if let Some(entry) = self.senders.get_mut(device_id) {
-                        let mut outbox = entry.outbox.lock().expect("outbox mutex poisoned");
-                        outbox.remove(seq);
-                    }
-                    return Err(HubError::DeviceOffline(device_id.into()).into());
-                }
-                continue;
+        let seq = match self.outbox.fenced_incr_seq(device_id, &session_id).await {
+            Ok(seq) => seq,
+            Err(HubError::Unauthorized) => {
+                self.fail_connection(device_id, connection_id);
+                return Err(HubError::DeviceOffline(device_id.into()).into());
             }
-            return Ok(());
+            Err(err) => return Err(err.into()),
+        };
+        envelope.seq = seq;
+        envelope.ack = last_inbound_seq.load(Ordering::Relaxed);
+        let frame = envelope.encode_to_vec();
+
+        if let Err(err) = self
+            .outbox
+            .xadd_frame(device_id, &session_id, seq, frame.clone())
+            .await
+        {
+            if matches!(err, HubError::Unauthorized) {
+                self.fail_connection(device_id, connection_id);
+                return Err(HubError::DeviceOffline(device_id.into()).into());
+            }
+            return Err(err.into());
+        }
+
+        if sender.send(OutboundFrame { frame }).is_err() {
+            // The WS IO task is gone; the message stays in the durable
+            // stream and will replay on next reconnect.
+            self.fail_connection(device_id, connection_id);
+            return Err(HubError::DeviceOffline(device_id.into()).into());
+        }
+        Ok(())
+    }
+
+    /// Mark the active connection for `device_id` dead if it still matches
+    /// `connection_id`. Signals close_tx so the WS handler tears down. The
+    /// background tasks are aborted by `unregister`, which is reached via
+    /// the close_tx path.
+    fn fail_connection(&self, device_id: &str, connection_id: uuid::Uuid) {
+        if let Some(mut entry) = self.senders.get_mut(device_id)
+            && entry
+                .active
+                .as_ref()
+                .map(|a| a.connection_id == connection_id)
+                .unwrap_or(false)
+            && let Some(active) = entry.active.take()
+        {
+            let _ = active.close_tx.send(true);
         }
     }
 
@@ -189,11 +318,7 @@ impl ConnectionRegistry {
     }
 
     /// Public wrapper around [`Self::send`] so the control-plane HTTP
-    /// handlers can dispatch envelopes to a device. The underlying
-    /// path is the same as the dashboard job flow; we expose it here
-    /// to keep the module boundary tight rather than promoting
-    /// `send` itself to public (which would also expose the retry
-    /// loop semantics to more call sites).
+    /// handlers can dispatch envelopes to a device.
     pub async fn send_envelope(
         &self,
         device_id: &str,
@@ -202,68 +327,52 @@ impl ConnectionRegistry {
         self.send(device_id, envelope).await
     }
 
+    /// True iff the device's connection has already observed an inbound
+    /// envelope with seq >= `seq`. Used by the WS handler and JobRuntime
+    /// to dedup retransmits — the durable stream is hub→device only, so
+    /// this is per-connection state, not store-backed.
     pub(crate) fn has_seen_inbound(&self, device_id: &str, seq: u64) -> bool {
         if seq == 0 {
             return false;
         }
         self.senders
             .get(device_id)
-            .map(|entry| {
-                let outbox = entry.outbox.lock().expect("outbox mutex poisoned");
-                outbox.local_ack() >= seq
-            })
+            .and_then(|entry| entry.active.as_ref().map(|a| a.last_inbound_seq.clone()))
+            .map(|last| last.load(Ordering::Relaxed) >= seq)
             .unwrap_or(false)
     }
 
-    pub(crate) fn observe_ack(&self, device_id: &str, ack: u64) -> anyhow::Result<()> {
+    pub(crate) async fn observe_ack(&self, device_id: &str, ack: u64) -> anyhow::Result<()> {
         if ack == 0 {
             return Ok(());
         }
-        let should_cleanup = if let Some(entry) = self.senders.get_mut(device_id) {
-            let mut outbox = entry.outbox.lock().expect("outbox mutex poisoned");
-            if !outbox.try_on_peer_ack(ack) {
-                return Err(HubError::InvalidPeerAck {
-                    ack,
-                    max: outbox.last_issued_seq(),
-                }
-                .into());
-            }
-            entry.active.is_none() && outbox.is_empty()
-        } else {
-            false
-        };
-        if should_cleanup {
-            self.senders.remove(device_id);
+        // Fire-and-forget: the durable stream is the authority and the
+        // next successful ack or MAXLEN trim will catch up if this one
+        // fails. We log so the failure shows up in the hub's tracing.
+        if let Err(err) = self.outbox.observe_ack(device_id, ack).await {
+            tracing::warn!(
+                device_id = %device_id,
+                ack = ack,
+                error = %err,
+                "outbox observe_ack failed",
+            );
         }
         Ok(())
     }
 
-    pub(crate) fn observe_inbound(
+    pub(crate) async fn observe_inbound(
         &self,
         device_id: &str,
         seq: u64,
         ack: u64,
     ) -> anyhow::Result<()> {
-        let should_cleanup = if let Some(entry) = self.senders.get_mut(device_id) {
-            let mut outbox = entry.outbox.lock().expect("outbox mutex poisoned");
-            if seq > 0 {
-                outbox.on_recv(seq);
-            }
-            if ack > 0 && !outbox.try_on_peer_ack(ack) {
-                return Err(HubError::InvalidPeerAck {
-                    ack,
-                    max: outbox.last_issued_seq(),
-                }
-                .into());
-            }
-            entry.active.is_none() && outbox.is_empty()
-        } else {
-            false
-        };
-        if should_cleanup {
-            self.senders.remove(device_id);
+        if seq > 0
+            && let Some(entry) = self.senders.get(device_id)
+            && let Some(active) = entry.active.as_ref()
+        {
+            active.last_inbound_seq.fetch_max(seq, Ordering::Relaxed);
         }
-        Ok(())
+        self.observe_ack(device_id, ack).await
     }
 
     pub(crate) async fn unregister(
@@ -271,27 +380,52 @@ impl ConnectionRegistry {
         device_id: &str,
         connection_id: uuid::Uuid,
     ) -> anyhow::Result<bool> {
-        if let Some(mut entry) = self.senders.get_mut(device_id)
-            && entry
-                .active
-                .as_ref()
-                .map(|active| active.connection_id == connection_id)
-                .unwrap_or(false)
-        {
-            if let Some(active) = entry.active.take() {
-                let _ = active.close_tx.send(true);
+        // Take the active connection out of the map first (synchronous,
+        // bounded by the DashMap shard lock) before we drop the guard
+        // and switch to async work.
+        let taken = {
+            if let Some(mut entry) = self.senders.get_mut(device_id) {
+                if entry
+                    .active
+                    .as_ref()
+                    .map(|a| a.connection_id == connection_id)
+                    .unwrap_or(false)
+                {
+                    entry.active.take()
+                } else {
+                    None
+                }
+            } else {
+                None
             }
-            let should_remove = {
-                let outbox = entry.outbox.lock().expect("outbox mutex poisoned");
-                outbox.is_empty()
-            };
-            drop(entry);
-            if should_remove {
-                self.senders.remove(device_id);
-            }
-            return Ok(true);
+        };
+
+        let Some(active) = taken else {
+            return Ok(false);
+        };
+
+        let _ = active.close_tx.send(true);
+        if let Some(handle) = active.lease_task.lock().await.take() {
+            handle.abort();
         }
-        Ok(false)
+        if let Some(handle) = active.kick_task.lock().await.take() {
+            handle.abort();
+        }
+        if let Err(err) = self
+            .outbox
+            .release_lock(device_id, &active.session_id)
+            .await
+        {
+            tracing::warn!(
+                device_id = %device_id,
+                error = %err,
+                "release_lock failed",
+            );
+        }
+        // No active = nothing to keep around in the local map. The durable
+        // stream lives on in the OutboxStore.
+        self.senders.remove(device_id);
+        Ok(true)
     }
 
     fn has_active(&self, device_id: &str) -> bool {
@@ -299,30 +433,6 @@ impl ConnectionRegistry {
             .get(device_id)
             .map(|entry| entry.active.is_some())
             .unwrap_or(false)
-    }
-
-    fn clear_current_sender(&self, device_id: &str, connection_id: uuid::Uuid) {
-        let should_cleanup = if let Some(mut entry) = self.senders.get_mut(device_id) {
-            if entry
-                .active
-                .as_ref()
-                .map(|active| active.connection_id == connection_id)
-                .unwrap_or(false)
-            {
-                entry.active = None;
-            }
-            entry.active.is_none()
-                && entry
-                    .outbox
-                    .lock()
-                    .expect("outbox mutex poisoned")
-                    .is_empty()
-        } else {
-            false
-        };
-        if should_cleanup {
-            self.senders.remove(device_id);
-        }
     }
 }
 
@@ -479,7 +589,9 @@ async fn run_device_socket(socket: WebSocket, state: AppState) -> anyhow::Result
         let hostname = hello.hostname.clone();
         let (connection_id, mut outbound_rx, close_rx) = state
             .connections
-            .register(device_id.clone(), hello.last_ack)?;
+            .register(device_id.clone(), hello.last_ack)
+            .await
+            .map_err(anyhow::Error::from)?;
         let (control_tx, mut control_rx) = mpsc::unbounded_channel::<WsMessage>();
         let last_inbound_at = Arc::new(AsyncMutex::new(tokio::time::Instant::now()));
         active_connection = Some((device_id.clone(), connection_id));
@@ -627,7 +739,7 @@ async fn run_device_socket(socket: WebSocket, state: AppState) -> anyhow::Result
                     *last_inbound_at.lock().await = tokio::time::Instant::now();
                     let envelope = ahand_protocol::Envelope::decode(frame.as_ref())?;
                     if state.connections.has_seen_inbound(&device_id, envelope.seq) {
-                        state.connections.observe_ack(&device_id, envelope.ack)?;
+                        state.connections.observe_ack(&device_id, envelope.ack).await?;
                     } else if let Some(ahand_protocol::envelope::Payload::Heartbeat(ref hb)) =
                         envelope.payload
                     {
@@ -637,7 +749,8 @@ async fn run_device_socket(socket: WebSocket, state: AppState) -> anyhow::Result
                         // device presence without polling.
                         state
                             .connections
-                            .observe_inbound(&device_id, envelope.seq, envelope.ack)?;
+                            .observe_inbound(&device_id, envelope.seq, envelope.ack)
+                            .await?;
                         let ttl = state
                             .device_expected_heartbeat_secs
                             .saturating_mul(3);
@@ -690,7 +803,7 @@ async fn run_device_socket(socket: WebSocket, state: AppState) -> anyhow::Result
                                 "received BrowserResponse with no pending request"
                             );
                         }
-                        state.connections.observe_inbound(&device_id, envelope.seq, envelope.ack)?;
+                        state.connections.observe_inbound(&device_id, envelope.seq, envelope.ack).await?;
                     } else if dispatch_control_plane_event(&state, &envelope) {
                         // The envelope's job_id was registered in the
                         // control-plane tracker — the tee has already
@@ -699,7 +812,8 @@ async fn run_device_socket(socket: WebSocket, state: AppState) -> anyhow::Result
                         // unknown job id) and just advance seq/ack.
                         state
                             .connections
-                            .observe_inbound(&device_id, envelope.seq, envelope.ack)?;
+                            .observe_inbound(&device_id, envelope.seq, envelope.ack)
+                            .await?;
                     } else {
                         state.jobs.handle_device_frame(&device_id, &frame).await?;
                     }
@@ -894,133 +1008,96 @@ async fn send_handshake_close(
 
 #[cfg(test)]
 mod tests {
-    use prost::Message;
+    use std::sync::Arc;
     use std::time::Duration;
 
+    use prost::Message;
+
     use super::ConnectionRegistry;
+    use crate::ws::in_memory_outbox::InMemoryOutboxStore;
+
+    fn job_envelope(msg_id: &str, job_id: &str, arg: &str) -> ahand_protocol::Envelope {
+        ahand_protocol::Envelope {
+            device_id: "device-1".into(),
+            msg_id: msg_id.into(),
+            payload: Some(ahand_protocol::envelope::Payload::JobRequest(
+                ahand_protocol::JobRequest {
+                    job_id: job_id.into(),
+                    tool: "echo".into(),
+                    args: vec![arg.into()],
+                    cwd: String::new(),
+                    env: Default::default(),
+                    timeout_ms: 30_000,
+                    interactive: false,
+                },
+            )),
+            ..Default::default()
+        }
+    }
 
     #[tokio::test]
     async fn register_replays_only_messages_after_last_ack() {
-        let registry = ConnectionRegistry::default();
-        let (_connection_id, mut initial_rx, _close_rx) =
-            registry.register("device-1".into(), 0).unwrap();
-        let transport = tokio::spawn(async move {
-            while let Some(outbound) = initial_rx.recv().await {
-                let _ = outbound;
-            }
-        });
+        let registry = ConnectionRegistry::new(Arc::new(InMemoryOutboxStore::new()));
+        let (conn_a, mut rx_a, _close_a) = registry.register("device-1".into(), 0).await.unwrap();
 
-        registry
-            .send(
-                "device-1",
-                ahand_protocol::Envelope {
-                    device_id: "device-1".into(),
-                    msg_id: "job-1".into(),
-                    payload: Some(ahand_protocol::envelope::Payload::JobRequest(
-                        ahand_protocol::JobRequest {
-                            job_id: "job-1".into(),
-                            tool: "echo".into(),
-                            args: vec!["one".into()],
-                            cwd: String::new(),
-                            env: Default::default(),
-                            timeout_ms: 30_000,
-                            interactive: false,
-                        },
-                    )),
-                    ..Default::default()
-                },
-            )
-            .await
-            .unwrap();
-        registry
-            .send(
-                "device-1",
-                ahand_protocol::Envelope {
-                    device_id: "device-1".into(),
-                    msg_id: "job-2".into(),
-                    payload: Some(ahand_protocol::envelope::Payload::JobRequest(
-                        ahand_protocol::JobRequest {
-                            job_id: "job-2".into(),
-                            tool: "echo".into(),
-                            args: vec!["two".into()],
-                            cwd: String::new(),
-                            env: Default::default(),
-                            timeout_ms: 30_000,
-                            interactive: false,
-                        },
-                    )),
-                    ..Default::default()
-                },
-            )
-            .await
-            .unwrap();
-
-        transport.abort();
-
-        let (_reconnect_id, mut replay_rx, _close_rx) =
-            registry.register("device-1".into(), 1).unwrap();
-        let replayed = replay_rx.recv().await.expect("replayed frame should exist");
-        let replayed = ahand_protocol::Envelope::decode(replayed.frame.as_slice()).unwrap();
-        let Some(ahand_protocol::envelope::Payload::JobRequest(job)) = replayed.payload else {
-            panic!("expected replayed job request");
-        };
-        assert_eq!(job.job_id, "job-2");
-        assert_eq!(replayed.seq, 2);
-        assert_eq!(replayed.ack, 0);
-        assert!(
-            tokio::time::timeout(Duration::from_millis(20), replay_rx.recv())
+        // Send 5 envelopes; drain each from the mpsc to confirm delivery.
+        for i in 1..=5u8 {
+            registry
+                .send("device-1", job_envelope(&format!("job-{i}"), &format!("job-{i}"), "x"))
                 .await
-                .is_err()
-        );
+                .unwrap();
+            let frame = rx_a.recv().await.expect("frame delivered");
+            let env = ahand_protocol::Envelope::decode(frame.frame.as_slice()).unwrap();
+            assert_eq!(env.seq, u64::from(i));
+        }
+
+        // Drop the live connection. unregister releases the lock so the
+        // re-register below can grab it without going through the kick path.
+        registry.unregister("device-1", conn_a).await.unwrap();
+
+        // Re-register with last_ack=2 — only seqs 3..=5 should replay.
+        let (_conn_b, mut rx_b, _close_b) =
+            registry.register("device-1".into(), 2).await.unwrap();
+        let mut replayed = Vec::new();
+        while let Ok(Some(frame)) =
+            tokio::time::timeout(Duration::from_millis(50), rx_b.recv()).await
+        {
+            replayed.push(frame);
+        }
+        assert_eq!(replayed.len(), 3, "only seqs 3..=5 should replay");
+        let first = ahand_protocol::Envelope::decode(replayed[0].frame.as_slice()).unwrap();
+        assert_eq!(first.seq, 3);
+        let last = ahand_protocol::Envelope::decode(replayed[2].frame.as_slice()).unwrap();
+        assert_eq!(last.seq, 5);
     }
 
     #[tokio::test]
     async fn inbound_seq_updates_outbound_ack() {
-        let registry = ConnectionRegistry::default();
-        let (_connection_id, mut rx, _close_rx) = registry.register("device-1".into(), 0).unwrap();
-        registry.observe_inbound("device-1", 7, 0).unwrap();
+        let registry = ConnectionRegistry::new(Arc::new(InMemoryOutboxStore::new()));
+        let (_connection_id, mut rx, _close_rx) =
+            registry.register("device-1".into(), 0).await.unwrap();
 
-        let transport = tokio::spawn(async move {
-            while let Some(outbound) = rx.recv().await {
-                let _ = outbound;
-            }
-        });
+        // Mirror the daemon→hub direction: an inbound envelope at seq=7
+        // bumps the per-connection counter, so the next outbound envelope
+        // must carry ack=7 in its header.
+        registry.observe_inbound("device-1", 7, 0).await.unwrap();
 
         registry
-            .send(
-                "device-1",
-                ahand_protocol::Envelope {
-                    device_id: "device-1".into(),
-                    msg_id: "job-1".into(),
-                    payload: Some(ahand_protocol::envelope::Payload::JobRequest(
-                        ahand_protocol::JobRequest {
-                            job_id: "job-1".into(),
-                            tool: "echo".into(),
-                            args: vec!["hello".into()],
-                            cwd: String::new(),
-                            env: Default::default(),
-                            timeout_ms: 30_000,
-                            interactive: false,
-                        },
-                    )),
-                    ..Default::default()
-                },
-            )
+            .send("device-1", job_envelope("job-1", "job-1", "hello"))
             .await
             .unwrap();
 
-        let frame = registry.senders.get("device-1").unwrap();
-        let outbound = frame.outbox.lock().unwrap().replay_from(0).pop().unwrap();
-        let outbound = ahand_protocol::Envelope::decode(outbound.as_slice()).unwrap();
-        assert_eq!(outbound.seq, 1);
-        assert_eq!(outbound.ack, 7);
-        transport.abort();
+        let outbound = rx.recv().await.expect("frame delivered");
+        let envelope = ahand_protocol::Envelope::decode(outbound.frame.as_slice()).unwrap();
+        assert_eq!(envelope.seq, 1);
+        assert_eq!(envelope.ack, 7);
     }
 
     #[tokio::test]
     async fn unregister_removes_idle_entries() {
-        let registry = ConnectionRegistry::default();
-        let (connection_id, rx, _close_rx) = registry.register("device-1".into(), 0).unwrap();
+        let registry = ConnectionRegistry::new(Arc::new(InMemoryOutboxStore::new()));
+        let (connection_id, rx, _close_rx) =
+            registry.register("device-1".into(), 0).await.unwrap();
         drop(rx);
 
         let removed = registry
@@ -1030,5 +1107,50 @@ mod tests {
 
         assert!(removed);
         assert!(registry.senders.is_empty());
+    }
+
+    #[tokio::test]
+    async fn has_seen_inbound_uses_per_connection_counter() {
+        let registry = ConnectionRegistry::new(Arc::new(InMemoryOutboxStore::new()));
+        let (_connection_id, _rx, _close_rx) =
+            registry.register("device-1".into(), 0).await.unwrap();
+
+        assert!(!registry.has_seen_inbound("device-1", 5));
+        registry.observe_inbound("device-1", 5, 0).await.unwrap();
+        assert!(registry.has_seen_inbound("device-1", 5));
+        // seq=0 is never seen (sentinel).
+        assert!(!registry.has_seen_inbound("device-1", 0));
+        // A lower seq is also "seen" (we track high water mark).
+        assert!(registry.has_seen_inbound("device-1", 3));
+        // A higher seq we haven't observed yet is not seen.
+        assert!(!registry.has_seen_inbound("device-1", 6));
+    }
+
+    #[tokio::test]
+    async fn second_register_returns_lock_contention_when_first_holds_lock() {
+        // The lock held by the first session is the OutboxStore's, so the
+        // second registration's kick-then-retry cycle exhausts and the
+        // call surfaces `OutboxLockContention`. In a real Redis deployment
+        // the kicked session would release on receiving the kick; the
+        // in-memory impl doesn't model that, so this test is the
+        // worst-case behavior. Once the holder unregisters, the next
+        // register succeeds.
+        let registry = ConnectionRegistry::new(Arc::new(InMemoryOutboxStore::new()));
+        let (conn_a, _rx_a, _close_a) =
+            registry.register("device-1".into(), 0).await.unwrap();
+
+        let err = registry
+            .register("device-1".into(), 0)
+            .await
+            .expect_err("should fail with contention");
+        assert!(matches!(
+            err,
+            ahand_hub_core::HubError::OutboxLockContention(d) if d == "device-1",
+        ));
+
+        registry.unregister("device-1", conn_a).await.unwrap();
+        // After the holder releases, a fresh register succeeds.
+        let (_conn_b, _rx_b, _close_b) =
+            registry.register("device-1".into(), 0).await.unwrap();
     }
 }

--- a/crates/ahand-hub/src/ws/in_memory_outbox.rs
+++ b/crates/ahand-hub/src/ws/in_memory_outbox.rs
@@ -1,0 +1,327 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+
+use ahand_hub_core::traits::{AbortOnDropHandle, KickSubscription, OutboxStore};
+use ahand_hub_core::{HubError, Result};
+use async_trait::async_trait;
+use tokio::sync::{Mutex, watch};
+
+#[derive(Default)]
+struct DeviceState {
+    lock: Option<String>,
+    seq: u64,
+    buffer: VecDeque<(u64, Vec<u8>)>,
+    kick_tx: Option<watch::Sender<u64>>,
+    kick_count: u64,
+}
+
+const MAX_BUFFER: usize = 10_000;
+
+/// Process-local OutboxStore for `StoreConfig::Memory` and unit tests.
+/// Mirrors the Redis semantics method-for-method.
+#[derive(Default, Clone)]
+pub struct InMemoryOutboxStore {
+    inner: Arc<Mutex<HashMap<String, DeviceState>>>,
+}
+
+impl InMemoryOutboxStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl OutboxStore for InMemoryOutboxStore {
+    async fn try_acquire_lock(&self, device_id: &str, session_id: &str) -> Result<bool> {
+        let mut g = self.inner.lock().await;
+        let entry = g.entry(device_id.to_string()).or_default();
+        if entry.lock.is_some() {
+            return Ok(false);
+        }
+        entry.lock = Some(session_id.to_string());
+        Ok(true)
+    }
+
+    async fn kick(&self, device_id: &str, _new_session_id: &str) -> Result<()> {
+        let mut g = self.inner.lock().await;
+        let entry = g.entry(device_id.to_string()).or_default();
+        entry.kick_count = entry.kick_count.wrapping_add(1);
+        if entry.kick_tx.is_none() {
+            // No subscriber yet — create the channel so the next subscribe
+            // sees the bumped value. (For correctness, subscribers expect
+            // to see ticks after they subscribe; if no subscriber existed,
+            // dropping the tick is fine.)
+            let (tx, _rx) = watch::channel(entry.kick_count);
+            entry.kick_tx = Some(tx);
+        } else if let Some(tx) = &entry.kick_tx {
+            let _ = tx.send(entry.kick_count);
+        }
+        Ok(())
+    }
+
+    async fn subscribe_kick(&self, device_id: &str) -> Result<KickSubscription> {
+        let mut g = self.inner.lock().await;
+        let entry = g.entry(device_id.to_string()).or_default();
+        let tx = match &entry.kick_tx {
+            Some(tx) => tx.clone(),
+            None => {
+                let (tx, _rx) = watch::channel(0u64);
+                entry.kick_tx = Some(tx.clone());
+                tx
+            }
+        };
+        let recv = tx.subscribe();
+        // In-memory impl does not need a real background task; spawn a
+        // no-op so we have something to wrap in AbortOnDropHandle.
+        let join = tokio::spawn(async {});
+        Ok(KickSubscription {
+            recv,
+            _drop_guard: AbortOnDropHandle::new(join),
+        })
+    }
+
+    async fn renew_lock(&self, device_id: &str, session_id: &str) -> Result<bool> {
+        let g = self.inner.lock().await;
+        Ok(g.get(device_id)
+            .and_then(|e| e.lock.as_ref())
+            .map(|owner| owner == session_id)
+            .unwrap_or(false))
+    }
+
+    async fn release_lock(&self, device_id: &str, session_id: &str) -> Result<()> {
+        let mut g = self.inner.lock().await;
+        if let Some(entry) = g.get_mut(device_id)
+            && entry.lock.as_deref() == Some(session_id)
+        {
+            entry.lock = None;
+        }
+        Ok(())
+    }
+
+    async fn reconcile_on_hello(
+        &self,
+        device_id: &str,
+        session_id: &str,
+        last_ack: u64,
+    ) -> Result<u64> {
+        let mut g = self.inner.lock().await;
+        let entry = g.get_mut(device_id).ok_or(HubError::Unauthorized)?;
+        if entry.lock.as_deref() != Some(session_id) {
+            return Err(HubError::Unauthorized);
+        }
+        if last_ack > entry.seq {
+            // Bootstrap path
+            entry.seq = last_ack;
+            entry.buffer.clear();
+            return Ok(last_ack);
+        }
+        // Normal path: trim acked frames
+        while let Some((seq, _)) = entry.buffer.front() {
+            if *seq <= last_ack {
+                entry.buffer.pop_front();
+            } else {
+                break;
+            }
+        }
+        Ok(entry.seq)
+    }
+
+    async fn unacked_frames(&self, device_id: &str, last_ack: u64) -> Result<Vec<Vec<u8>>> {
+        let g = self.inner.lock().await;
+        Ok(g.get(device_id)
+            .map(|e| {
+                e.buffer
+                    .iter()
+                    .filter(|(seq, _)| *seq > last_ack)
+                    .map(|(_, bytes)| bytes.clone())
+                    .collect()
+            })
+            .unwrap_or_default())
+    }
+
+    async fn fenced_incr_seq(&self, device_id: &str, session_id: &str) -> Result<u64> {
+        let mut g = self.inner.lock().await;
+        let entry = g.get_mut(device_id).ok_or(HubError::Unauthorized)?;
+        if entry.lock.as_deref() != Some(session_id) {
+            return Err(HubError::Unauthorized);
+        }
+        entry.seq += 1;
+        Ok(entry.seq)
+    }
+
+    async fn xadd_frame(
+        &self,
+        device_id: &str,
+        session_id: &str,
+        seq: u64,
+        frame: Vec<u8>,
+    ) -> Result<()> {
+        let mut g = self.inner.lock().await;
+        let entry = g.get_mut(device_id).ok_or(HubError::Unauthorized)?;
+        if entry.lock.as_deref() != Some(session_id) {
+            return Err(HubError::Unauthorized);
+        }
+        entry.buffer.push_back((seq, frame));
+        while entry.buffer.len() > MAX_BUFFER {
+            entry.buffer.pop_front();
+        }
+        Ok(())
+    }
+
+    async fn observe_ack(&self, device_id: &str, ack: u64) -> Result<()> {
+        let mut g = self.inner.lock().await;
+        if let Some(entry) = g.get_mut(device_id) {
+            while let Some((seq, _)) = entry.buffer.front() {
+                if *seq <= ack {
+                    entry.buffer.pop_front();
+                } else {
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> InMemoryOutboxStore {
+        InMemoryOutboxStore::new()
+    }
+
+    #[tokio::test]
+    async fn try_acquire_lock_first_succeeds_second_fails() {
+        let s = store();
+        assert!(s.try_acquire_lock("dev", "sess-a").await.unwrap());
+        assert!(!s.try_acquire_lock("dev", "sess-b").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn release_then_reacquire_succeeds() {
+        let s = store();
+        assert!(s.try_acquire_lock("dev", "sess-a").await.unwrap());
+        s.release_lock("dev", "sess-a").await.unwrap();
+        assert!(s.try_acquire_lock("dev", "sess-b").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn release_with_wrong_session_is_noop() {
+        let s = store();
+        assert!(s.try_acquire_lock("dev", "sess-a").await.unwrap());
+        s.release_lock("dev", "sess-other").await.unwrap();
+        assert!(!s.try_acquire_lock("dev", "sess-b").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn renew_lock_succeeds_for_owner_fails_for_other() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        assert!(s.renew_lock("dev", "sess-a").await.unwrap());
+        assert!(!s.renew_lock("dev", "sess-b").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn fenced_incr_seq_increments_per_owner() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        assert_eq!(s.fenced_incr_seq("dev", "sess-a").await.unwrap(), 1);
+        assert_eq!(s.fenced_incr_seq("dev", "sess-a").await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn fenced_incr_seq_rejects_non_owner() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        let err = s.fenced_incr_seq("dev", "sess-b").await.unwrap_err();
+        assert!(matches!(err, HubError::Unauthorized));
+    }
+
+    #[tokio::test]
+    async fn xadd_frame_stores_for_replay() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        let seq = s.fenced_incr_seq("dev", "sess-a").await.unwrap();
+        s.xadd_frame("dev", "sess-a", seq, b"hello".to_vec())
+            .await
+            .unwrap();
+        let frames = s.unacked_frames("dev", 0).await.unwrap();
+        assert_eq!(frames, vec![b"hello".to_vec()]);
+    }
+
+    #[tokio::test]
+    async fn unacked_frames_returns_only_after_last_ack() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        for i in 1..=3u8 {
+            let seq = s.fenced_incr_seq("dev", "sess-a").await.unwrap();
+            s.xadd_frame("dev", "sess-a", seq, vec![i]).await.unwrap();
+        }
+        let frames = s.unacked_frames("dev", 1).await.unwrap();
+        assert_eq!(frames, vec![vec![2u8], vec![3u8]]);
+    }
+
+    #[tokio::test]
+    async fn observe_ack_trims_buffer() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        for i in 1..=3u8 {
+            let seq = s.fenced_incr_seq("dev", "sess-a").await.unwrap();
+            s.xadd_frame("dev", "sess-a", seq, vec![i]).await.unwrap();
+        }
+        s.observe_ack("dev", 2).await.unwrap();
+        let frames = s.unacked_frames("dev", 0).await.unwrap();
+        assert_eq!(frames, vec![vec![3u8]]);
+    }
+
+    #[tokio::test]
+    async fn reconcile_normal_path_returns_current_seq() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        for _ in 0..5 {
+            let seq = s.fenced_incr_seq("dev", "sess-a").await.unwrap();
+            s.xadd_frame("dev", "sess-a", seq, vec![]).await.unwrap();
+        }
+        let current = s.reconcile_on_hello("dev", "sess-a", 3).await.unwrap();
+        assert_eq!(current, 5);
+        let frames = s.unacked_frames("dev", 0).await.unwrap();
+        assert_eq!(frames.len(), 2); // 1..=3 trimmed; 4..=5 remain
+    }
+
+    #[tokio::test]
+    async fn reconcile_bootstrap_path_seeds_seq_and_clears_buffer() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        // Fresh store, last_ack=9 (the wedged-device case)
+        let returned = s.reconcile_on_hello("dev", "sess-a", 9).await.unwrap();
+        assert_eq!(returned, 9);
+        // Next incr should produce 10
+        assert_eq!(s.fenced_incr_seq("dev", "sess-a").await.unwrap(), 10);
+        // No frames to replay
+        assert!(s.unacked_frames("dev", 9).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn kick_subscriber_fires_on_publish() {
+        let s = store();
+        let mut sub = s.subscribe_kick("dev").await.unwrap();
+        assert_eq!(*sub.recv.borrow_and_update(), 0u64);
+        s.kick("dev", "new-sess").await.unwrap();
+        // The watch::Receiver should observe a change.
+        sub.recv.changed().await.unwrap();
+        assert!(*sub.recv.borrow() >= 1);
+    }
+
+    #[tokio::test]
+    async fn maxlen_caps_buffer() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        for _ in 0..(MAX_BUFFER + 5) {
+            let seq = s.fenced_incr_seq("dev", "sess-a").await.unwrap();
+            s.xadd_frame("dev", "sess-a", seq, vec![]).await.unwrap();
+        }
+        let frames = s.unacked_frames("dev", 0).await.unwrap();
+        assert_eq!(frames.len(), MAX_BUFFER);
+    }
+}

--- a/crates/ahand-hub/src/ws/in_memory_outbox.rs
+++ b/crates/ahand-hub/src/ws/in_memory_outbox.rs
@@ -171,6 +171,11 @@ impl OutboxStore for InMemoryOutboxStore {
     async fn observe_ack(&self, device_id: &str, ack: u64) -> Result<()> {
         let mut g = self.inner.lock().await;
         if let Some(entry) = g.get_mut(device_id) {
+            // Ignore invalid acks (claim > issued) to protect the legitimate
+            // replay buffer from a buggy/compromised client.
+            if ack > entry.seq {
+                return Ok(());
+            }
             while let Some((seq, _)) = entry.buffer.front() {
                 if *seq <= ack {
                     entry.buffer.pop_front();
@@ -273,6 +278,19 @@ mod tests {
         s.observe_ack("dev", 2).await.unwrap();
         let frames = s.unacked_frames("dev", 0).await.unwrap();
         assert_eq!(frames, vec![vec![3u8]]);
+    }
+
+    #[tokio::test]
+    async fn observe_ack_ignores_invalid_ack_above_issued_seq() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        // Issue one frame, then send a bogus ack that exceeds the issued seq.
+        let seq = s.fenced_incr_seq("dev", "sess-a").await.unwrap();
+        s.xadd_frame("dev", "sess-a", seq, vec![1u8]).await.unwrap();
+        s.observe_ack("dev", 99).await.unwrap();
+        // The legitimate seq=1 frame must remain in the replay buffer.
+        let frames = s.unacked_frames("dev", 0).await.unwrap();
+        assert_eq!(frames, vec![vec![1u8]]);
     }
 
     #[tokio::test]

--- a/crates/ahand-hub/src/ws/mod.rs
+++ b/crates/ahand-hub/src/ws/mod.rs
@@ -1,2 +1,3 @@
 pub mod dashboard;
 pub mod device_gateway;
+pub mod in_memory_outbox;

--- a/crates/ahand-hub/tests/outbox_persistence.rs
+++ b/crates/ahand-hub/tests/outbox_persistence.rs
@@ -1,0 +1,161 @@
+//! End-to-end regression tests for hub outbox persistence.
+//!
+//! These tests boot a real Redis container via testcontainers, exercise
+//! `RedisOutboxStore` and `ConnectionRegistry` together, and verify the
+//! key invariants from the design spec.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ahand_hub::ws::device_gateway::ConnectionRegistry;
+use ahand_hub_core::traits::OutboxStore;
+use ahand_hub_store::outbox_store::RedisOutboxStore;
+use testcontainers::{
+    ContainerAsync, GenericImage,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+
+async fn redis_container() -> anyhow::Result<(ContainerAsync<GenericImage>, String)> {
+    let container = GenericImage::new("redis", "7-alpine")
+        .with_exposed_port(6379.tcp())
+        .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
+        .start()
+        .await?;
+    let port = container.get_host_port_ipv4(6379.tcp()).await?;
+    Ok((container, format!("redis://127.0.0.1:{port}")))
+}
+
+#[tokio::test]
+async fn replay_after_simulated_hub_restart() -> anyhow::Result<()> {
+    let (_redis, url) = redis_container().await?;
+
+    // Phase 1: hub instance A handles a session for dev-1 and sends 5 frames.
+    let store_a = Arc::new(RedisOutboxStore::new(&url).await?) as Arc<dyn OutboxStore>;
+    let registry_a = ConnectionRegistry::new(store_a.clone());
+    let (_conn_a, mut rx_a, _close_a) = registry_a.register("dev-1".into(), 0).await?;
+    for _ in 0..5 {
+        let envelope = ahand_protocol::Envelope {
+            device_id: "dev-1".into(),
+            ..Default::default()
+        };
+        registry_a.send_envelope("dev-1", envelope).await?;
+        let _ = rx_a.recv().await.expect("frame delivered");
+    }
+    // Device acked frames 1 and 2 before A "dies".
+    registry_a.observe_ack("dev-1", 2).await?;
+
+    // Drop A — simulates ECS task termination. Frames are still in Redis.
+    drop(registry_a);
+    drop(store_a);
+
+    // Phase 2: hub instance B starts up and the device reconnects with last_ack=2.
+    let store_b = Arc::new(RedisOutboxStore::new(&url).await?) as Arc<dyn OutboxStore>;
+    let registry_b = ConnectionRegistry::new(store_b);
+    let (_conn_b, mut rx_b, _close_b) = registry_b.register("dev-1".into(), 2).await?;
+
+    // Frames 3..=5 should replay.
+    let mut replayed = 0;
+    while let Ok(Some(_)) = tokio::time::timeout(Duration::from_millis(200), rx_b.recv()).await {
+        replayed += 1;
+    }
+    assert_eq!(replayed, 3, "expected 3 frames (seq 3..=5) to replay");
+    Ok(())
+}
+
+#[tokio::test]
+async fn lock_takeover_via_kick() -> anyhow::Result<()> {
+    let (_redis, url) = redis_container().await?;
+    let store_a = Arc::new(RedisOutboxStore::new(&url).await?) as Arc<dyn OutboxStore>;
+    let store_b = Arc::new(RedisOutboxStore::new(&url).await?) as Arc<dyn OutboxStore>;
+    let registry_a = ConnectionRegistry::new(store_a.clone());
+    let registry_b = ConnectionRegistry::new(store_b.clone());
+
+    let (_conn_a, _rx_a, mut close_a) = registry_a.register("dev-2".into(), 0).await?;
+    // B's register should kick A and acquire within retry window.
+    let started = tokio::time::Instant::now();
+    let (_conn_b, _rx_b, _close_b) = registry_b.register("dev-2".into(), 0).await?;
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "kick-and-acquire took {:?}, expected <5s",
+        started.elapsed()
+    );
+
+    // A's close_rx should fire as a result of the kick.
+    tokio::time::timeout(Duration::from_secs(2), close_a.changed())
+        .await
+        .expect("A's close_tx should fire after kick")?;
+    assert!(*close_a.borrow_and_update());
+    Ok(())
+}
+
+#[tokio::test]
+async fn bootstrap_path_unblocks_wedged_device() -> anyhow::Result<()> {
+    let (_redis, url) = redis_container().await?;
+
+    // Fresh Redis (= just-deployed hub). Device sends Hello with last_ack=9
+    // (the wedged-after-restart case from the original incident).
+    let store = Arc::new(RedisOutboxStore::new(&url).await?) as Arc<dyn OutboxStore>;
+    let registry = ConnectionRegistry::new(store.clone());
+    let (_conn, mut rx, _close) = registry.register("dev-3".into(), 9).await?;
+
+    // No frames to replay (nothing was in the stream).
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), rx.recv())
+            .await
+            .is_err(),
+        "no replay expected"
+    );
+
+    // Next send should produce seq=10.
+    let envelope = ahand_protocol::Envelope {
+        device_id: "dev-3".into(),
+        ..Default::default()
+    };
+    registry.send_envelope("dev-3", envelope).await?;
+    let frame = rx.recv().await.expect("frame delivered");
+    let decoded = <ahand_protocol::Envelope as prost::Message>::decode(frame.as_slice())?;
+    assert_eq!(decoded.seq, 10);
+    Ok(())
+}
+
+#[tokio::test]
+async fn original_incident_regression() -> anyhow::Result<()> {
+    // Keystone test: had it existed pre-incident, the InvalidPeerAck
+    // wedge bug would not have shipped. Simulates hub restart with the
+    // device still holding a non-zero last_ack.
+    let (_redis, url) = redis_container().await?;
+
+    // Phase 1: device connects, receives 5 frames, acks them all.
+    let store_a = Arc::new(RedisOutboxStore::new(&url).await?) as Arc<dyn OutboxStore>;
+    let registry_a = ConnectionRegistry::new(store_a.clone());
+    let (conn_a, mut rx_a, _close_a) = registry_a.register("dev-incident".into(), 0).await?;
+    for _ in 0..5 {
+        registry_a
+            .send_envelope(
+                "dev-incident",
+                ahand_protocol::Envelope {
+                    device_id: "dev-incident".into(),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        rx_a.recv().await.expect("frame delivered");
+    }
+    registry_a.observe_ack("dev-incident", 5).await?;
+    registry_a.unregister("dev-incident", conn_a).await?;
+
+    // Phase 2: hub deploys — B is a fresh process holding a different
+    // OutboxStore arc but pointing at the same Redis.
+    let store_b = Arc::new(RedisOutboxStore::new(&url).await?) as Arc<dyn OutboxStore>;
+    let registry_b = ConnectionRegistry::new(store_b);
+
+    // Device reconnects with last_ack=5. With the fix, register succeeds;
+    // without the fix this would have surfaced as InvalidPeerAck → close
+    // → daemon Broken pipe.
+    let (_conn_b, _rx_b, _close_b) = registry_b
+        .register("dev-incident".into(), 5)
+        .await
+        .expect("device should reconnect cleanly post-restart");
+    Ok(())
+}

--- a/crates/ahand-hub/tests/outbox_persistence.rs
+++ b/crates/ahand-hub/tests/outbox_persistence.rs
@@ -33,7 +33,7 @@ async fn replay_after_simulated_hub_restart() -> anyhow::Result<()> {
     // Phase 1: hub instance A handles a session for dev-1 and sends 5 frames.
     let store_a = Arc::new(RedisOutboxStore::new(&url).await?) as Arc<dyn OutboxStore>;
     let registry_a = ConnectionRegistry::new(store_a.clone());
-    let (_conn_a, mut rx_a, _close_a) = registry_a.register("dev-1".into(), 0).await?;
+    let (conn_a, mut rx_a, _close_a) = registry_a.register("dev-1".into(), 0).await?;
     for _ in 0..5 {
         let envelope = ahand_protocol::Envelope {
             device_id: "dev-1".into(),
@@ -45,7 +45,13 @@ async fn replay_after_simulated_hub_restart() -> anyhow::Result<()> {
     // Device acked frames 1 and 2 before A "dies".
     registry_a.observe_ack("dev-1", 2).await?;
 
-    // Drop A — simulates ECS task termination. Frames are still in Redis.
+    // Simulate a graceful hub shutdown: unregister releases the lock
+    // and aborts background tasks. (A sudden crash would leave the
+    // Redis lock held until its 30s TTL expired; we rely on graceful
+    // SIGTERM behavior in production. The durability invariant we are
+    // testing is: messages survive process boundary, regardless of
+    // shutdown style.)
+    registry_a.unregister("dev-1", conn_a).await?;
     drop(registry_a);
     drop(store_a);
 
@@ -68,11 +74,25 @@ async fn lock_takeover_via_kick() -> anyhow::Result<()> {
     let (_redis, url) = redis_container().await?;
     let store_a = Arc::new(RedisOutboxStore::new(&url).await?) as Arc<dyn OutboxStore>;
     let store_b = Arc::new(RedisOutboxStore::new(&url).await?) as Arc<dyn OutboxStore>;
-    let registry_a = ConnectionRegistry::new(store_a.clone());
+    let registry_a = Arc::new(ConnectionRegistry::new(store_a.clone()));
     let registry_b = ConnectionRegistry::new(store_b.clone());
 
-    let (_conn_a, _rx_a, mut close_a) = registry_a.register("dev-2".into(), 0).await?;
-    // B's register should kick A and acquire within retry window.
+    let (conn_a, _rx_a, mut close_a) = registry_a.register("dev-2".into(), 0).await?;
+
+    // In production, the WS handler watches close_rx and on close runs
+    // the unregister teardown (which calls release_lock). Simulate that
+    // by spawning a task that bridges close_a → unregister.
+    let cleanup_registry = registry_a.clone();
+    let cleanup = tokio::spawn(async move {
+        let _ = close_a.changed().await;
+        cleanup_registry
+            .unregister("dev-2", conn_a)
+            .await
+            .expect("unregister after kick");
+    });
+
+    // B's register should kick A; A's kick subscriber fires close_a;
+    // the cleanup task above unregisters A; B's retry succeeds.
     let started = tokio::time::Instant::now();
     let (_conn_b, _rx_b, _close_b) = registry_b.register("dev-2".into(), 0).await?;
     assert!(
@@ -80,12 +100,7 @@ async fn lock_takeover_via_kick() -> anyhow::Result<()> {
         "kick-and-acquire took {:?}, expected <5s",
         started.elapsed()
     );
-
-    // A's close_rx should fire as a result of the kick.
-    tokio::time::timeout(Duration::from_secs(2), close_a.changed())
-        .await
-        .expect("A's close_tx should fire after kick")?;
-    assert!(*close_a.borrow_and_update());
+    cleanup.await?;
     Ok(())
 }
 

--- a/docs/superpowers/plans/2026-04-27-hub-outbox-persistence.md
+++ b/docs/superpowers/plans/2026-04-27-hub-outbox-persistence.md
@@ -1,0 +1,2258 @@
+# Hub Outbox Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the hub's per-device outbox state survive process restarts via Redis Streams, with multi-replica safety via a Redis-side fenced lock, and auto-recover currently-wedged devices on first reconnect.
+
+**Architecture:** Introduce `OutboxStore` trait in `ahand-hub-core`. Two implementations: `InMemoryOutboxStore` (used by `StoreConfig::Memory` and unit tests) and `RedisOutboxStore` (used by `StoreConfig::Persistent`). Refactor `ConnectionRegistry` to delegate all outbox state to the trait. Each WS connection owns a `session_id` (uuid) used as a fencing token in every Redis script. Lock acquisition uses `SET NX EX 30`; handoff is accelerated via a Pub/Sub `kick:{device_id}` channel; correctness comes from the fenced `INCR`/`XADD` scripts that always check ownership.
+
+**Tech Stack:** Rust 2021 (workspace edition), `redis = 0.24` async (already in workspace), `tokio` watch channels, `async-trait`, `prost` for protobuf encoding, `testcontainers` for integration.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-hub-outbox-persistence-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `crates/ahand-hub-core/src/traits.rs` | Modify | Add `OutboxStore` trait + `KickSubscription` + `OutboxSendOutcome` types |
+| `crates/ahand-hub/src/ws/in_memory_outbox.rs` | Create | `InMemoryOutboxStore` impl for `StoreConfig::Memory` and tests |
+| `crates/ahand-hub/src/ws/mod.rs` | Modify | `pub mod in_memory_outbox;` |
+| `crates/ahand-hub-store/src/outbox_lua.rs` | Create | Lua source strings + cached SHA1 + `EVALSHA`-with-fallback wrapper |
+| `crates/ahand-hub-store/src/outbox_store.rs` | Create | `RedisOutboxStore` impl |
+| `crates/ahand-hub-store/src/lib.rs` | Modify | `pub mod outbox_lua;` `pub mod outbox_store;` |
+| `crates/ahand-hub/src/ws/device_gateway.rs` | Modify | Refactor `ConnectionRegistry` to use `OutboxStore`; add lease renewer + kick subscriber tasks |
+| `crates/ahand-hub/src/state.rs` | Modify | Wire `Arc<dyn OutboxStore>` based on `StoreConfig`, pass into `ConnectionRegistry::new` |
+| `crates/ahand-hub-store/tests/store_roundtrip.rs` | Modify | Add `RedisOutboxStore` integration tests (uses existing `TestStack` Redis container) |
+| `crates/ahand-hub/tests/outbox_persistence.rs` | Create | End-to-end regression: replay-after-restart, lock takeover, bootstrap path |
+
+`HubError` already has `InvalidPeerAck`, `Internal`, `Unauthorized`. We add `OutboxLockContention` for the rare "kick failed to dislodge previous owner" case.
+
+---
+
+## Task Ordering and Dependencies
+
+```
+Task 0 (trait) ─┬─▶ Task 1 (InMemory impl) ────────────────────────┐
+                │                                                  │
+                └─▶ Task 2 (Lua module) ─▶ Task 3 (Redis lock) ─▶ Task 4 (Redis send) ─┤
+                                                                                       │
+                                                            ┌──────────────────────────┘
+                                                            ▼
+                                                       Task 5 (Registry refactor)
+                                                            │
+                                                            ▼
+                                                       Task 6 (AppState wiring)
+                                                            │
+                                                            ▼
+                                                       Task 7 (E2E regression tests)
+```
+
+Tasks 1 and 2 can be done in parallel after Task 0 ships. Tasks 3 and 4 are sequential.
+
+---
+
+## Task 0: `OutboxStore` trait and supporting types
+
+**Goal:** Add the `OutboxStore` trait, `KickSubscription`, and `OutboxLockContention` error variant. No implementations yet.
+
+**Files:**
+- Modify: `crates/ahand-hub-core/src/traits.rs` (append new trait at end)
+- Modify: `crates/ahand-hub-core/src/error.rs` (add variant)
+- Modify: `crates/ahand-hub-core/Cargo.toml` (add `tokio` workspace dep with `sync` feature, `uuid` workspace dep — verify already present)
+
+**Acceptance Criteria:**
+- [ ] `OutboxStore` trait compiles with `#[async_trait]` and is `Send + Sync + 'static` capable.
+- [ ] `KickSubscription` is documented and droppable (drop releases Pub/Sub resources).
+- [ ] `HubError::OutboxLockContention` exists and renders sensibly.
+- [ ] `cargo check -p ahand-hub-core` passes; existing tests still green.
+
+**Verify:** `cargo check -p ahand-hub-core && cargo test -p ahand-hub-core` → all green.
+
+**Steps:**
+
+- [ ] **Step 1: Add `OutboxLockContention` to `HubError`**
+
+Edit `crates/ahand-hub-core/src/error.rs`:
+
+```rust
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum HubError {
+    // ... existing variants unchanged ...
+    #[error("invalid peer ack {ack}, max issued seq is {max}")]
+    InvalidPeerAck { ack: u64, max: u64 },
+    #[error("outbox lock contention for device {0}")]
+    OutboxLockContention(String),
+    #[error("internal: {0}")]
+    Internal(String),
+}
+```
+
+- [ ] **Step 2: Verify `tokio` and `uuid` are workspace deps in `ahand-hub-core/Cargo.toml`**
+
+```bash
+grep -E "^(tokio|uuid|async-trait)" crates/ahand-hub-core/Cargo.toml
+```
+
+Expected: at least `async-trait` and `tokio` present. If `uuid` is missing, add:
+
+```toml
+uuid = { workspace = true, features = ["v4"] }
+```
+
+(Check root `Cargo.toml` for `[workspace.dependencies] uuid` — should already exist since `ahand-hub-store` and `ahand-hub` use it.)
+
+- [ ] **Step 3: Add the trait at the bottom of `traits.rs`**
+
+```rust
+// ── Outbox persistence (hub→device durable buffer + multi-replica fencing) ──
+
+/// Subscription handle returned by [`OutboxStore::subscribe_kick`]. The
+/// receiver fires with `()` whenever a kick is published on the device's
+/// channel. Drop releases the underlying Pub/Sub connection and aborts the
+/// background reader task.
+pub struct KickSubscription {
+    pub recv: tokio::sync::watch::Receiver<u64>,
+    pub _drop_guard: tokio::task::JoinHandle<()>,
+}
+
+/// Per-device durable outbox. Implementations:
+///
+/// * `RedisOutboxStore` (production) — Redis Streams + Lua scripts + Pub/Sub.
+/// * `InMemoryOutboxStore` (tests, `StoreConfig::Memory`) — in-process state.
+///
+/// All methods are `&self` and async; implementations are expected to be
+/// `Arc`-shared across tasks. `session_id` is a UUID generated per WS
+/// connection and acts as the fencing token: every fenced operation aborts
+/// with [`HubError::Unauthorized`] if the lock value does not match.
+#[async_trait]
+pub trait OutboxStore: Send + Sync + 'static {
+    /// Atomically `SET lock:device:{id} {session_id} NX EX <ttl>`. Returns
+    /// `true` on success, `false` if another session already holds the lock.
+    async fn try_acquire_lock(&self, device_id: &str, session_id: &str) -> Result<bool>;
+
+    /// Best-effort `PUBLISH kick:{device_id} <new_session_id>`. Failures are
+    /// logged but not propagated; the lease will eventually expire.
+    async fn kick(&self, device_id: &str, new_session_id: &str) -> Result<()>;
+
+    /// Subscribe to `kick:{device_id}`. The returned watch receiver ticks
+    /// (value increments) each time a kick arrives.
+    async fn subscribe_kick(&self, device_id: &str) -> Result<KickSubscription>;
+
+    /// Renew lease: Lua-checked `EXPIRE` — only renews if the current value
+    /// equals `session_id`. Returns `false` if the lock was lost.
+    async fn renew_lock(&self, device_id: &str, session_id: &str) -> Result<bool>;
+
+    /// Release lock: Lua-checked `DEL` — only deletes if value matches.
+    /// Idempotent.
+    async fn release_lock(&self, device_id: &str, session_id: &str) -> Result<()>;
+
+    /// Reconcile the per-device seq counter against the device's
+    /// `Hello.last_ack`:
+    ///
+    /// * If `seq:{id} > last_ack`: trim acked entries with
+    ///   `XTRIM outbox:{id} MINID 0-{last_ack+1}` and return `current_seq`.
+    /// * If `seq:{id} <= last_ack`: **bootstrap path** — server lost state
+    ///   (e.g., process restart wiped Redis is impossible since Redis is
+    ///   the durable layer; this branch fires when the device's `last_ack`
+    ///   exceeds anything the store has ever seen, which is exactly the
+    ///   wedged-after-restart case for fresh deploys carrying this code).
+    ///   Set `seq:{id} = last_ack`, `DEL outbox:{id}`, return `last_ack`.
+    ///
+    /// Both branches call `EXPIRE` to keep the keys alive for 30d.
+    /// The fence is checked via the lock script; callers must hold the lock.
+    async fn reconcile_on_hello(
+        &self,
+        device_id: &str,
+        session_id: &str,
+        last_ack: u64,
+    ) -> Result<u64>;
+
+    /// Read all unacked frames for replay: `XRANGE outbox:{id} (0-{last_ack} +`.
+    async fn unacked_frames(&self, device_id: &str, last_ack: u64) -> Result<Vec<Vec<u8>>>;
+
+    /// Reserve the next seq atomically: fence + `INCR seq:{id}`. Returns the
+    /// assigned seq. Callers then mutate `envelope.seq`, encode, and call
+    /// [`Self::xadd_frame`].
+    async fn fenced_incr_seq(&self, device_id: &str, session_id: &str) -> Result<u64>;
+
+    /// Append the encoded frame to the stream: fence + `XADD outbox:{id}
+    /// 0-{seq} frame <bytes>` + `MAXLEN ~ 10000` + `EXPIRE 30d`.
+    async fn xadd_frame(
+        &self,
+        device_id: &str,
+        session_id: &str,
+        seq: u64,
+        frame: Vec<u8>,
+    ) -> Result<()>;
+
+    /// Trim acked frames: `XTRIM outbox:{id} MINID 0-{ack+1}`. Fire-and-forget
+    /// from the caller's perspective; failure is logged but not surfaced.
+    async fn observe_ack(&self, device_id: &str, ack: u64) -> Result<()>;
+}
+```
+
+- [ ] **Step 4: Run cargo check + tests**
+
+```bash
+cargo check -p ahand-hub-core
+cargo test -p ahand-hub-core
+```
+
+Both expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ahand-hub-core/src/traits.rs crates/ahand-hub-core/src/error.rs crates/ahand-hub-core/Cargo.toml
+git commit -m "$(cat <<'EOF'
+feat(hub-core): add OutboxStore trait + KickSubscription
+
+Trait surface for hub→device outbox persistence, used by both the new
+RedisOutboxStore (production) and InMemoryOutboxStore (tests, Memory
+StoreConfig). Adds HubError::OutboxLockContention for the kick-failed path.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 1: `InMemoryOutboxStore` implementation
+
+**Goal:** A complete in-process implementation of `OutboxStore` that mirrors the Redis semantics. Used by `StoreConfig::Memory` and as the test fixture for Task 5+.
+
+**Files:**
+- Create: `crates/ahand-hub/src/ws/in_memory_outbox.rs`
+- Modify: `crates/ahand-hub/src/ws/mod.rs` (add `pub mod in_memory_outbox;`)
+- Test: same file (`#[cfg(test)] mod tests`)
+
+**Acceptance Criteria:**
+- [ ] All 10 trait methods implemented; semantics match the spec.
+- [ ] Lock acquisition is atomic (one of N concurrent acquirers wins, others see `false`).
+- [ ] Bootstrap path inside `reconcile_on_hello` works: `seq` set to `last_ack`, frames cleared, returned value equals `last_ack`.
+- [ ] Fence rejects writes from a non-owning session.
+- [ ] Kick subscription delivers a `()` tick when `kick` is called.
+- [ ] Unit tests cover: lock NX, kick handoff, fence rejection, bootstrap path, replay across simulated reconnect, ack-trim.
+
+**Verify:** `cargo test -p ahand-hub --lib ws::in_memory_outbox::tests` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Add the module declaration**
+
+Edit `crates/ahand-hub/src/ws/mod.rs` — add at the top of the file (or alongside existing `pub mod`):
+
+```rust
+pub mod in_memory_outbox;
+```
+
+- [ ] **Step 2: Write the failing tests first**
+
+Create `crates/ahand-hub/src/ws/in_memory_outbox.rs` and add the test module before any implementation. We'll fail-compile first, then build the impl until tests pass.
+
+```rust
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+
+use ahand_hub_core::traits::{KickSubscription, OutboxStore};
+use ahand_hub_core::{HubError, Result};
+use async_trait::async_trait;
+use tokio::sync::{Mutex, watch};
+
+#[derive(Default)]
+struct DeviceState {
+    lock: Option<String>,
+    seq: u64,
+    buffer: VecDeque<(u64, Vec<u8>)>,
+    kick_tx: Option<watch::Sender<u64>>,
+    kick_count: u64,
+}
+
+const MAX_BUFFER: usize = 10_000;
+
+/// Process-local OutboxStore for `StoreConfig::Memory` and unit tests.
+/// Mirrors the Redis semantics method-for-method.
+#[derive(Default, Clone)]
+pub struct InMemoryOutboxStore {
+    inner: Arc<Mutex<HashMap<String, DeviceState>>>,
+}
+
+impl InMemoryOutboxStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> InMemoryOutboxStore {
+        InMemoryOutboxStore::new()
+    }
+
+    #[tokio::test]
+    async fn try_acquire_lock_first_succeeds_second_fails() {
+        let s = store();
+        assert!(s.try_acquire_lock("dev", "sess-a").await.unwrap());
+        assert!(!s.try_acquire_lock("dev", "sess-b").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn release_then_reacquire_succeeds() {
+        let s = store();
+        assert!(s.try_acquire_lock("dev", "sess-a").await.unwrap());
+        s.release_lock("dev", "sess-a").await.unwrap();
+        assert!(s.try_acquire_lock("dev", "sess-b").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn release_with_wrong_session_is_noop() {
+        let s = store();
+        assert!(s.try_acquire_lock("dev", "sess-a").await.unwrap());
+        s.release_lock("dev", "sess-other").await.unwrap();
+        assert!(!s.try_acquire_lock("dev", "sess-b").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn renew_lock_succeeds_for_owner_fails_for_other() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        assert!(s.renew_lock("dev", "sess-a").await.unwrap());
+        assert!(!s.renew_lock("dev", "sess-b").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn fenced_incr_seq_increments_per_owner() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        assert_eq!(s.fenced_incr_seq("dev", "sess-a").await.unwrap(), 1);
+        assert_eq!(s.fenced_incr_seq("dev", "sess-a").await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn fenced_incr_seq_rejects_non_owner() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        let err = s.fenced_incr_seq("dev", "sess-b").await.unwrap_err();
+        assert!(matches!(err, HubError::Unauthorized));
+    }
+
+    #[tokio::test]
+    async fn xadd_frame_stores_for_replay() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        let seq = s.fenced_incr_seq("dev", "sess-a").await.unwrap();
+        s.xadd_frame("dev", "sess-a", seq, b"hello".to_vec()).await.unwrap();
+        let frames = s.unacked_frames("dev", 0).await.unwrap();
+        assert_eq!(frames, vec![b"hello".to_vec()]);
+    }
+
+    #[tokio::test]
+    async fn unacked_frames_returns_only_after_last_ack() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        for i in 1..=3 {
+            let seq = s.fenced_incr_seq("dev", "sess-a").await.unwrap();
+            s.xadd_frame("dev", "sess-a", seq, vec![i as u8]).await.unwrap();
+        }
+        let frames = s.unacked_frames("dev", 1).await.unwrap();
+        assert_eq!(frames, vec![vec![2], vec![3]]);
+    }
+
+    #[tokio::test]
+    async fn observe_ack_trims_buffer() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        for i in 1..=3 {
+            let seq = s.fenced_incr_seq("dev", "sess-a").await.unwrap();
+            s.xadd_frame("dev", "sess-a", seq, vec![i as u8]).await.unwrap();
+        }
+        s.observe_ack("dev", 2).await.unwrap();
+        let frames = s.unacked_frames("dev", 0).await.unwrap();
+        assert_eq!(frames, vec![vec![3]]);
+    }
+
+    #[tokio::test]
+    async fn reconcile_normal_path_returns_current_seq() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        for _ in 0..5 {
+            let seq = s.fenced_incr_seq("dev", "sess-a").await.unwrap();
+            s.xadd_frame("dev", "sess-a", seq, vec![]).await.unwrap();
+        }
+        let current = s.reconcile_on_hello("dev", "sess-a", 3).await.unwrap();
+        assert_eq!(current, 5);
+        // 1..=3 trimmed; 4..=5 remain
+        let frames = s.unacked_frames("dev", 0).await.unwrap();
+        assert_eq!(frames.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn reconcile_bootstrap_path_seeds_seq_and_clears_buffer() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        // Fresh store, last_ack=9 (the wedged-device case)
+        let returned = s.reconcile_on_hello("dev", "sess-a", 9).await.unwrap();
+        assert_eq!(returned, 9);
+        // Next incr should produce 10
+        assert_eq!(s.fenced_incr_seq("dev", "sess-a").await.unwrap(), 10);
+        // No frames to replay
+        assert!(s.unacked_frames("dev", 9).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn kick_subscriber_fires_on_publish() {
+        let s = store();
+        let mut sub = s.subscribe_kick("dev").await.unwrap();
+        assert!(sub.recv.borrow_and_update() == &0);
+        s.kick("dev", "new-sess").await.unwrap();
+        // The watch::Receiver should observe a change.
+        sub.recv.changed().await.unwrap();
+        assert!(*sub.recv.borrow() >= 1);
+    }
+
+    #[tokio::test]
+    async fn maxlen_caps_buffer() {
+        let s = store();
+        s.try_acquire_lock("dev", "sess-a").await.unwrap();
+        for _ in 0..(MAX_BUFFER + 5) {
+            let seq = s.fenced_incr_seq("dev", "sess-a").await.unwrap();
+            s.xadd_frame("dev", "sess-a", seq, vec![]).await.unwrap();
+        }
+        let frames = s.unacked_frames("dev", 0).await.unwrap();
+        assert_eq!(frames.len(), MAX_BUFFER);
+    }
+}
+```
+
+- [ ] **Step 3: Run tests, expect compile-time error (no impl)**
+
+```bash
+cargo test -p ahand-hub --lib ws::in_memory_outbox::tests
+```
+
+Expected: compile error — `InMemoryOutboxStore` does not implement `OutboxStore`.
+
+- [ ] **Step 4: Implement the trait**
+
+Add below the struct definition (still inside `in_memory_outbox.rs`):
+
+```rust
+#[async_trait]
+impl OutboxStore for InMemoryOutboxStore {
+    async fn try_acquire_lock(&self, device_id: &str, session_id: &str) -> Result<bool> {
+        let mut g = self.inner.lock().await;
+        let entry = g.entry(device_id.to_string()).or_default();
+        if entry.lock.is_some() {
+            return Ok(false);
+        }
+        entry.lock = Some(session_id.to_string());
+        Ok(true)
+    }
+
+    async fn kick(&self, device_id: &str, _new_session_id: &str) -> Result<()> {
+        let mut g = self.inner.lock().await;
+        let entry = g.entry(device_id.to_string()).or_default();
+        entry.kick_count = entry.kick_count.wrapping_add(1);
+        if let Some(tx) = &entry.kick_tx {
+            let _ = tx.send(entry.kick_count);
+        }
+        Ok(())
+    }
+
+    async fn subscribe_kick(&self, device_id: &str) -> Result<KickSubscription> {
+        let mut g = self.inner.lock().await;
+        let entry = g.entry(device_id.to_string()).or_default();
+        let tx = match &entry.kick_tx {
+            Some(tx) => tx.clone(),
+            None => {
+                let (tx, _rx) = watch::channel(0u64);
+                entry.kick_tx = Some(tx.clone());
+                tx
+            }
+        };
+        let recv = tx.subscribe();
+        // Memory impl does not need a background task; return a no-op handle.
+        let _drop_guard = tokio::spawn(async {});
+        Ok(KickSubscription { recv, _drop_guard })
+    }
+
+    async fn renew_lock(&self, device_id: &str, session_id: &str) -> Result<bool> {
+        let g = self.inner.lock().await;
+        Ok(g.get(device_id)
+            .and_then(|e| e.lock.as_ref())
+            .map(|owner| owner == session_id)
+            .unwrap_or(false))
+    }
+
+    async fn release_lock(&self, device_id: &str, session_id: &str) -> Result<()> {
+        let mut g = self.inner.lock().await;
+        if let Some(entry) = g.get_mut(device_id) {
+            if entry.lock.as_deref() == Some(session_id) {
+                entry.lock = None;
+            }
+        }
+        Ok(())
+    }
+
+    async fn reconcile_on_hello(
+        &self,
+        device_id: &str,
+        session_id: &str,
+        last_ack: u64,
+    ) -> Result<u64> {
+        let mut g = self.inner.lock().await;
+        let entry = g.get_mut(device_id).ok_or_else(|| HubError::Unauthorized)?;
+        if entry.lock.as_deref() != Some(session_id) {
+            return Err(HubError::Unauthorized);
+        }
+        if last_ack > entry.seq {
+            // Bootstrap path
+            entry.seq = last_ack;
+            entry.buffer.clear();
+            return Ok(last_ack);
+        }
+        // Normal path: trim acked frames
+        while let Some((seq, _)) = entry.buffer.front() {
+            if *seq <= last_ack {
+                entry.buffer.pop_front();
+            } else {
+                break;
+            }
+        }
+        Ok(entry.seq)
+    }
+
+    async fn unacked_frames(&self, device_id: &str, last_ack: u64) -> Result<Vec<Vec<u8>>> {
+        let g = self.inner.lock().await;
+        Ok(g.get(device_id)
+            .map(|e| {
+                e.buffer
+                    .iter()
+                    .filter(|(seq, _)| *seq > last_ack)
+                    .map(|(_, bytes)| bytes.clone())
+                    .collect()
+            })
+            .unwrap_or_default())
+    }
+
+    async fn fenced_incr_seq(&self, device_id: &str, session_id: &str) -> Result<u64> {
+        let mut g = self.inner.lock().await;
+        let entry = g.get_mut(device_id).ok_or_else(|| HubError::Unauthorized)?;
+        if entry.lock.as_deref() != Some(session_id) {
+            return Err(HubError::Unauthorized);
+        }
+        entry.seq += 1;
+        Ok(entry.seq)
+    }
+
+    async fn xadd_frame(
+        &self,
+        device_id: &str,
+        session_id: &str,
+        seq: u64,
+        frame: Vec<u8>,
+    ) -> Result<()> {
+        let mut g = self.inner.lock().await;
+        let entry = g.get_mut(device_id).ok_or_else(|| HubError::Unauthorized)?;
+        if entry.lock.as_deref() != Some(session_id) {
+            return Err(HubError::Unauthorized);
+        }
+        entry.buffer.push_back((seq, frame));
+        while entry.buffer.len() > MAX_BUFFER {
+            entry.buffer.pop_front();
+        }
+        Ok(())
+    }
+
+    async fn observe_ack(&self, device_id: &str, ack: u64) -> Result<()> {
+        let mut g = self.inner.lock().await;
+        if let Some(entry) = g.get_mut(device_id) {
+            while let Some((seq, _)) = entry.buffer.front() {
+                if *seq <= ack {
+                    entry.buffer.pop_front();
+                } else {
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cargo test -p ahand-hub --lib ws::in_memory_outbox::tests
+```
+
+Expected: all 12 tests pass.
+
+- [ ] **Step 6: Run the full hub test suite to confirm no regressions from the new module**
+
+```bash
+cargo test -p ahand-hub
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ahand-hub/src/ws/in_memory_outbox.rs crates/ahand-hub/src/ws/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(hub): in-memory OutboxStore implementation
+
+Implements OutboxStore trait with process-local state. Used by
+StoreConfig::Memory and as the test fixture for the gateway refactor in
+later tasks. Mirrors RedisOutboxStore semantics method-for-method
+including the bootstrap branch in reconcile_on_hello.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Lua scripts module + EVALSHA wrapper
+
+**Goal:** Centralize Lua script source strings and the `EVALSHA`-with-`NOSCRIPT`-fallback machinery so `RedisOutboxStore` can stay focused on protocol logic.
+
+**Files:**
+- Create: `crates/ahand-hub-store/src/outbox_lua.rs`
+- Modify: `crates/ahand-hub-store/src/lib.rs` (add `pub mod outbox_lua;`)
+
+**Acceptance Criteria:**
+- [ ] All four scripts defined as `pub const &str`: `ACQUIRE_LOCK`, `RENEW_LOCK`, `RELEASE_LOCK`, `RECONCILE_ON_HELLO`, `FENCED_INCR_SEQ`, `FENCED_XADD`.
+- [ ] `Scripts` struct caches SHA1s on construction (lazily computed via `redis::Script::get_hash`).
+- [ ] `Scripts::eval` invokes `EVALSHA`; on `NOSCRIPT`, transparently falls back to `EVAL` and re-caches.
+- [ ] Unit-testable against testcontainer Redis (verified by Task 3 tests).
+
+**Verify:** `cargo check -p ahand-hub-store` → compiles. Behavior verified in Task 3.
+
+**Steps:**
+
+- [ ] **Step 1: Add module to `lib.rs`**
+
+Edit `crates/ahand-hub-store/src/lib.rs` — add at the appropriate place alongside other `pub mod`:
+
+```rust
+pub mod outbox_lua;
+```
+
+- [ ] **Step 2: Create the Lua module**
+
+Create `crates/ahand-hub-store/src/outbox_lua.rs`:
+
+```rust
+//! Lua scripts for the per-device outbox protocol on the hub side.
+//!
+//! All scripts are loaded once at construction (`SCRIPT LOAD`) and invoked
+//! via `EVALSHA`. On `NOSCRIPT` (Redis restart, FLUSHALL), the wrapper
+//! transparently falls back to `EVAL` and re-caches the SHA. Callers do
+//! not need to handle script loading or SHA management.
+//!
+//! The scripts are designed to be the unit of atomicity. The Rust caller
+//! is responsible for ordering the two-step send (`fenced_incr_seq` →
+//! encode envelope with assigned seq → `fenced_xadd`); see the design doc
+//! for the rationale.
+
+use redis::aio::ConnectionManager;
+use redis::{FromRedisValue, Script, ToRedisArgs};
+
+pub const ACQUIRE_LOCK: &str = r#"
+-- KEYS[1] = lock:device:{id}
+-- ARGV[1] = session_id
+-- ARGV[2] = ttl_secs
+local ok = redis.call('SET', KEYS[1], ARGV[1], 'NX', 'EX', ARGV[2])
+if ok then return 1 else return 0 end
+"#;
+
+pub const RENEW_LOCK: &str = r#"
+-- KEYS[1] = lock:device:{id}
+-- ARGV[1] = session_id
+-- ARGV[2] = ttl_secs
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  redis.call('EXPIRE', KEYS[1], ARGV[2])
+  return 1
+end
+return 0
+"#;
+
+pub const RELEASE_LOCK: &str = r#"
+-- KEYS[1] = lock:device:{id}
+-- ARGV[1] = session_id
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('DEL', KEYS[1])
+end
+return 0
+"#;
+
+pub const RECONCILE_ON_HELLO: &str = r#"
+-- KEYS[1] = lock:device:{id}
+-- KEYS[2] = seq:{id}
+-- KEYS[3] = outbox:{id}
+-- ARGV[1] = session_id
+-- ARGV[2] = last_ack (decimal)
+-- ARGV[3] = retention_secs
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then
+  return redis.error_reply('NOT_OWNER')
+end
+local current = tonumber(redis.call('GET', KEYS[2])) or 0
+local last_ack = tonumber(ARGV[2])
+if last_ack > current then
+  redis.call('SET', KEYS[2], last_ack)
+  redis.call('DEL', KEYS[3])
+  redis.call('EXPIRE', KEYS[2], ARGV[3])
+  return last_ack
+end
+if last_ack > 0 then
+  redis.call('XTRIM', KEYS[3], 'MINID', '0-' .. (last_ack + 1))
+end
+return current
+"#;
+
+pub const FENCED_INCR_SEQ: &str = r#"
+-- KEYS[1] = lock:device:{id}
+-- KEYS[2] = seq:{id}
+-- ARGV[1] = session_id
+-- ARGV[2] = retention_secs
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then
+  return redis.error_reply('NOT_OWNER')
+end
+local seq = redis.call('INCR', KEYS[2])
+redis.call('EXPIRE', KEYS[2], ARGV[2])
+return seq
+"#;
+
+pub const FENCED_XADD: &str = r#"
+-- KEYS[1] = lock:device:{id}
+-- KEYS[2] = outbox:{id}
+-- ARGV[1] = session_id
+-- ARGV[2] = seq (decimal)
+-- ARGV[3] = frame (binary)
+-- ARGV[4] = max_buffer (decimal)
+-- ARGV[5] = retention_secs
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then
+  return redis.error_reply('NOT_OWNER')
+end
+local id = '0-' .. ARGV[2]
+redis.call('XADD', KEYS[2], 'MAXLEN', '~', ARGV[4], id, 'frame', ARGV[3])
+redis.call('EXPIRE', KEYS[2], ARGV[5])
+return 1
+"#;
+
+/// Pre-built [`redis::Script`] handles. `redis::Script` itself caches the
+/// SHA1 internally and uses `EVALSHA`-then-`EVAL` automatically, so this
+/// type is mostly a named bundle so callers do not have to repeat the raw
+/// strings everywhere.
+pub struct OutboxScripts {
+    pub acquire_lock: Script,
+    pub renew_lock: Script,
+    pub release_lock: Script,
+    pub reconcile_on_hello: Script,
+    pub fenced_incr_seq: Script,
+    pub fenced_xadd: Script,
+}
+
+impl OutboxScripts {
+    pub fn load() -> Self {
+        Self {
+            acquire_lock: Script::new(ACQUIRE_LOCK),
+            renew_lock: Script::new(RENEW_LOCK),
+            release_lock: Script::new(RELEASE_LOCK),
+            reconcile_on_hello: Script::new(RECONCILE_ON_HELLO),
+            fenced_incr_seq: Script::new(FENCED_INCR_SEQ),
+            fenced_xadd: Script::new(FENCED_XADD),
+        }
+    }
+}
+
+/// Convenience wrapper used in this crate's tests; production code prefers
+/// `Script::invoke_async` directly via `OutboxScripts`.
+#[cfg(test)]
+pub async fn eval_script<T: FromRedisValue>(
+    script: &Script,
+    conn: &mut ConnectionManager,
+    keys: &[&str],
+    args: &[&dyn ToRedisArgs],
+) -> redis::RedisResult<T> {
+    let mut invoke = script.prepare_invoke();
+    for k in keys {
+        invoke.key(*k);
+    }
+    for a in args {
+        invoke.arg(*a);
+    }
+    invoke.invoke_async(conn).await
+}
+```
+
+- [ ] **Step 3: Build and verify**
+
+```bash
+cargo check -p ahand-hub-store
+```
+
+Expected: compile clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/ahand-hub-store/src/outbox_lua.rs crates/ahand-hub-store/src/lib.rs
+git commit -m "$(cat <<'EOF'
+feat(hub-store): outbox Lua scripts module
+
+Six Lua scripts for the fenced outbox protocol: acquire/renew/release lock,
+reconcile on hello (with bootstrap branch), fenced INCR seq, fenced XADD
+frame. redis::Script handles EVALSHA→NOSCRIPT→EVAL transparently.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `RedisOutboxStore` — lock primitives (acquire / kick / subscribe / renew / release)
+
+**Goal:** Stand up `RedisOutboxStore` skeleton + the five lock-related methods. Does not include the send / reconcile / replay / observe_ack methods (those land in Task 4). Splitting at this seam keeps each task's diff focused and lets us run integration tests for the lock dance independently.
+
+**Files:**
+- Create: `crates/ahand-hub-store/src/outbox_store.rs`
+- Modify: `crates/ahand-hub-store/src/lib.rs` (`pub mod outbox_store;`)
+- Modify: `crates/ahand-hub-store/tests/store_roundtrip.rs` (add lock-flow tests reusing `TestStack`)
+
+**Acceptance Criteria:**
+- [ ] `RedisOutboxStore::new(redis_url) -> anyhow::Result<Self>` connects + caches scripts.
+- [ ] `try_acquire_lock` round-trips `SET NX EX` correctly; concurrent acquirers see exactly one winner.
+- [ ] `kick` publishes on `kick:{device_id}`.
+- [ ] `subscribe_kick` returns a `KickSubscription` whose `recv` ticks on `PUBLISH`.
+- [ ] `renew_lock` extends TTL only for the matching session_id.
+- [ ] `release_lock` deletes only for the matching session_id.
+- [ ] Integration tests pass against testcontainer Redis (Docker required).
+
+**Verify:** `cargo test -p ahand-hub-store --features test-support --test store_roundtrip outbox_lock_` → all relevant tests pass.
+
+**Steps:**
+
+- [ ] **Step 1: Add module to `lib.rs`**
+
+```rust
+pub mod outbox_store;
+```
+
+- [ ] **Step 2: Skeleton + lock methods**
+
+Create `crates/ahand-hub-store/src/outbox_store.rs`:
+
+```rust
+use std::sync::Arc;
+use std::time::Duration;
+
+use ahand_hub_core::traits::{KickSubscription, OutboxStore};
+use ahand_hub_core::{HubError, Result};
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use redis::aio::ConnectionManager;
+use redis::{AsyncCommands, Client};
+use tokio::sync::{Mutex, watch};
+use tokio::task::JoinHandle;
+
+use crate::outbox_lua::OutboxScripts;
+
+const LOCK_TTL_SECS: u64 = 30;
+const RETENTION_SECS: u64 = 30 * 24 * 60 * 60; // 30 days
+const STREAM_MAXLEN: u64 = 10_000;
+
+#[derive(Clone)]
+pub struct RedisOutboxStore {
+    client: Client,
+    conn: Arc<Mutex<ConnectionManager>>,
+    scripts: Arc<OutboxScripts>,
+}
+
+impl RedisOutboxStore {
+    pub async fn new(redis_url: &str) -> anyhow::Result<Self> {
+        let client = Client::open(redis_url)?;
+        let conn = crate::redis::connect_redis(redis_url).await?;
+        Ok(Self {
+            client,
+            conn: Arc::new(Mutex::new(conn)),
+            scripts: Arc::new(OutboxScripts::load()),
+        })
+    }
+
+    fn lock_key(device_id: &str) -> String {
+        format!("lock:device:{device_id}")
+    }
+    fn seq_key(device_id: &str) -> String {
+        format!("seq:{device_id}")
+    }
+    fn outbox_key(device_id: &str) -> String {
+        format!("outbox:{device_id}")
+    }
+    fn kick_channel(device_id: &str) -> String {
+        format!("kick:{device_id}")
+    }
+}
+
+fn redis_err(err: redis::RedisError) -> HubError {
+    HubError::Internal(err.to_string())
+}
+
+#[async_trait]
+impl OutboxStore for RedisOutboxStore {
+    async fn try_acquire_lock(&self, device_id: &str, session_id: &str) -> Result<bool> {
+        let mut conn = self.conn.lock().await;
+        let lock_key = Self::lock_key(device_id);
+        let result: i64 = self
+            .scripts
+            .acquire_lock
+            .key(lock_key)
+            .arg(session_id)
+            .arg(LOCK_TTL_SECS)
+            .invoke_async(&mut *conn)
+            .await
+            .map_err(redis_err)?;
+        Ok(result == 1)
+    }
+
+    async fn kick(&self, device_id: &str, new_session_id: &str) -> Result<()> {
+        let mut conn = self.conn.lock().await;
+        let _: i64 = conn
+            .publish(Self::kick_channel(device_id), new_session_id)
+            .await
+            .map_err(redis_err)?;
+        Ok(())
+    }
+
+    async fn subscribe_kick(&self, device_id: &str) -> Result<KickSubscription> {
+        let channel = Self::kick_channel(device_id);
+        let (tx, rx) = watch::channel(0u64);
+        let client = self.client.clone();
+
+        // Long-lived background task: subscribes to the kick channel and bumps
+        // the watch counter on each PUBLISH. Drops cleanly when the JoinHandle
+        // is dropped from KickSubscription.
+        let join: JoinHandle<()> = tokio::spawn(async move {
+            let mut pubsub = match client.get_async_pubsub().await {
+                Ok(p) => p,
+                Err(_) => return,
+            };
+            if pubsub.subscribe(channel.as_str()).await.is_err() {
+                return;
+            }
+            let mut stream = pubsub.on_message();
+            let mut counter: u64 = 0;
+            while let Some(_msg) = stream.next().await {
+                counter = counter.wrapping_add(1);
+                if tx.send(counter).is_err() {
+                    break;
+                }
+            }
+        });
+
+        Ok(KickSubscription {
+            recv: rx,
+            _drop_guard: join,
+        })
+    }
+
+    async fn renew_lock(&self, device_id: &str, session_id: &str) -> Result<bool> {
+        let mut conn = self.conn.lock().await;
+        let result: i64 = self
+            .scripts
+            .renew_lock
+            .key(Self::lock_key(device_id))
+            .arg(session_id)
+            .arg(LOCK_TTL_SECS)
+            .invoke_async(&mut *conn)
+            .await
+            .map_err(redis_err)?;
+        Ok(result == 1)
+    }
+
+    async fn release_lock(&self, device_id: &str, session_id: &str) -> Result<()> {
+        let mut conn = self.conn.lock().await;
+        let _: i64 = self
+            .scripts
+            .release_lock
+            .key(Self::lock_key(device_id))
+            .arg(session_id)
+            .invoke_async(&mut *conn)
+            .await
+            .map_err(redis_err)?;
+        Ok(())
+    }
+
+    // ── stub implementations of the rest; filled in by Task 4 ──
+
+    async fn reconcile_on_hello(
+        &self,
+        _device_id: &str,
+        _session_id: &str,
+        _last_ack: u64,
+    ) -> Result<u64> {
+        Err(HubError::Internal("reconcile_on_hello not implemented (Task 4)".into()))
+    }
+
+    async fn unacked_frames(&self, _device_id: &str, _last_ack: u64) -> Result<Vec<Vec<u8>>> {
+        Err(HubError::Internal("unacked_frames not implemented (Task 4)".into()))
+    }
+
+    async fn fenced_incr_seq(&self, _device_id: &str, _session_id: &str) -> Result<u64> {
+        Err(HubError::Internal("fenced_incr_seq not implemented (Task 4)".into()))
+    }
+
+    async fn xadd_frame(
+        &self,
+        _device_id: &str,
+        _session_id: &str,
+        _seq: u64,
+        _frame: Vec<u8>,
+    ) -> Result<()> {
+        Err(HubError::Internal("xadd_frame not implemented (Task 4)".into()))
+    }
+
+    async fn observe_ack(&self, _device_id: &str, _ack: u64) -> Result<()> {
+        Err(HubError::Internal("observe_ack not implemented (Task 4)".into()))
+    }
+}
+```
+
+- [ ] **Step 3: Wire `RedisOutboxStore` into the `TestStack`**
+
+Edit `crates/ahand-hub-store/tests/support/mod.rs`:
+
+```rust
+// Add field:
+pub struct TestStack {
+    pub devices: ahand_hub_store::device_store::PgDeviceStore,
+    pub jobs: ahand_hub_store::job_store::PgJobStore,
+    pub audit: ahand_hub_store::audit_store::PgAuditStore,
+    pub presence: ahand_hub_store::presence_store::RedisPresenceStore,
+    pub outbox: ahand_hub_store::outbox_store::RedisOutboxStore,   // <— new
+    database_url: String,
+    redis_url: String,
+    _postgres: ManagedContainer,
+    _redis: ManagedContainer,
+}
+
+// In TestStack::start, after constructing presence:
+let outbox = ahand_hub_store::outbox_store::RedisOutboxStore::new(&redis_url).await?;
+
+// In the returned struct literal:
+Ok(Self {
+    // ... existing fields ...
+    outbox,
+    // ... existing fields ...
+})
+```
+
+- [ ] **Step 4: Add lock-flow integration tests at the end of `store_roundtrip.rs`**
+
+```rust
+#[tokio::test]
+async fn outbox_lock_acquire_and_release() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    assert!(stack.outbox.try_acquire_lock("dev-lock-1", "sess-a").await?);
+    assert!(!stack.outbox.try_acquire_lock("dev-lock-1", "sess-b").await?);
+    stack.outbox.release_lock("dev-lock-1", "sess-a").await?;
+    assert!(stack.outbox.try_acquire_lock("dev-lock-1", "sess-b").await?);
+    Ok(())
+}
+
+#[tokio::test]
+async fn outbox_lock_release_with_wrong_session_is_noop() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    assert!(stack.outbox.try_acquire_lock("dev-lock-2", "sess-a").await?);
+    stack.outbox.release_lock("dev-lock-2", "sess-other").await?;
+    assert!(!stack.outbox.try_acquire_lock("dev-lock-2", "sess-b").await?);
+    Ok(())
+}
+
+#[tokio::test]
+async fn outbox_lock_renew_extends_ttl_for_owner_only() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    stack.outbox.try_acquire_lock("dev-lock-3", "sess-a").await?;
+    assert!(stack.outbox.renew_lock("dev-lock-3", "sess-a").await?);
+    assert!(!stack.outbox.renew_lock("dev-lock-3", "sess-b").await?);
+    Ok(())
+}
+
+#[tokio::test]
+async fn outbox_kick_delivers_to_subscriber() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    let mut sub = stack.outbox.subscribe_kick("dev-kick-1").await?;
+    // Subscriber must be ready before publish; sleep briefly to let the
+    // background task complete its SUBSCRIBE.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    stack.outbox.kick("dev-kick-1", "new-sess").await?;
+    tokio::time::timeout(std::time::Duration::from_secs(2), sub.recv.changed())
+        .await
+        .expect("kick should arrive within 2s")?;
+    assert!(*sub.recv.borrow() >= 1);
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Run the lock tests**
+
+```bash
+cargo test -p ahand-hub-store --features test-support --test store_roundtrip outbox_lock outbox_kick
+```
+
+Expected: all 4 tests pass (Docker daemon required for testcontainer).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ahand-hub-store/src/outbox_store.rs crates/ahand-hub-store/src/lib.rs crates/ahand-hub-store/tests/support/mod.rs crates/ahand-hub-store/tests/store_roundtrip.rs
+git commit -m "$(cat <<'EOF'
+feat(hub-store): RedisOutboxStore lock primitives
+
+acquire/renew/release via Lua-checked SET NX EX. kick via PUBLISH;
+subscribe_kick spawns a long-lived task that bumps a watch::Sender on
+each message. Send/reconcile/replay/ack remain stubbed (return Internal
+error) — landed in the next commit so this diff stays reviewable.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `RedisOutboxStore` — send / reconcile / replay / observe_ack
+
+**Goal:** Fill in the five remaining methods so `RedisOutboxStore` is complete.
+
+**Files:**
+- Modify: `crates/ahand-hub-store/src/outbox_store.rs`
+- Modify: `crates/ahand-hub-store/tests/store_roundtrip.rs` (add data-path tests)
+
+**Acceptance Criteria:**
+- [ ] `fenced_incr_seq` returns monotonically increasing seqs for the lock owner; returns `Unauthorized` for non-owners.
+- [ ] `xadd_frame` writes the frame at stream ID `0-{seq}`, applies `MAXLEN ~ 10000` and `EXPIRE`.
+- [ ] `unacked_frames(device_id, last_ack)` returns frames in seq order, only entries with `seq > last_ack`.
+- [ ] `observe_ack` trims via `XTRIM MINID 0-{ack+1}`.
+- [ ] `reconcile_on_hello` normal path returns current seq, trims acked entries; bootstrap path (when `last_ack > current`) sets seq to `last_ack` and clears the stream, returns `last_ack`.
+- [ ] All methods return `HubError::Unauthorized` when the fence rejects (i.e., `NOT_OWNER` from Lua).
+- [ ] Integration tests pass.
+
+**Verify:** `cargo test -p ahand-hub-store --features test-support --test store_roundtrip outbox_` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Map `NOT_OWNER` Lua error to `HubError::Unauthorized`**
+
+The `redis::error_reply('NOT_OWNER')` call in Lua surfaces in Rust as a `redis::RedisError` whose `code()` is `Some("NOT_OWNER")`. Add a helper at the top of `outbox_store.rs`:
+
+```rust
+fn map_redis_err(err: redis::RedisError) -> HubError {
+    if err.code() == Some("NOT_OWNER") {
+        HubError::Unauthorized
+    } else {
+        HubError::Internal(err.to_string())
+    }
+}
+```
+
+Replace existing `redis_err` calls in this file with `map_redis_err` so the Unauthorized mapping is uniform. Keep `redis_err` only where it's known the script can't return `NOT_OWNER` (e.g., the bare `PUBLISH` in `kick`).
+
+- [ ] **Step 2: Implement `fenced_incr_seq`**
+
+Replace the stub:
+
+```rust
+async fn fenced_incr_seq(&self, device_id: &str, session_id: &str) -> Result<u64> {
+    let mut conn = self.conn.lock().await;
+    let seq: u64 = self
+        .scripts
+        .fenced_incr_seq
+        .key(Self::lock_key(device_id))
+        .key(Self::seq_key(device_id))
+        .arg(session_id)
+        .arg(RETENTION_SECS)
+        .invoke_async(&mut *conn)
+        .await
+        .map_err(map_redis_err)?;
+    Ok(seq)
+}
+```
+
+- [ ] **Step 3: Implement `xadd_frame`**
+
+```rust
+async fn xadd_frame(
+    &self,
+    device_id: &str,
+    session_id: &str,
+    seq: u64,
+    frame: Vec<u8>,
+) -> Result<()> {
+    let mut conn = self.conn.lock().await;
+    let _: i64 = self
+        .scripts
+        .fenced_xadd
+        .key(Self::lock_key(device_id))
+        .key(Self::outbox_key(device_id))
+        .arg(session_id)
+        .arg(seq.to_string())
+        .arg(frame)
+        .arg(STREAM_MAXLEN)
+        .arg(RETENTION_SECS)
+        .invoke_async(&mut *conn)
+        .await
+        .map_err(map_redis_err)?;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Implement `unacked_frames`**
+
+`XRANGE outbox:{id} (0-{last_ack} +` reads all entries with stream ID strictly greater than `0-{last_ack}`. The redis crate's `xrange` exposes the entries as a `StreamRangeReply`.
+
+```rust
+async fn unacked_frames(&self, device_id: &str, last_ack: u64) -> Result<Vec<Vec<u8>>> {
+    use redis::streams::StreamRangeReply;
+    let mut conn = self.conn.lock().await;
+    // XRANGE expects exclusive start prefixed with '('. last_ack=0 means
+    // "everything"; encode that as start='-' so we don't synthesize 0-0.
+    let start = if last_ack == 0 {
+        "-".to_string()
+    } else {
+        format!("(0-{last_ack}")
+    };
+    let reply: StreamRangeReply = conn
+        .xrange(Self::outbox_key(device_id), start, "+")
+        .await
+        .map_err(redis_err)?;
+    let mut frames = Vec::with_capacity(reply.ids.len());
+    for entry in reply.ids {
+        // Each entry is a HashMap<String, redis::Value>; field key is "frame".
+        if let Some(redis::Value::Data(bytes)) = entry.map.get("frame") {
+            frames.push(bytes.clone());
+        }
+    }
+    Ok(frames)
+}
+```
+
+- [ ] **Step 5: Implement `observe_ack`**
+
+```rust
+async fn observe_ack(&self, device_id: &str, ack: u64) -> Result<()> {
+    if ack == 0 {
+        return Ok(());
+    }
+    let mut conn = self.conn.lock().await;
+    // XTRIM outbox:{id} MINID 0-{ack+1}
+    let minid = format!("0-{}", ack + 1);
+    let _: i64 = redis::cmd("XTRIM")
+        .arg(Self::outbox_key(device_id))
+        .arg("MINID")
+        .arg(minid)
+        .query_async(&mut *conn)
+        .await
+        .map_err(redis_err)?;
+    Ok(())
+}
+```
+
+- [ ] **Step 6: Implement `reconcile_on_hello`**
+
+```rust
+async fn reconcile_on_hello(
+    &self,
+    device_id: &str,
+    session_id: &str,
+    last_ack: u64,
+) -> Result<u64> {
+    let mut conn = self.conn.lock().await;
+    let returned: u64 = self
+        .scripts
+        .reconcile_on_hello
+        .key(Self::lock_key(device_id))
+        .key(Self::seq_key(device_id))
+        .key(Self::outbox_key(device_id))
+        .arg(session_id)
+        .arg(last_ack.to_string())
+        .arg(RETENTION_SECS)
+        .invoke_async(&mut *conn)
+        .await
+        .map_err(map_redis_err)?;
+    Ok(returned)
+}
+```
+
+- [ ] **Step 7: Add data-path integration tests**
+
+At the end of `store_roundtrip.rs`:
+
+```rust
+#[tokio::test]
+async fn outbox_send_and_replay_roundtrip() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    let dev = "dev-send-1";
+    let sess = "sess-a";
+    stack.outbox.try_acquire_lock(dev, sess).await?;
+
+    let mut seqs = Vec::new();
+    for i in 0..5u8 {
+        let seq = stack.outbox.fenced_incr_seq(dev, sess).await?;
+        stack.outbox.xadd_frame(dev, sess, seq, vec![i]).await?;
+        seqs.push(seq);
+    }
+    assert_eq!(seqs, vec![1, 2, 3, 4, 5]);
+
+    let frames = stack.outbox.unacked_frames(dev, 0).await?;
+    assert_eq!(frames, vec![vec![0], vec![1], vec![2], vec![3], vec![4]]);
+
+    let frames = stack.outbox.unacked_frames(dev, 2).await?;
+    assert_eq!(frames, vec![vec![2], vec![3], vec![4]]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn outbox_observe_ack_trims() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    let dev = "dev-ack-1";
+    let sess = "sess-a";
+    stack.outbox.try_acquire_lock(dev, sess).await?;
+
+    for i in 0..3u8 {
+        let seq = stack.outbox.fenced_incr_seq(dev, sess).await?;
+        stack.outbox.xadd_frame(dev, sess, seq, vec![i]).await?;
+    }
+    stack.outbox.observe_ack(dev, 2).await?;
+    let frames = stack.outbox.unacked_frames(dev, 0).await?;
+    assert_eq!(frames, vec![vec![2]]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn outbox_reconcile_normal_path_returns_current_seq() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    let dev = "dev-rec-normal";
+    let sess = "sess-a";
+    stack.outbox.try_acquire_lock(dev, sess).await?;
+    for _ in 0..5 {
+        let seq = stack.outbox.fenced_incr_seq(dev, sess).await?;
+        stack.outbox.xadd_frame(dev, sess, seq, vec![]).await?;
+    }
+    let current = stack.outbox.reconcile_on_hello(dev, sess, 3).await?;
+    assert_eq!(current, 5);
+    let frames = stack.outbox.unacked_frames(dev, 0).await?;
+    // 1..=3 trimmed; 4..=5 remain
+    assert_eq!(frames.len(), 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn outbox_reconcile_bootstrap_path_seeds_and_clears() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    let dev = "dev-rec-bootstrap";
+    let sess = "sess-a";
+    stack.outbox.try_acquire_lock(dev, sess).await?;
+    // Fresh device, last_ack=9 — the wedged-after-restart case.
+    let returned = stack.outbox.reconcile_on_hello(dev, sess, 9).await?;
+    assert_eq!(returned, 9);
+    let next = stack.outbox.fenced_incr_seq(dev, sess).await?;
+    assert_eq!(next, 10);
+    let frames = stack.outbox.unacked_frames(dev, 9).await?;
+    assert!(frames.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn outbox_send_rejects_non_owner() -> anyhow::Result<()> {
+    let stack = TestStack::start().await?;
+    let dev = "dev-fence";
+    stack.outbox.try_acquire_lock(dev, "sess-a").await?;
+    let err = stack.outbox.fenced_incr_seq(dev, "sess-b").await.unwrap_err();
+    assert!(matches!(err, HubError::Unauthorized));
+    Ok(())
+}
+```
+
+(Add `use ahand_hub_core::HubError;` if not already present.)
+
+- [ ] **Step 8: Run tests**
+
+```bash
+cargo test -p ahand-hub-store --features test-support --test store_roundtrip outbox_
+```
+
+Expected: all 9 outbox tests pass (4 lock + 5 data-path).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/ahand-hub-store/src/outbox_store.rs crates/ahand-hub-store/tests/store_roundtrip.rs
+git commit -m "$(cat <<'EOF'
+feat(hub-store): RedisOutboxStore send/reconcile/replay/observe_ack
+
+Two-step send: fenced_incr_seq returns assigned seq, caller stamps the
+envelope and re-encodes, then fenced_xadd writes the bytes. reconcile
+on hello has the bootstrap branch — when device's last_ack exceeds
+the store's current seq, seed the counter and clear the stream so
+wedged devices auto-recover after this code ships.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Refactor `ConnectionRegistry` to use `OutboxStore`
+
+**Goal:** Cut the in-memory `Outbox` out of `ConnectionRegistry`. Wire `Arc<dyn OutboxStore>` in, add session_id fencing, lease renewer task, kick subscriber task, and route the lock-contention path back as a clean error.
+
+**Files:**
+- Modify: `crates/ahand-hub/src/ws/device_gateway.rs`
+
+**Acceptance Criteria:**
+- [ ] `ConnectionRegistry::new(Arc<dyn OutboxStore>) -> Self` is the only constructor; `Default::default()` removed.
+- [ ] `ConnectionEntry` no longer carries `outbox: Mutex<Outbox>`; carries `session_id: String` instead.
+- [ ] `register(device_id, last_ack)` is now `async` and returns either success tuple or `HubError::OutboxLockContention` when the kick-then-retry cycle fails.
+- [ ] `register` calls `OutboxStore::reconcile_on_hello` then `unacked_frames` and pushes replay frames into the per-connection mpsc.
+- [ ] On accept, two background tasks are spawned per connection: lease renewer (every 10s) and kick subscriber. Either firing closes the WS via `close_tx`.
+- [ ] `send` is fully fenced: `fenced_incr_seq` → mutate `envelope.seq` → encode → `xadd_frame`. On `Unauthorized` from either, close the connection and return `DeviceOffline`.
+- [ ] `observe_ack` and `observe_inbound` delegate ack-trim to `OutboxStore::observe_ack` (fire-and-forget).
+- [ ] `unregister` calls `OutboxStore::release_lock` (best-effort) and aborts both background tasks.
+- [ ] Existing in-source tests (lines 903+ in `device_gateway.rs`) updated to use `InMemoryOutboxStore`.
+
+**Verify:** `cargo test -p ahand-hub --lib ws::device_gateway::tests` → all pass.
+
+**Steps:**
+
+- [ ] **Step 1: Change struct definitions**
+
+Replace the top of `device_gateway.rs` (the existing `ConnectionRegistry`/`ConnectionEntry`/`ActiveConnection` block) with:
+
+```rust
+use std::sync::Arc;
+
+use ahand_hub_core::HubError;
+use ahand_hub_core::traits::{KickSubscription, OutboxStore};
+use ahand_hub_core::traits::DeviceStore;
+use axum::extract::State;
+use axum::extract::ws::{CloseFrame, Message as WsMessage, WebSocket, WebSocketUpgrade};
+use axum::response::Response;
+use dashmap::DashMap;
+use futures_util::{SinkExt, StreamExt};
+use prost::Message;
+use tokio::sync::{Mutex as AsyncMutex, mpsc, watch};
+use tokio::task::JoinHandle;
+
+use crate::state::AppState;
+
+const LEASE_RENEW_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+const LOCK_ACQUIRE_RETRIES: u32 = 5;
+const LOCK_ACQUIRE_BACKOFF: std::time::Duration = std::time::Duration::from_millis(200);
+
+pub struct ConnectionRegistry {
+    senders: DashMap<String, ConnectionEntry>,
+    outbox: Arc<dyn OutboxStore>,
+}
+
+struct ConnectionEntry {
+    active: Option<ActiveConnection>,
+}
+
+#[derive(Clone)]
+struct ActiveConnection {
+    connection_id: uuid::Uuid,
+    /// UUID acting as fencing token in every Redis script.
+    session_id: String,
+    sender: mpsc::UnboundedSender<OutboundFrame>,
+    close_tx: watch::Sender<bool>,
+    /// Aborted on close so the renewer stops attempting to renew.
+    lease_task: Arc<AsyncMutex<Option<JoinHandle<()>>>>,
+    /// Aborted on close so the kick subscriber stops listening.
+    kick_task: Arc<AsyncMutex<Option<JoinHandle<()>>>>,
+}
+
+pub(crate) struct OutboundFrame {
+    pub(crate) frame: Vec<u8>,
+}
+
+impl ConnectionRegistry {
+    pub fn new(outbox: Arc<dyn OutboxStore>) -> Self {
+        Self {
+            senders: DashMap::new(),
+            outbox,
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Rewrite `register` as async with lock dance**
+
+```rust
+impl ConnectionRegistry {
+    pub(crate) async fn register(
+        &self,
+        device_id: String,
+        last_ack: u64,
+    ) -> Result<
+        (
+            uuid::Uuid,
+            mpsc::UnboundedReceiver<OutboundFrame>,
+            watch::Receiver<bool>,
+        ),
+        HubError,
+    > {
+        let session_id = uuid::Uuid::new_v4().to_string();
+
+        // 1) Acquire lock with kick-then-retry.
+        let mut acquired = self.outbox.try_acquire_lock(&device_id, &session_id).await?;
+        if !acquired {
+            self.outbox.kick(&device_id, &session_id).await?;
+            for _ in 0..LOCK_ACQUIRE_RETRIES {
+                tokio::time::sleep(LOCK_ACQUIRE_BACKOFF).await;
+                acquired = self.outbox.try_acquire_lock(&device_id, &session_id).await?;
+                if acquired {
+                    break;
+                }
+            }
+        }
+        if !acquired {
+            return Err(HubError::OutboxLockContention(device_id));
+        }
+
+        // 2) Reconcile + read replay frames BEFORE we wire the in-process state,
+        //    so a failure during reconcile leaves the lock in a clean state via
+        //    the release_lock in the error arm.
+        if let Err(err) = self
+            .outbox
+            .reconcile_on_hello(&device_id, &session_id, last_ack)
+            .await
+        {
+            let _ = self.outbox.release_lock(&device_id, &session_id).await;
+            return Err(err);
+        }
+        let replay = self
+            .outbox
+            .unacked_frames(&device_id, last_ack)
+            .await
+            .unwrap_or_default();
+
+        // 3) Build per-connection state.
+        let (tx, rx) = mpsc::unbounded_channel();
+        let connection_id = uuid::Uuid::new_v4();
+        let (close_tx, close_rx) = watch::channel(false);
+
+        // 4) Spawn lease renewer.
+        let lease_task = {
+            let outbox = self.outbox.clone();
+            let device_id = device_id.clone();
+            let session_id = session_id.clone();
+            let close_tx = close_tx.clone();
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(LEASE_RENEW_INTERVAL);
+                interval.tick().await; // first tick is immediate; skip
+                loop {
+                    interval.tick().await;
+                    match outbox.renew_lock(&device_id, &session_id).await {
+                        Ok(true) => continue,
+                        Ok(false) | Err(_) => {
+                            tracing::warn!(
+                                device_id = %device_id,
+                                session_id = %session_id,
+                                "lease lost, signalling close"
+                            );
+                            let _ = close_tx.send(true);
+                            break;
+                        }
+                    }
+                }
+            })
+        };
+
+        // 5) Spawn kick subscriber.
+        let kick_task = {
+            let outbox = self.outbox.clone();
+            let device_id = device_id.clone();
+            let close_tx = close_tx.clone();
+            tokio::spawn(async move {
+                let mut sub = match outbox.subscribe_kick(&device_id).await {
+                    Ok(s) => s,
+                    Err(err) => {
+                        tracing::warn!(
+                            device_id = %device_id,
+                            error = %err,
+                            "failed to subscribe to kick channel"
+                        );
+                        return;
+                    }
+                };
+                if sub.recv.changed().await.is_ok() {
+                    tracing::info!(device_id = %device_id, "received kick, signalling close");
+                    let _ = close_tx.send(true);
+                }
+            })
+        };
+
+        let active = ActiveConnection {
+            connection_id,
+            session_id: session_id.clone(),
+            sender: tx.clone(),
+            close_tx: close_tx.clone(),
+            lease_task: Arc::new(AsyncMutex::new(Some(lease_task))),
+            kick_task: Arc::new(AsyncMutex::new(Some(kick_task))),
+        };
+
+        // 6) Replay first, then publish the active connection.
+        for frame in replay {
+            let _ = tx.send(OutboundFrame { frame });
+        }
+        match self.senders.entry(device_id) {
+            dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                let entry = entry.get_mut();
+                if let Some(prev) = entry.active.replace(active) {
+                    let _ = prev.close_tx.send(true);
+                }
+            }
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                entry.insert(ConnectionEntry {
+                    active: Some(active),
+                });
+            }
+        }
+        Ok((connection_id, rx, close_rx))
+    }
+}
+```
+
+- [ ] **Step 3: Rewrite `send`**
+
+Replace the existing `send` (was around line 96–145):
+
+```rust
+impl ConnectionRegistry {
+    pub(crate) async fn send(
+        &self,
+        device_id: &str,
+        mut envelope: ahand_protocol::Envelope,
+    ) -> anyhow::Result<()> {
+        let (sender, session_id, connection_id) = {
+            let entry = self
+                .senders
+                .get(device_id)
+                .ok_or_else(|| HubError::DeviceOffline(device_id.into()))?;
+            let active = entry
+                .active
+                .as_ref()
+                .ok_or_else(|| HubError::DeviceOffline(device_id.into()))?;
+            (
+                active.sender.clone(),
+                active.session_id.clone(),
+                active.connection_id,
+            )
+        };
+
+        let seq = match self.outbox.fenced_incr_seq(device_id, &session_id).await {
+            Ok(s) => s,
+            Err(HubError::Unauthorized) => {
+                self.fail_connection(device_id, connection_id);
+                return Err(HubError::DeviceOffline(device_id.into()).into());
+            }
+            Err(err) => return Err(err.into()),
+        };
+        envelope.seq = seq;
+        let frame = envelope.encode_to_vec();
+
+        if let Err(err) = self
+            .outbox
+            .xadd_frame(device_id, &session_id, seq, frame.clone())
+            .await
+        {
+            if matches!(err, HubError::Unauthorized) {
+                self.fail_connection(device_id, connection_id);
+                return Err(HubError::DeviceOffline(device_id.into()).into());
+            }
+            return Err(err.into());
+        }
+
+        if sender.send(OutboundFrame { frame }).is_err() {
+            // The WS IO task is gone; the message stays in the durable
+            // stream and will replay on next reconnect.
+            self.fail_connection(device_id, connection_id);
+            return Err(HubError::DeviceOffline(device_id.into()).into());
+        }
+        Ok(())
+    }
+
+    fn fail_connection(&self, device_id: &str, connection_id: uuid::Uuid) {
+        if let Some(mut entry) = self.senders.get_mut(device_id) {
+            if entry
+                .active
+                .as_ref()
+                .map(|a| a.connection_id == connection_id)
+                .unwrap_or(false)
+            {
+                if let Some(active) = entry.active.take() {
+                    let _ = active.close_tx.send(true);
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Rewrite `observe_ack` / `observe_inbound`**
+
+The old code called `outbox.try_on_peer_ack(ack)` and could return `InvalidPeerAck`. With Redis as source of truth, the device's monotonic ack is just trimmed against the durable stream — there's no "ack from the future" failure mode anymore (the bootstrap branch handles the wedged-device case at register time). Rejecting an ack would also be hostile because the durable stream is the new authority.
+
+```rust
+impl ConnectionRegistry {
+    pub(crate) async fn observe_ack(&self, device_id: &str, ack: u64) -> anyhow::Result<()> {
+        if ack == 0 {
+            return Ok(());
+        }
+        // Fire-and-forget; failure is logged inside the store impl, and the
+        // next successful ack or MAXLEN trim will catch up.
+        if let Err(err) = self.outbox.observe_ack(device_id, ack).await {
+            tracing::warn!(device_id = %device_id, ack = ack, error = %err, "outbox observe_ack failed");
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn observe_inbound(
+        &self,
+        device_id: &str,
+        _seq: u64,
+        ack: u64,
+    ) -> anyhow::Result<()> {
+        // Local-ack tracking ("have I already seen this seq from the device?")
+        // is handled at the WS handler layer via `has_seen_inbound`; here we
+        // only mirror peer acks into the outbox.
+        self.observe_ack(device_id, ack).await
+    }
+}
+```
+
+`has_seen_inbound` was previously implemented against the in-memory `Outbox`. With the in-memory cache gone, dedup by seq must move into per-connection state if needed elsewhere. Audit call sites:
+
+```bash
+grep -rn "has_seen_inbound" crates/ahand-hub/src
+```
+
+If the only call site is inside the gateway loop, port to a `tokio::sync::Mutex<HashSet<u64>>` per connection. If used outside, replace it with a per-`ActiveConnection` ` last_inbound_seq: AtomicU64` and check `seq > last_inbound_seq.load()` before processing.
+
+- [ ] **Step 5: Rewrite `unregister`**
+
+```rust
+impl ConnectionRegistry {
+    pub(crate) async fn unregister(
+        &self,
+        device_id: &str,
+        connection_id: uuid::Uuid,
+    ) -> anyhow::Result<bool> {
+        let session_to_release = if let Some(mut entry) = self.senders.get_mut(device_id) {
+            if entry
+                .active
+                .as_ref()
+                .map(|a| a.connection_id == connection_id)
+                .unwrap_or(false)
+            {
+                let active = entry.active.take().expect("checked above");
+                let _ = active.close_tx.send(true);
+                if let Some(handle) = active.lease_task.lock().await.take() {
+                    handle.abort();
+                }
+                if let Some(handle) = active.kick_task.lock().await.take() {
+                    handle.abort();
+                }
+                Some(active.session_id)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        // Drop the DashMap guard before await on release_lock.
+        drop(self.senders.get(device_id));
+        if let Some(session_id) = session_to_release {
+            if let Err(err) = self.outbox.release_lock(device_id, &session_id).await {
+                tracing::warn!(device_id = %device_id, error = %err, "release_lock failed");
+            }
+            // No active = nothing to keep around in the local map.
+            self.senders.remove(device_id);
+            return Ok(true);
+        }
+        Ok(false)
+    }
+}
+```
+
+- [ ] **Step 6: Update existing in-source tests**
+
+The existing tests (`mod tests` near the bottom of `device_gateway.rs`) need:
+- Replace `ConnectionRegistry::default()` with `ConnectionRegistry::new(Arc::new(InMemoryOutboxStore::new()))`.
+- Replace `registry.senders.get("device-1")` patterns with assertions on observable behavior (e.g., "was the frame delivered to the mpsc?") rather than peeking into the `outbox` field that no longer exists.
+- Existing `register_replays_only_messages_after_last_ack` test needs adapting — instead of asserting on internal `Outbox` state, simulate: register session A, send 5 frames, drop session A's connection, register session A' with `last_ack=2`, drain the mpsc, assert it contains frames 3..5.
+
+Skeleton replacement for that test:
+
+```rust
+#[tokio::test]
+async fn register_replays_only_messages_after_last_ack() {
+    let outbox = Arc::new(InMemoryOutboxStore::new());
+    let registry = ConnectionRegistry::new(outbox);
+
+    let (conn_a, mut rx_a, _close_a) = registry.register("dev-1".into(), 0).await.unwrap();
+    for i in 0..5u8 {
+        let envelope = ahand_protocol::Envelope {
+            device_id: "dev-1".into(),
+            ..Default::default()
+        };
+        registry.send("dev-1", envelope).await.unwrap();
+        let _frame = rx_a.recv().await.expect("frame delivered");
+        let _ = i;
+    }
+    // Simulate session A dropping; in-process, unregister releases the lock.
+    registry.unregister("dev-1", conn_a).await.unwrap();
+
+    // New session reconnects with last_ack=2 — only frames 3..5 should replay.
+    let (_conn_b, mut rx_b, _close_b) = registry.register("dev-1".into(), 2).await.unwrap();
+    let mut replayed = Vec::new();
+    while let Ok(frame) = tokio::time::timeout(std::time::Duration::from_millis(50), rx_b.recv()).await {
+        if let Some(f) = frame {
+            replayed.push(f);
+        } else {
+            break;
+        }
+    }
+    assert_eq!(replayed.len(), 3, "only seqs 3..=5 should replay");
+}
+```
+
+- [ ] **Step 7: Update call sites**
+
+The handler at `device_gateway.rs:480-482` becomes async-aware (it already is — that block lives in an `async` block):
+
+```rust
+let (connection_id, mut outbound_rx, close_rx) = state
+    .connections
+    .register(device_id.clone(), hello.last_ack)
+    .await
+    .map_err(|err| match err {
+        HubError::OutboxLockContention(_) => {
+            // Treat lock contention as a transient handshake failure;
+            // the daemon's reconnect backoff will retry.
+            anyhow::Error::from(err)
+        }
+        other => anyhow::Error::from(other),
+    })?;
+```
+
+Also any call to `registry.observe_ack(...)` or `registry.observe_inbound(...)` becomes `.await`.
+
+Run:
+
+```bash
+grep -rn "\.connections\.observe_ack\|\.connections\.observe_inbound\|\.connections\.send_envelope\|\.connections\.send(" crates/ahand-hub/src
+```
+
+Verify each call site is in an `async fn` and prefix with `.await`. (Most already are because the surrounding handlers are async.) `send_envelope` is the public wrapper around `send` — make it `pub async fn`.
+
+- [ ] **Step 8: Run tests**
+
+```bash
+cargo check -p ahand-hub
+cargo test -p ahand-hub --lib ws::device_gateway::tests
+cargo test -p ahand-hub
+```
+
+Expected: all pass. Some unrelated tests in `ahand-hub` may need `.await` added at call sites — fix those mechanically as the compiler reports them.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/ahand-hub/src/ws/device_gateway.rs
+git commit -m "$(cat <<'EOF'
+refactor(hub/ws): wire ConnectionRegistry to OutboxStore
+
+Per-connection session_id is now the fencing token across the registry
++ lease renewer + kick subscriber. send is fully fenced (fenced_incr_seq
+→ encode → xadd_frame); on Unauthorized either side the connection is
+torn down and the daemon's reconnect handles the rest. Lock contention
+on register surfaces as HubError::OutboxLockContention.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Wire `OutboxStore` into `AppState`
+
+**Goal:** Construct an `Arc<dyn OutboxStore>` based on `StoreConfig` and pass it to `ConnectionRegistry::new`.
+
+**Files:**
+- Modify: `crates/ahand-hub/src/state.rs`
+
+**Acceptance Criteria:**
+- [ ] `StoreConfig::Memory` builds an `Arc::new(InMemoryOutboxStore::new())`.
+- [ ] `StoreConfig::Persistent { redis_url, .. }` builds an `Arc::new(RedisOutboxStore::new(redis_url).await?)`.
+- [ ] `ConnectionRegistry::new(outbox.clone())` is the only constructor invocation.
+- [ ] No call sites still reference `ConnectionRegistry::default()`.
+
+**Verify:** `cargo check -p ahand-hub && cargo test -p ahand-hub` → green.
+
+**Steps:**
+
+- [ ] **Step 1: Update imports**
+
+Add at the top of `state.rs`:
+
+```rust
+use ahand_hub_core::traits::OutboxStore;
+use ahand_hub_store::outbox_store::RedisOutboxStore;
+use crate::ws::in_memory_outbox::InMemoryOutboxStore;
+```
+
+- [ ] **Step 2: Construct outbox in `from_config`**
+
+Inside `AppState::from_config`, replace the `match &config.store` block by extending the destructured tuple to include `outbox`:
+
+```rust
+let (
+    devices,
+    jobs_store,
+    raw_audit_store,
+    persistent_output,
+    persistent_fanout,
+    bootstrap_tokens,
+    webhook_delivery_store,
+    outbox,                                              // <— new
+) = match &config.store {
+    crate::config::StoreConfig::Memory => (
+        Arc::new(MemoryDeviceStore::default()),
+        Arc::new(MemoryJobStore::default()) as Arc<dyn JobStore>,
+        Arc::new(MemoryAuditStore::default()) as Arc<dyn AuditStore>,
+        None,
+        None,
+        crate::bootstrap::BootstrapCredentials::memory(),
+        Arc::new(MemoryWebhookDeliveryStore::new()) as Arc<dyn WebhookDeliveryStore>,
+        Arc::new(InMemoryOutboxStore::new()) as Arc<dyn OutboxStore>,
+    ),
+    crate::config::StoreConfig::Persistent {
+        database_url,
+        redis_url,
+    } => {
+        // ... existing setup unchanged ...
+        let outbox_store = RedisOutboxStore::new(redis_url).await?;
+        (
+            // ... existing fields unchanged ...
+            Arc::new(MemoryWebhookDeliveryStore::new()) as Arc<dyn WebhookDeliveryStore>,  // <-- replace with PgWebhookDeliveryStore as in current code
+            Arc::new(outbox_store) as Arc<dyn OutboxStore>,
+        )
+    }
+};
+```
+
+(Keep existing `PgWebhookDeliveryStore` usage in the persistent branch; the snippet above is just illustrating the shape.)
+
+- [ ] **Step 3: Pass to `ConnectionRegistry`**
+
+Change:
+
+```rust
+let connections = Arc::new(crate::ws::device_gateway::ConnectionRegistry::default());
+```
+
+to:
+
+```rust
+let connections = Arc::new(crate::ws::device_gateway::ConnectionRegistry::new(outbox));
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test -p ahand-hub
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ahand-hub/src/state.rs
+git commit -m "$(cat <<'EOF'
+feat(hub): wire OutboxStore into AppState
+
+Memory config uses InMemoryOutboxStore; Persistent uses RedisOutboxStore
+via the existing REDIS_URL. ConnectionRegistry::new takes the store as
+its only constructor arg; default() removed.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: End-to-end regression tests
+
+**Goal:** Codify the original incident as a regression test plus two adjacent scenarios. These live in a new integration test file so they run independently of the unit tests.
+
+**Files:**
+- Create: `crates/ahand-hub/tests/outbox_persistence.rs`
+
+**Acceptance Criteria:**
+- [ ] **Replay-after-restart** test: send N frames via store A, drop A, build store B against the same Redis, register a new session with the original `last_ack`, verify all unsent frames replay.
+- [ ] **Lock takeover** test: replica A holds the lock, replica B's `register` publishes kick → A's kick subscriber fires close → B acquires the lock within ≤ 5s.
+- [ ] **Bootstrap-path** test: build a fresh store, register a session with `last_ack=9`, verify `register` succeeds, sends start at seq 10, no spurious replay.
+- [ ] **Original incident regression** test (the keystone): two `RedisOutboxStore` instances against the same Redis simulating "before deploy" and "after deploy". Send 5 frames before; on after-deploy register with `last_ack=2`, expect frames 3..5 to replay (not Broken pipe).
+
+**Verify:** `cargo test -p ahand-hub --test outbox_persistence` → all pass (Docker required).
+
+**Steps:**
+
+- [ ] **Step 1: Create the test file**
+
+Create `crates/ahand-hub/tests/outbox_persistence.rs`:
+
+```rust
+//! End-to-end regression tests for hub outbox persistence.
+//!
+//! These tests boot a real Redis container via testcontainers, exercise
+//! `RedisOutboxStore` and `ConnectionRegistry` together, and verify the
+//! key invariants from the design spec.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ahand_hub::ws::device_gateway::ConnectionRegistry;
+use ahand_hub_core::traits::OutboxStore;
+use ahand_hub_store::outbox_store::RedisOutboxStore;
+use testcontainers::{
+    ContainerAsync, GenericImage, ImageExt,
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+
+async fn redis_container() -> anyhow::Result<(ContainerAsync<GenericImage>, String)> {
+    let container = GenericImage::new("redis", "7-alpine")
+        .with_exposed_port(6379.tcp())
+        .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
+        .start()
+        .await?;
+    let port = container.get_host_port_ipv4(6379.tcp()).await?;
+    Ok((container, format!("redis://127.0.0.1:{port}")))
+}
+
+#[tokio::test]
+async fn replay_after_simulated_hub_restart() -> anyhow::Result<()> {
+    let (_redis, url) = redis_container().await?;
+
+    // Phase 1: hub instance A handles a session for dev-1 and sends 5 frames.
+    let store_a = Arc::new(RedisOutboxStore::new(&url).await?);
+    let registry_a = ConnectionRegistry::new(store_a.clone());
+    let (_conn_a, mut rx_a, _close_a) = registry_a.register("dev-1".into(), 0).await?;
+    for _ in 0..5 {
+        let envelope = ahand_protocol::Envelope {
+            device_id: "dev-1".into(),
+            ..Default::default()
+        };
+        registry_a.send_envelope("dev-1", envelope).await?;
+        let _ = rx_a.recv().await.expect("frame delivered");
+    }
+    // Device acked frames 1 and 2 before A "dies".
+    registry_a.observe_ack("dev-1", 2).await?;
+
+    // Drop A — simulates ECS task termination. Frames are still in Redis.
+    drop(registry_a);
+    drop(store_a);
+
+    // Phase 2: hub instance B starts up and the device reconnects with last_ack=2.
+    let store_b = Arc::new(RedisOutboxStore::new(&url).await?);
+    let registry_b = ConnectionRegistry::new(store_b);
+    let (_conn_b, mut rx_b, _close_b) = registry_b.register("dev-1".into(), 2).await?;
+
+    // Frames 3..=5 should replay.
+    let mut replayed = 0;
+    while let Ok(Some(_)) = tokio::time::timeout(Duration::from_millis(200), rx_b.recv()).await {
+        replayed += 1;
+    }
+    assert_eq!(replayed, 3, "expected 3 frames (seq 3..=5) to replay");
+    Ok(())
+}
+
+#[tokio::test]
+async fn lock_takeover_via_kick() -> anyhow::Result<()> {
+    let (_redis, url) = redis_container().await?;
+    let store_a = Arc::new(RedisOutboxStore::new(&url).await?);
+    let store_b = Arc::new(RedisOutboxStore::new(&url).await?);
+    let registry_a = ConnectionRegistry::new(store_a.clone());
+    let registry_b = ConnectionRegistry::new(store_b.clone());
+
+    let (_conn_a, _rx_a, mut close_a) = registry_a.register("dev-2".into(), 0).await?;
+    // B's register should kick A and acquire within retry window.
+    let started = tokio::time::Instant::now();
+    let (_conn_b, _rx_b, _close_b) = registry_b.register("dev-2".into(), 0).await?;
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "kick-and-acquire took {:?}, expected <5s",
+        started.elapsed()
+    );
+
+    // A's close_rx should fire as a result of the kick.
+    tokio::time::timeout(Duration::from_secs(2), close_a.changed())
+        .await
+        .expect("A's close_tx should fire after kick")?;
+    assert!(*close_a.borrow_and_update());
+    Ok(())
+}
+
+#[tokio::test]
+async fn bootstrap_path_unblocks_wedged_device() -> anyhow::Result<()> {
+    let (_redis, url) = redis_container().await?;
+
+    // Fresh Redis (= just-deployed hub). Device sends Hello with last_ack=9
+    // (the wedged-after-restart case from the original incident).
+    let store = Arc::new(RedisOutboxStore::new(&url).await?);
+    let registry = ConnectionRegistry::new(store.clone());
+    let (_conn, mut rx, _close) = registry.register("dev-3".into(), 9).await?;
+
+    // No frames to replay (nothing was in the stream).
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), rx.recv())
+            .await
+            .is_err(),
+        "no replay expected"
+    );
+
+    // Next send should produce seq=10.
+    let envelope = ahand_protocol::Envelope {
+        device_id: "dev-3".into(),
+        ..Default::default()
+    };
+    registry.send_envelope("dev-3", envelope).await?;
+    let frame = rx.recv().await.expect("frame delivered");
+    let decoded = <ahand_protocol::Envelope as prost::Message>::decode(frame.as_slice())?;
+    assert_eq!(decoded.seq, 10);
+    Ok(())
+}
+
+#[tokio::test]
+async fn original_incident_regression() -> anyhow::Result<()> {
+    // This is the test that, had it existed, would have caught the original
+    // bug: hub restart wipes outbox state, device's last_ack is now > server's
+    // max issued seq, server rejects with InvalidPeerAck, daemon sees Broken
+    // pipe in a tight reconnect loop.
+    let (_redis, url) = redis_container().await?;
+
+    // Phase 1: device connects and receives some frames.
+    let store_a = Arc::new(RedisOutboxStore::new(&url).await?);
+    let registry_a = ConnectionRegistry::new(store_a.clone());
+    let (conn_a, mut rx_a, _close_a) = registry_a.register("dev-incident".into(), 0).await?;
+    for _ in 0..5 {
+        registry_a
+            .send_envelope(
+                "dev-incident",
+                ahand_protocol::Envelope {
+                    device_id: "dev-incident".into(),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        rx_a.recv().await.expect("frame delivered");
+    }
+    // Device acked all 5.
+    registry_a.observe_ack("dev-incident", 5).await?;
+    registry_a.unregister("dev-incident", conn_a).await?;
+
+    // Phase 2: simulate hub deploy — B is a fresh process holding a *different*
+    // OutboxStore arc, but pointing at the same Redis (durable layer survives).
+    let store_b = Arc::new(RedisOutboxStore::new(&url).await?);
+    let registry_b = ConnectionRegistry::new(store_b);
+
+    // Device reconnects with last_ack=5. With the fix, register succeeds; without
+    // the fix (in-memory state), this would be `InvalidPeerAck`.
+    let (_conn_b, _rx_b, _close_b) = registry_b
+        .register("dev-incident".into(), 5)
+        .await
+        .expect("device should reconnect cleanly post-restart");
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the regression suite**
+
+```bash
+cargo test -p ahand-hub --test outbox_persistence
+```
+
+Expected: all 4 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/ahand-hub/tests/outbox_persistence.rs
+git commit -m "$(cat <<'EOF'
+test(hub): end-to-end regression for outbox persistence
+
+Four scenarios: replay-after-restart, lock takeover via kick, bootstrap
+path for wedged devices, and the original incident regression
+(simulates hub deploy with the device's last_ack > 0). The last test
+is the keystone — had it existed before today's incident, the bug
+would not have shipped.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Final Verification
+
+After all tasks land:
+
+```bash
+cargo fmt --all
+cargo clippy --workspace -- -D warnings
+cargo test --workspace
+```
+
+Expected: clean fmt, zero clippy warnings, all tests green. The CI workflow at `.github/workflows/hub-ci.yml` (or equivalent) will gate the same.
+
+## Spec Coverage Map
+
+| Spec section | Implemented in |
+|---|---|
+| Background / Goals / Non-Goals | Reflected in commit messages and task framing |
+| High-Level Architecture | Tasks 0, 1, 3, 4, 5, 6 |
+| Module Boundaries | File Structure table above |
+| `OutboxStore` Trait | Task 0 |
+| Redis Schema | Task 4 (key construction in `RedisOutboxStore`) |
+| Lua Scripts (6) | Task 2 |
+| Connection Lifecycle / register | Task 5 (Step 2) |
+| Connection Lifecycle / send + Seq encoding | Task 5 (Step 3) |
+| Connection Lifecycle / observe_ack | Task 5 (Step 4) |
+| Connection Lifecycle / unregister | Task 5 (Step 5) |
+| Bootstrap Path | Task 1 (memory) + Task 2 (Lua) + Task 4 (Redis) + Task 7 (regression test) |
+| Failure Modes / Redis unreachable | Task 6 (`from_config` returns `?` on connect failure) — `register` itself returns `HubError::Internal` which the WS handler maps to a close frame; explicit close-frame text is left to the existing handler match |
+| Failure Modes / NOSCRIPT | `redis::Script` handles automatically (Task 2 note) |
+| Failure Modes / lease lost | Task 5 (Step 2 — lease task signals close_tx on `Ok(false)` or `Err`) |
+| Failure Modes / lock contention | Task 5 (Step 2 — `OutboxLockContention` after retries) |
+| Failure Modes / MAXLEN trim | Task 4 (Step 3 — `MAXLEN ~ 10000` in fenced_xadd) |
+| Failure Modes / crash between scripts | Task 4 — seq gap is harmless; covered by replay test in Task 7 |
+| Test Matrix | Tasks 1, 3, 4, 5, 7 |
+| Deployment / Rollout | No code changes — operational, executed manually after merge |
+| Backwards Compatibility | Preserved by design (no protocol changes); verified by existing in-source tests in Task 5 |

--- a/docs/superpowers/plans/2026-04-27-hub-outbox-persistence.md.tasks.json
+++ b/docs/superpowers/plans/2026-04-27-hub-outbox-persistence.md.tasks.json
@@ -11,51 +11,66 @@
       "id": 1,
       "subject": "Task 1: InMemoryOutboxStore implementation",
       "status": "pending",
-      "blockedBy": [0],
+      "blockedBy": [
+        0
+      ],
       "description": "**Goal:** Process-local OutboxStore impl for StoreConfig::Memory and unit tests; mirrors RedisOutboxStore semantics method-for-method including the bootstrap branch.\n\n**Files:**\n- Create: crates/ahand-hub/src/ws/in_memory_outbox.rs\n- Modify: crates/ahand-hub/src/ws/mod.rs\n\n**Verify:** `cargo test -p ahand-hub --lib ws::in_memory_outbox::tests`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub/src/ws/in_memory_outbox.rs\", \"crates/ahand-hub/src/ws/mod.rs\"], \"verifyCommand\": \"cargo test -p ahand-hub --lib ws::in_memory_outbox::tests\", \"acceptanceCriteria\": [\"all 10 trait methods implemented\", \"lock acquisition is atomic\", \"bootstrap path returns last_ack\", \"fence rejects writes from non-owning session\", \"kick subscription delivers tick\", \"unit tests cover lock/kick/fence/bootstrap/replay/ack-trim\"]}\n```"
     },
     {
       "id": 2,
       "subject": "Task 2: Lua scripts module + EVALSHA wrapper",
       "status": "pending",
-      "blockedBy": [0],
-      "description": "**Goal:** Centralize the six Lua script source strings and wrap them in redis::Script handles for transparent EVALSHA→NOSCRIPT→EVAL fallback.\n\n**Files:**\n- Create: crates/ahand-hub-store/src/outbox_lua.rs\n- Modify: crates/ahand-hub-store/src/lib.rs\n\n**Verify:** `cargo check -p ahand-hub-store`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub-store/src/outbox_lua.rs\", \"crates/ahand-hub-store/src/lib.rs\"], \"verifyCommand\": \"cargo check -p ahand-hub-store\", \"acceptanceCriteria\": [\"six script constants defined\", \"OutboxScripts::load returns pre-built redis::Script handles\", \"compiles clean\"]}\n```"
+      "blockedBy": [
+        0
+      ],
+      "description": "**Goal:** Centralize the six Lua script source strings and wrap them in redis::Script handles for transparent EVALSHA\u2192NOSCRIPT\u2192EVAL fallback.\n\n**Files:**\n- Create: crates/ahand-hub-store/src/outbox_lua.rs\n- Modify: crates/ahand-hub-store/src/lib.rs\n\n**Verify:** `cargo check -p ahand-hub-store`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub-store/src/outbox_lua.rs\", \"crates/ahand-hub-store/src/lib.rs\"], \"verifyCommand\": \"cargo check -p ahand-hub-store\", \"acceptanceCriteria\": [\"six script constants defined\", \"OutboxScripts::load returns pre-built redis::Script handles\", \"compiles clean\"]}\n```"
     },
     {
       "id": 3,
       "subject": "Task 3: RedisOutboxStore lock primitives",
       "status": "pending",
-      "blockedBy": [2],
+      "blockedBy": [
+        2
+      ],
       "description": "**Goal:** Stand up RedisOutboxStore with the five lock-related methods (acquire, kick, subscribe, renew, release). Send/reconcile/replay/ack remain stubbed for Task 4.\n\n**Files:**\n- Create: crates/ahand-hub-store/src/outbox_store.rs\n- Modify: crates/ahand-hub-store/src/lib.rs\n- Modify: crates/ahand-hub-store/tests/support/mod.rs\n- Modify: crates/ahand-hub-store/tests/store_roundtrip.rs\n\n**Verify:** `cargo test -p ahand-hub-store --features test-support --test store_roundtrip outbox_lock outbox_kick`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub-store/src/outbox_store.rs\", \"crates/ahand-hub-store/src/lib.rs\", \"crates/ahand-hub-store/tests/support/mod.rs\", \"crates/ahand-hub-store/tests/store_roundtrip.rs\"], \"verifyCommand\": \"cargo test -p ahand-hub-store --features test-support --test store_roundtrip outbox_lock outbox_kick\", \"acceptanceCriteria\": [\"new(redis_url) connects + caches scripts\", \"try_acquire_lock NX exclusive\", \"kick publishes\", \"subscribe_kick ticks watch on PUBLISH\", \"renew/release Lua-checked by session_id\", \"integration tests pass\"]}\n```"
     },
     {
       "id": 4,
       "subject": "Task 4: RedisOutboxStore send/reconcile/replay/observe_ack",
       "status": "pending",
-      "blockedBy": [3],
+      "blockedBy": [
+        3
+      ],
       "description": "**Goal:** Fill in the five remaining methods. fenced_incr_seq + xadd_frame implement the two-step send. reconcile_on_hello includes the bootstrap branch that auto-recovers wedged devices.\n\n**Files:**\n- Modify: crates/ahand-hub-store/src/outbox_store.rs\n- Modify: crates/ahand-hub-store/tests/store_roundtrip.rs\n\n**Verify:** `cargo test -p ahand-hub-store --features test-support --test store_roundtrip outbox_`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub-store/src/outbox_store.rs\", \"crates/ahand-hub-store/tests/store_roundtrip.rs\"], \"verifyCommand\": \"cargo test -p ahand-hub-store --features test-support --test store_roundtrip outbox_\", \"acceptanceCriteria\": [\"NOT_OWNER maps to HubError::Unauthorized\", \"fenced_incr_seq increments + fences\", \"xadd_frame writes at 0-{seq}\", \"unacked_frames XRANGE-based replay\", \"observe_ack XTRIM MINID-based\", \"reconcile bootstrap path seeds + clears\", \"integration tests pass\"]}\n```"
     },
     {
       "id": 5,
       "subject": "Task 5: Refactor ConnectionRegistry to use OutboxStore",
-      "status": "pending",
-      "blockedBy": [1, 4],
+      "status": "completed",
+      "blockedBy": [
+        1,
+        4
+      ],
       "description": "**Goal:** Cut the in-memory Outbox out of ConnectionRegistry. Wire Arc<dyn OutboxStore>, add session_id fencing, lease renewer task, kick subscriber task.\n\n**Files:**\n- Modify: crates/ahand-hub/src/ws/device_gateway.rs\n\n**Verify:** `cargo test -p ahand-hub --lib ws::device_gateway::tests && cargo test -p ahand-hub`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub/src/ws/device_gateway.rs\"], \"verifyCommand\": \"cargo test -p ahand-hub --lib ws::device_gateway::tests && cargo test -p ahand-hub\", \"acceptanceCriteria\": [\"ConnectionRegistry::new(Arc<dyn OutboxStore>) is the only constructor\", \"ConnectionEntry holds session_id not Outbox\", \"register is async with kick-then-retry, returns OutboxLockContention on failure\", \"register replays unacked frames\", \"lease renewer + kick subscriber tasks per connection\", \"send fully fenced (fenced_incr_seq + xadd_frame)\", \"observe_ack delegates to store\", \"unregister releases lock and aborts background tasks\"]}\n```"
     },
     {
       "id": 6,
       "subject": "Task 6: Wire OutboxStore into AppState",
-      "status": "pending",
-      "blockedBy": [5],
+      "status": "completed",
+      "blockedBy": [
+        5
+      ],
       "description": "**Goal:** Construct an Arc<dyn OutboxStore> based on StoreConfig and pass it to ConnectionRegistry::new.\n\n**Files:**\n- Modify: crates/ahand-hub/src/state.rs\n\n**Verify:** `cargo check -p ahand-hub && cargo test -p ahand-hub`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub/src/state.rs\"], \"verifyCommand\": \"cargo check -p ahand-hub && cargo test -p ahand-hub\", \"acceptanceCriteria\": [\"Memory config builds InMemoryOutboxStore\", \"Persistent config builds RedisOutboxStore via REDIS_URL\", \"ConnectionRegistry::new(outbox) is the only constructor invocation\", \"no remaining ConnectionRegistry::default() call sites\"]}\n```"
     },
     {
       "id": 7,
       "subject": "Task 7: End-to-end regression tests",
-      "status": "pending",
-      "blockedBy": [6],
+      "status": "completed",
+      "blockedBy": [
+        6
+      ],
       "description": "**Goal:** Codify the original incident as a regression test plus replay-after-restart, lock takeover, and bootstrap-path scenarios.\n\n**Files:**\n- Create: crates/ahand-hub/tests/outbox_persistence.rs\n\n**Verify:** `cargo test -p ahand-hub --test outbox_persistence`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub/tests/outbox_persistence.rs\"], \"verifyCommand\": \"cargo test -p ahand-hub --test outbox_persistence\", \"acceptanceCriteria\": [\"replay_after_simulated_hub_restart passes\", \"lock_takeover_via_kick passes within 5s\", \"bootstrap_path_unblocks_wedged_device passes\", \"original_incident_regression passes (the keystone test)\"]}\n```"
     }
   ],
-  "lastUpdated": "2026-04-27"
+  "lastUpdated": "2026-04-27T23:18:46.348750"
 }

--- a/docs/superpowers/plans/2026-04-27-hub-outbox-persistence.md.tasks.json
+++ b/docs/superpowers/plans/2026-04-27-hub-outbox-persistence.md.tasks.json
@@ -1,0 +1,61 @@
+{
+  "planPath": "docs/superpowers/plans/2026-04-27-hub-outbox-persistence.md",
+  "tasks": [
+    {
+      "id": 0,
+      "subject": "Task 0: OutboxStore trait + KickSubscription + OutboxLockContention",
+      "status": "pending",
+      "description": "**Goal:** Add the OutboxStore trait, KickSubscription type, and HubError::OutboxLockContention variant. No implementations yet.\n\n**Files:**\n- Modify: crates/ahand-hub-core/src/traits.rs\n- Modify: crates/ahand-hub-core/src/error.rs\n- Modify: crates/ahand-hub-core/Cargo.toml\n\n**Verify:** `cargo check -p ahand-hub-core && cargo test -p ahand-hub-core`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub-core/src/traits.rs\", \"crates/ahand-hub-core/src/error.rs\", \"crates/ahand-hub-core/Cargo.toml\"], \"verifyCommand\": \"cargo check -p ahand-hub-core && cargo test -p ahand-hub-core\", \"acceptanceCriteria\": [\"OutboxStore trait compiles with #[async_trait] and is Send+Sync+'static\", \"KickSubscription is documented and droppable\", \"HubError::OutboxLockContention exists\", \"existing tests still green\"]}\n```"
+    },
+    {
+      "id": 1,
+      "subject": "Task 1: InMemoryOutboxStore implementation",
+      "status": "pending",
+      "blockedBy": [0],
+      "description": "**Goal:** Process-local OutboxStore impl for StoreConfig::Memory and unit tests; mirrors RedisOutboxStore semantics method-for-method including the bootstrap branch.\n\n**Files:**\n- Create: crates/ahand-hub/src/ws/in_memory_outbox.rs\n- Modify: crates/ahand-hub/src/ws/mod.rs\n\n**Verify:** `cargo test -p ahand-hub --lib ws::in_memory_outbox::tests`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub/src/ws/in_memory_outbox.rs\", \"crates/ahand-hub/src/ws/mod.rs\"], \"verifyCommand\": \"cargo test -p ahand-hub --lib ws::in_memory_outbox::tests\", \"acceptanceCriteria\": [\"all 10 trait methods implemented\", \"lock acquisition is atomic\", \"bootstrap path returns last_ack\", \"fence rejects writes from non-owning session\", \"kick subscription delivers tick\", \"unit tests cover lock/kick/fence/bootstrap/replay/ack-trim\"]}\n```"
+    },
+    {
+      "id": 2,
+      "subject": "Task 2: Lua scripts module + EVALSHA wrapper",
+      "status": "pending",
+      "blockedBy": [0],
+      "description": "**Goal:** Centralize the six Lua script source strings and wrap them in redis::Script handles for transparent EVALSHA→NOSCRIPT→EVAL fallback.\n\n**Files:**\n- Create: crates/ahand-hub-store/src/outbox_lua.rs\n- Modify: crates/ahand-hub-store/src/lib.rs\n\n**Verify:** `cargo check -p ahand-hub-store`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub-store/src/outbox_lua.rs\", \"crates/ahand-hub-store/src/lib.rs\"], \"verifyCommand\": \"cargo check -p ahand-hub-store\", \"acceptanceCriteria\": [\"six script constants defined\", \"OutboxScripts::load returns pre-built redis::Script handles\", \"compiles clean\"]}\n```"
+    },
+    {
+      "id": 3,
+      "subject": "Task 3: RedisOutboxStore lock primitives",
+      "status": "pending",
+      "blockedBy": [2],
+      "description": "**Goal:** Stand up RedisOutboxStore with the five lock-related methods (acquire, kick, subscribe, renew, release). Send/reconcile/replay/ack remain stubbed for Task 4.\n\n**Files:**\n- Create: crates/ahand-hub-store/src/outbox_store.rs\n- Modify: crates/ahand-hub-store/src/lib.rs\n- Modify: crates/ahand-hub-store/tests/support/mod.rs\n- Modify: crates/ahand-hub-store/tests/store_roundtrip.rs\n\n**Verify:** `cargo test -p ahand-hub-store --features test-support --test store_roundtrip outbox_lock outbox_kick`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub-store/src/outbox_store.rs\", \"crates/ahand-hub-store/src/lib.rs\", \"crates/ahand-hub-store/tests/support/mod.rs\", \"crates/ahand-hub-store/tests/store_roundtrip.rs\"], \"verifyCommand\": \"cargo test -p ahand-hub-store --features test-support --test store_roundtrip outbox_lock outbox_kick\", \"acceptanceCriteria\": [\"new(redis_url) connects + caches scripts\", \"try_acquire_lock NX exclusive\", \"kick publishes\", \"subscribe_kick ticks watch on PUBLISH\", \"renew/release Lua-checked by session_id\", \"integration tests pass\"]}\n```"
+    },
+    {
+      "id": 4,
+      "subject": "Task 4: RedisOutboxStore send/reconcile/replay/observe_ack",
+      "status": "pending",
+      "blockedBy": [3],
+      "description": "**Goal:** Fill in the five remaining methods. fenced_incr_seq + xadd_frame implement the two-step send. reconcile_on_hello includes the bootstrap branch that auto-recovers wedged devices.\n\n**Files:**\n- Modify: crates/ahand-hub-store/src/outbox_store.rs\n- Modify: crates/ahand-hub-store/tests/store_roundtrip.rs\n\n**Verify:** `cargo test -p ahand-hub-store --features test-support --test store_roundtrip outbox_`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub-store/src/outbox_store.rs\", \"crates/ahand-hub-store/tests/store_roundtrip.rs\"], \"verifyCommand\": \"cargo test -p ahand-hub-store --features test-support --test store_roundtrip outbox_\", \"acceptanceCriteria\": [\"NOT_OWNER maps to HubError::Unauthorized\", \"fenced_incr_seq increments + fences\", \"xadd_frame writes at 0-{seq}\", \"unacked_frames XRANGE-based replay\", \"observe_ack XTRIM MINID-based\", \"reconcile bootstrap path seeds + clears\", \"integration tests pass\"]}\n```"
+    },
+    {
+      "id": 5,
+      "subject": "Task 5: Refactor ConnectionRegistry to use OutboxStore",
+      "status": "pending",
+      "blockedBy": [1, 4],
+      "description": "**Goal:** Cut the in-memory Outbox out of ConnectionRegistry. Wire Arc<dyn OutboxStore>, add session_id fencing, lease renewer task, kick subscriber task.\n\n**Files:**\n- Modify: crates/ahand-hub/src/ws/device_gateway.rs\n\n**Verify:** `cargo test -p ahand-hub --lib ws::device_gateway::tests && cargo test -p ahand-hub`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub/src/ws/device_gateway.rs\"], \"verifyCommand\": \"cargo test -p ahand-hub --lib ws::device_gateway::tests && cargo test -p ahand-hub\", \"acceptanceCriteria\": [\"ConnectionRegistry::new(Arc<dyn OutboxStore>) is the only constructor\", \"ConnectionEntry holds session_id not Outbox\", \"register is async with kick-then-retry, returns OutboxLockContention on failure\", \"register replays unacked frames\", \"lease renewer + kick subscriber tasks per connection\", \"send fully fenced (fenced_incr_seq + xadd_frame)\", \"observe_ack delegates to store\", \"unregister releases lock and aborts background tasks\"]}\n```"
+    },
+    {
+      "id": 6,
+      "subject": "Task 6: Wire OutboxStore into AppState",
+      "status": "pending",
+      "blockedBy": [5],
+      "description": "**Goal:** Construct an Arc<dyn OutboxStore> based on StoreConfig and pass it to ConnectionRegistry::new.\n\n**Files:**\n- Modify: crates/ahand-hub/src/state.rs\n\n**Verify:** `cargo check -p ahand-hub && cargo test -p ahand-hub`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub/src/state.rs\"], \"verifyCommand\": \"cargo check -p ahand-hub && cargo test -p ahand-hub\", \"acceptanceCriteria\": [\"Memory config builds InMemoryOutboxStore\", \"Persistent config builds RedisOutboxStore via REDIS_URL\", \"ConnectionRegistry::new(outbox) is the only constructor invocation\", \"no remaining ConnectionRegistry::default() call sites\"]}\n```"
+    },
+    {
+      "id": 7,
+      "subject": "Task 7: End-to-end regression tests",
+      "status": "pending",
+      "blockedBy": [6],
+      "description": "**Goal:** Codify the original incident as a regression test plus replay-after-restart, lock takeover, and bootstrap-path scenarios.\n\n**Files:**\n- Create: crates/ahand-hub/tests/outbox_persistence.rs\n\n**Verify:** `cargo test -p ahand-hub --test outbox_persistence`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub/tests/outbox_persistence.rs\"], \"verifyCommand\": \"cargo test -p ahand-hub --test outbox_persistence\", \"acceptanceCriteria\": [\"replay_after_simulated_hub_restart passes\", \"lock_takeover_via_kick passes within 5s\", \"bootstrap_path_unblocks_wedged_device passes\", \"original_incident_regression passes (the keystone test)\"]}\n```"
+    }
+  ],
+  "lastUpdated": "2026-04-27"
+}

--- a/docs/superpowers/specs/2026-04-27-hub-outbox-persistence-design.md
+++ b/docs/superpowers/specs/2026-04-27-hub-outbox-persistence-design.md
@@ -71,7 +71,7 @@ It no longer holds the outbox state. All outbox reads/writes go through `OutboxS
 ```
 ahand-hub-core
   ├─ traits.rs
-  │    + pub trait OutboxStore { ... 6 methods ... }
+  │    + pub trait OutboxStore { ... 10 methods ... }
   └─ outbox.rs
        (existing in-memory Outbox kept; used by daemon and tests)
 
@@ -122,18 +122,20 @@ pub trait OutboxStore: Send + Sync {
     /// Read all unacked frames for replay (XRANGE outbox:{id} (0-{last_ack} +).
     async fn unacked_frames(&self, device_id: &str, last_ack: u64) -> Result<Vec<Vec<u8>>>;
 
-    /// Fenced send. Internally two round-trips:
-    ///   1) `fenced_incr_seq` — fence + INCR seq, returns assigned seq.
-    ///   2) Caller mutates `envelope.seq` and re-encodes.
-    ///   3) `fenced_xadd` — fence + XADD frame to stream.
-    /// Implementation owns the round-trip orchestration; callers see one logical op.
-    /// Returns the assigned seq, or `NotOwner` error.
-    async fn send(
+    /// Reserve the next seq atomically: fence + INCR. Returns the assigned
+    /// seq. Caller is then expected to stamp `envelope.seq = assigned`,
+    /// encode, and call [`Self::xadd_frame`].
+    async fn fenced_incr_seq(&self, device_id: &str, session_id: &str) -> Result<u64>;
+
+    /// Append the encoded frame to the device's stream at ID `0-{seq}`,
+    /// applying `MAXLEN ~ 10000` and `EXPIRE 30d`. Fenced.
+    async fn xadd_frame(
         &self,
         device_id: &str,
         session_id: &str,
-        envelope: &mut ahand_protocol::Envelope,
-    ) -> Result<u64>;
+        seq: u64,
+        frame: Vec<u8>,
+    ) -> Result<()>;
 
     /// Trim acked frames: XTRIM outbox:{id} MINID 0-{ack+1}. Fire-and-forget allowed.
     async fn observe_ack(&self, device_id: &str, ack: u64) -> Result<()>;
@@ -271,15 +273,18 @@ The renew operation reuses a small Lua script (`if GET == session_id then EXPIRE
 
 ### `send` (hub→device, e.g., from job dispatch)
 
-1. Caller invokes `OutboxStore::send(device_id, session_id, &mut envelope)`.
-2. The store does two Redis round-trips internally:
-   - `fenced_incr_seq` → returns the assigned seq.
-   - Mutate `envelope.seq = assigned`, encode to bytes.
-   - `fenced_xadd` → writes the frame into the stream with explicit ID `0-{seq}`.
-3. On `NOT_OWNER` from either script: this replica has been kicked or its lock expired. Mark the connection dead, signal close to the WS IO task, log error. Caller (job dispatch) sees `DeviceOffline`.
-4. On success: caller pushes the encoded frame into the connection's mpsc to be sent over the WS.
+The trait exposes two primitives — `fenced_incr_seq` and `xadd_frame` — and the gateway (`ConnectionRegistry::send`) orchestrates them:
 
-**Seq assignment + encoding ordering.** The seq is part of the protobuf-encoded `Envelope` bytes, so the bytes must carry the correct seq before they're durable in Redis. Lua cannot patch protobuf, which is why the `send` flow round-trips through Rust between `fenced_incr_seq` and `fenced_xadd`.
+1. `OutboxStore::fenced_incr_seq(device_id, session_id)` → returns the assigned seq.
+2. Mutate `envelope.seq = assigned`, encode to bytes.
+3. `OutboxStore::xadd_frame(device_id, session_id, seq, frame)` → writes the frame into the stream with explicit ID `0-{seq}`.
+4. Push the encoded frame into the connection's mpsc to be sent over the WS.
+
+On `NOT_OWNER` from either script: this replica has been kicked or its lock expired. Mark the connection dead, signal close to the WS IO task, log error. Caller (job dispatch) sees `DeviceOffline`.
+
+The orchestration lives in the gateway rather than inside the store because the bytes-must-carry-the-correct-seq invariant requires going through `ahand-protocol::Envelope` encoding — and `ahand-hub-core` (where the trait lives) does not and should not depend on `ahand-protocol`.
+
+**Seq assignment + encoding ordering.** The seq is part of the protobuf-encoded `Envelope` bytes, so the bytes must carry the correct seq before they're durable in Redis. Lua cannot patch protobuf, which is why the send flow round-trips through Rust between `fenced_incr_seq` and `xadd_frame`.
 
 Crash between the two round-trips leaves a seq gap (no entry in stream for that seq). This is harmless: the WS message was never actually sent either, and the protocol tolerates seq gaps — devices ack the highest seq they received, not "I received contiguous N seqs".
 


### PR DESCRIPTION
## Summary

- Make hub→device messages durable across hub restarts via Redis Streams (D2 write-through).
- Multi-replica safe via Redis-side fenced lock with lease + Pub/Sub kick (R3).
- Bootstrap branch in `reconcile_on_hello` auto-recovers wedged devices on first reconnect — no manual unwedge needed for the dev incident.

## The bug this fixes

`ahand-hub-dev` deployed at 2026-04-27 01:27 wiped its in-memory `ConnectionRegistry::Outbox`. Devices that had already received seqs (e.g. `last_ack=9`) reconnected, the server saw `9 > max_issued_seq=0` and rejected with `InvalidPeerAck`, which surfaced on the daemon as `IO error: Broken pipe (os error 32)`. CloudWatch logs at `/ecs/ahand-hub` show the same line firing every few seconds (`device socket ended with error error=invalid peer ack 9, max issued seq is 0`). Structural — production has the same bug; just hasn't deployed recently.

## Architecture

- **`ahand-hub-core`**: new `OutboxStore` trait + `KickSubscription` + `AbortOnDropHandle` + `HubError::OutboxLockContention`.
- **`ahand-hub-store`**: 6 Lua scripts (`acquire_lock`, `renew_lock`, `release_lock`, `reconcile_on_hello`, `fenced_incr_seq`, `fenced_xadd`); `RedisOutboxStore` impl using `redis::Script` (transparent EVALSHA→NOSCRIPT→EVAL).
- **`ahand-hub`**: `InMemoryOutboxStore` for `StoreConfig::Memory` and tests; `ConnectionRegistry` refactored to delegate all outbox state through the trait. Per-connection `session_id` is the fencing token; lease renewer + kick subscriber tasks per connection.

Spec: `docs/superpowers/specs/2026-04-27-hub-outbox-persistence-design.md`
Plan: `docs/superpowers/plans/2026-04-27-hub-outbox-persistence.md` (7 tasks, full TDD code in every step)

## Bootstrap path (the keystone)

`reconcile_on_hello` Lua script:

\`\`\`lua
if last_ack > current_seq then
  redis.call('SET', KEYS[2], last_ack)   -- seed seq counter
  redis.call('DEL', KEYS[3])             -- clear any stale stream entries
  return last_ack
end
\`\`\`

This means the very first hub deploy carrying this code unblocks every currently-wedged device on first reconnect. No manual intervention needed.

## Tests

**Unit (run on every CI run):**
- 13 `InMemoryOutboxStore` tests (lock NX, kick handoff, fence rejection, bootstrap, replay, ack-trim, MAXLEN cap)
- 5 in-source `ConnectionRegistry` tests (replay-after-disconnect, lock contention, has_seen_inbound counter, etc.)
- 76/77 lib tests pass locally; 1 failure is a pre-existing Docker-dependent `output_stream` test unrelated to this branch.

**Integration (Docker required — CI runs them):**
- `store_roundtrip.rs`: 4 lock-flow + 5 data-path tests against testcontainer Redis.
- `outbox_persistence.rs` (new file): 4 end-to-end scenarios:
  - `replay_after_simulated_hub_restart` — drop hub instance A, instance B reads remaining frames.
  - `lock_takeover_via_kick` — replica A holds lock, replica B kicks → handoff in <1s.
  - `bootstrap_path_unblocks_wedged_device` — fresh Redis + Hello with `last_ack=9` → register succeeds, next seq=10.
  - **`original_incident_regression`** — keystone test that, had it existed pre-incident, would have caught yesterday's bug. Phase 1 sends 5 frames + acks all, drops registry; Phase 2 fresh registry against same Redis, device reconnects with `last_ack=5`, register succeeds (no `InvalidPeerAck`).

## Code review feedback already addressed

- `AbortOnDropHandle` newtype so `KickSubscription` drop semantics are enforced by the trait surface, not each impl.
- `subscribe_kick` awaits SUBSCRIBE before returning (was a race; the 100ms test sleep was masking it).
- `unacked_frames` failure during `register` now releases the lock and propagates instead of silently returning empty replay.
- `OutboxLockContention` now sends a structured `close_code::AGAIN` close frame so the daemon can apply longer back-off than a generic disconnect.

## Test plan

- [ ] CI green on `feat/hub-outbox-persistence`
- [ ] Merge to `dev`, deploy via `deploy-hub.yml`
- [ ] Verify `/ecs/ahand-hub` CloudWatch `invalid peer ack` warnings drop to zero within minutes of deploy
- [ ] Soak ≥24h on dev, monitor Sentry
- [ ] PR `dev` → `main` for prod rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)