### PR TITLE
fix(ahand-hub): unblock prod deploy + observability for silent startup hangs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,6 +1950,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4128,17 +4137,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ jsonwebtoken = "9"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 anyhow = "1"
 thiserror = "2"
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/ahand-hub/src/main.rs
+++ b/crates/ahand-hub/src/main.rs
@@ -1,12 +1,22 @@
 use ahand_hub::{build_app, config::Config, state::AppState};
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    init_tracing();
+
+    tracing::info!(
+        git_sha = std::env::var("GIT_SHA").as_deref().unwrap_or("unknown"),
+        "ahand-hub starting"
+    );
 
     let config = Config::from_env()?;
     let bind_addr = config.bind_addr.clone();
+
+    tracing::info!(bind_addr = %bind_addr, "config loaded; connecting to backing services");
     let state = AppState::from_config(config).await?;
+
+    tracing::info!("backing services connected; binding listener");
     let app = build_app(state.clone());
     let listener = tokio::net::TcpListener::bind(&bind_addr).await?;
 
@@ -16,6 +26,19 @@ async fn main() -> anyhow::Result<()> {
         .await?;
     state.shutdown().await?;
     Ok(())
+}
+
+fn init_tracing() {
+    let level = std::env::var("AHAND_HUB_LOG_LEVEL").unwrap_or_else(|_| "info".into());
+    let filter = EnvFilter::try_new(&level).unwrap_or_else(|_| EnvFilter::new("info"));
+    let format = std::env::var("AHAND_HUB_LOG_FORMAT").unwrap_or_default();
+
+    let builder = tracing_subscriber::fmt().with_env_filter(filter);
+    if format.eq_ignore_ascii_case("json") {
+        builder.json().init();
+    } else {
+        builder.init();
+    }
 }
 
 async fn shutdown_signal() {

--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -5,20 +5,21 @@ data "aws_lb" "traefik" {
 module "ahand_hub" {
   source = "../../modules/ahand-hub"
 
-  env                        = "dev"
-  ecs_cluster_name           = "openclaw-hive-dev"
-  api_domain                 = "ahand-hub.dev.team9.ai"
-  openclaw_rds_host          = var.openclaw_rds_host
-  vpc_id                     = var.vpc_id
-  subnet_ids                 = var.subnet_ids
-  traefik_security_group_id  = var.traefik_security_group_id
+  env                            = "dev"
+  ecs_cluster_name               = "openclaw-hive-dev"
+  api_domain                     = "ahand-hub.dev.team9.ai"
+  openclaw_rds_host              = var.openclaw_rds_host
+  openclaw_rds_security_group_id = var.openclaw_rds_security_group_id
+  vpc_id                         = var.vpc_id
+  subnet_ids                     = var.subnet_ids
+  traefik_security_group_id      = var.traefik_security_group_id
   # Note: team9 gateway is at api.dev.team9.ai (not gateway.dev.*). Path
   # is /api/v1/ahand/hub-webhook because the gateway has URI versioning
   # with defaultVersion='1'. The ssm.tf module concats ${gateway_public_url}
   # with the webhook path; set this to the BASE (no path), which the
   # module already expects.
-  gateway_public_url         = "https://api.dev.team9.ai"
-  redis_mode                 = "create"
+  gateway_public_url = "https://api.dev.team9.ai"
+  redis_mode         = "create"
 }
 
 output "execution_role_arn" {

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -22,3 +22,8 @@ variable "openclaw_rds_host" {
   type    = string
   default = "openclaw-hive-dev.chq8i2se49qd.us-east-1.rds.amazonaws.com"
 }
+
+variable "openclaw_rds_security_group_id" {
+  type    = string
+  default = "sg-03be90e5bf963ddc3"
+}

--- a/infra/envs/prod/main.tf
+++ b/infra/envs/prod/main.tf
@@ -10,15 +10,16 @@ data "aws_lb" "traefik" {
 module "ahand_hub" {
   source = "../../modules/ahand-hub"
 
-  env                        = "prod"
-  ecs_cluster_name           = "openclaw-hive"
-  api_domain                 = "ahand-hub.team9.ai"
-  openclaw_rds_host          = var.openclaw_rds_host
-  vpc_id                     = var.vpc_id
-  subnet_ids                 = var.subnet_ids
-  traefik_security_group_id  = var.traefik_security_group_id
-  gateway_public_url         = "https://gateway.team9.ai"
-  redis_mode                 = "create"
+  env                            = "prod"
+  ecs_cluster_name               = "openclaw-hive"
+  api_domain                     = "ahand-hub.team9.ai"
+  openclaw_rds_host              = var.openclaw_rds_host
+  openclaw_rds_security_group_id = var.openclaw_rds_security_group_id
+  vpc_id                         = var.vpc_id
+  subnet_ids                     = var.subnet_ids
+  traefik_security_group_id      = var.traefik_security_group_id
+  gateway_public_url             = "https://gateway.team9.ai"
+  redis_mode                     = "create"
 }
 
 output "execution_role_arn" {

--- a/infra/envs/prod/variables.tf
+++ b/infra/envs/prod/variables.tf
@@ -22,3 +22,8 @@ variable "openclaw_rds_host" {
   type    = string
   default = "openclaw-hive-prod.chq8i2se49qd.us-east-1.rds.amazonaws.com"
 }
+
+variable "openclaw_rds_security_group_id" {
+  type    = string
+  default = "sg-0263c046dbc5b2be6"
+}

--- a/infra/modules/ahand-hub/ecs.tf
+++ b/infra/modules/ahand-hub/ecs.tf
@@ -56,6 +56,19 @@ resource "aws_security_group_rule" "redis_ingress_from_task" {
   description              = "ahand-hub-${var.env} ECS task"
 }
 
+# Attach the task SG to the openclaw-hive RDS SG ingress on 5432. The RDS
+# SG is owned by the openclaw-hive stack so we only authorize an extra
+# source group here; we do not manage the SG itself.
+resource "aws_security_group_rule" "rds_ingress_from_task" {
+  type                     = "ingress"
+  from_port                = var.openclaw_rds_port
+  to_port                  = var.openclaw_rds_port
+  protocol                 = "tcp"
+  security_group_id        = var.openclaw_rds_security_group_id
+  source_security_group_id = aws_security_group.task.id
+  description              = "ahand-hub-${var.env} ECS task to RDS ${var.openclaw_rds_port}"
+}
+
 resource "aws_ecs_task_definition" "stub" {
   family                   = "ahand-hub-${var.env}"
   cpu                      = var.env == "prod" ? "512" : "256"
@@ -99,8 +112,8 @@ resource "aws_ecs_service" "ahand_hub" {
   launch_type     = "FARGATE"
 
   network_configuration {
-    subnets          = var.subnet_ids
-    security_groups  = [aws_security_group.task.id]
+    subnets         = var.subnet_ids
+    security_groups = [aws_security_group.task.id]
     # VPC has only public subnets → Fargate tasks need public IPs to reach
     # ECR / SSM / CloudWatch via the IGW. Traefik still targets the private
     # IP via Docker labels; the public IP is outbound-only in practice.

--- a/infra/modules/ahand-hub/variables.tf
+++ b/infra/modules/ahand-hub/variables.tf
@@ -40,6 +40,11 @@ variable "openclaw_rds_port" {
   default     = 5432
 }
 
+variable "openclaw_rds_security_group_id" {
+  description = "Security group attached to the openclaw-hive RDS instance. Required so the ahand-hub ECS task SG can be authorized inbound on port 5432."
+  type        = string
+}
+
 variable "vpc_id" {
   description = "VPC that hosts ECS tasks, RDS, and Redis"
   type        = string

--- a/infra/shared/main.tf
+++ b/infra/shared/main.tf
@@ -85,9 +85,9 @@ resource "aws_iam_role_policy" "github_actions_deploy" {
         Resource = "*"
       },
       {
-        Sid      = "PassAhandHubRoles"
-        Effect   = "Allow"
-        Action   = ["iam:PassRole"]
+        Sid    = "PassAhandHubRoles"
+        Effect = "Allow"
+        Action = ["iam:PassRole"]
         Resource = [
           "arn:aws:iam::${var.aws_account_id}:role/ahand-hub-prod-execution",
           "arn:aws:iam::${var.aws_account_id}:role/ahand-hub-dev-execution",


### PR DESCRIPTION
## Summary

Follow-ups from the first prod deploy of ahand-hub (PR #14 → main, 2026-04-27/28). The deploy initially failed because the prod RDS SG was missing an inbound rule for the ECS task SG; the binary then silently hung on the DB connection with zero logs, which made root-causing slow. This PR captures both fixes.

### 1. Capture RDS SG ingress in Terraform (`infra/`)

The dev RDS SG had `ahand-hub-dev-task-sg` allowed inbound on 5432; the prod RDS SG did not. Both rules were/are absent from Terraform — dev was added by hand outside IaC, and prod was just added by hand to unblock the prod rollout (rule id `sgr-075c534c3a5b4d996`).

This PR mirrors the existing `redis_ingress_from_task` pattern: a new `openclaw_rds_security_group_id` module variable + an `aws_security_group_rule "rds_ingress_from_task"` resource, wired from both env stacks with the actual SG ids as variable defaults.

⚠️ **Apply gotcha**: `aws_security_group_rule` does not have an "ensure exists" mode. The next `terraform apply` will collide with the manual rules already present in AWS for both dev and prod. To apply cleanly, the operator needs to either:
- `terraform import module.ahand_hub.aws_security_group_rule.rds_ingress_from_task <rule_id>` for each env, or
- `aws ec2 revoke-security-group-ingress` the manual rules first and let Terraform recreate them (brief outage on next DB connect attempt — fine for dev, schedule for prod).

### 2. Make startup hangs visible (`crates/ahand-hub/src/main.rs`)

The previous main.rs only emitted its first log line *after* DB + Redis + bind succeeded, so a hang on `AppState::from_config` produced zero CloudWatch events — exactly what we saw on the first prod rollout. This PR:

- Adds `tracing::info!` at each boot phase (starting / config loaded / backing services connected / listening), with GIT_SHA in the boot log for image-version tracing.
- Honors the `AHAND_HUB_LOG_FORMAT` (json|text) and `AHAND_HUB_LOG_LEVEL` env vars that were already set in the prod task definition but silently ignored. Adds `env-filter` + `json` features to the workspace `tracing-subscriber`.

Default behavior with neither env var set is unchanged (text, info).

## Test plan
- [x] `cargo check --workspace` clean
- [x] `cargo test -p ahand-hub --test job_flow` (11/11 pass)
- [x] `terraform fmt -check -recursive infra/` clean
- [ ] Reviewer: confirm the apply-gotcha plan above before merging if a `terraform apply` is imminent
- [ ] Post-merge: deploy to dev fires automatically; verify dev hub still healthy + emits json logs at info if env vars stay as configured