### PR TITLE
infra(ahand-hub): make webhook_url operator-owned via ignore_changes

### DIFF
--- a/infra/modules/ahand-hub/ssm.tf
+++ b/infra/modules/ahand-hub/ssm.tf
@@ -91,11 +91,17 @@ resource "aws_ssm_parameter" "device_bootstrap_device_id" {
 resource "aws_ssm_parameter" "webhook_url" {
   name = "/ahand-hub/${var.env}/WEBHOOK_URL"
   type = "String"
-  # Gateway uses NestJS URI versioning (defaultVersion='1') so the
-  # controller path resolves under /api/v1/ahand/hub-webhook, not
-  # /api/ahand/...
+  # Default value derives from gateway_public_url with the NestJS URI-version
+  # path the gateway exposes (defaultVersion='1' → /api/v1/ahand/hub-webhook).
+  # ignore_changes lets the operator pin a different value via put-parameter
+  # without Terraform reverting it on subsequent applies — same pattern as
+  # database_url, sentry_dsn, device_bootstrap_device_id.
   value = "${var.gateway_public_url}/api/v1/ahand/hub-webhook"
   tags  = local.common_tags
+
+  lifecycle {
+    ignore_changes = [value]
+  }
 }
 
 resource "aws_ssm_parameter" "sentry_dsn" {


### PR DESCRIPTION
## Summary

After importing the RDS-ingress SG rules in PR #16's apply window, the standing \`terraform plan\` for both envs has one remaining diff: \`/ahand-hub/{dev,prod}/WEBHOOK_URL\` SSM values were hand-pinned by ww-admin (see \`describe-parameters\` LastModifiedUser) and Terraform wants to revert them to the module default \`\${gateway_public_url}/api/v1/ahand/hub-webhook\` on every apply.

This PR mirrors the existing \`database_url\` / \`sentry_dsn\` / \`device_bootstrap_device_id\` pattern: keep the resource declared (so a missing parameter still shows as drift) but \`ignore_changes = [value]\` so \`terraform apply\` does not revert operator-set values.

### What about the other dev drift?

Two minor dev-only items are intentionally left to be resolved by a one-time \`terraform apply\` in dev:

- \`aws_ecs_service.ahand_hub.enable_execute_command: true → false\` — someone toggled ECS Exec on via CLI, but the dev task role does not grant \`ssmmessages:*\`, so \`aws ecs execute-command\` would fail anyway. Letting apply flip it back to the module default cleans up a non-functional flag with no operational impact. If we later want functional ECS Exec, that is a separate change (variable + IAM).
- \`aws_security_group_rule.rds_ingress_from_task: description: null → "ahand-hub-dev ECS task to RDS 5432"\` — pure metadata sync after the import in PR #16's import window.

Prod plan after this PR is clean (the new \`ignore_changes\` makes the only standing diff disappear without an apply being required).

## Test plan
- [x] \`terraform fmt -check -recursive infra/\` clean
- [x] \`terraform plan\` against dev confirms: \`Plan: 0 to add, 2 to change, 0 to destroy\` (the two non-destructive items above; webhook_url is no longer in the diff)
- [ ] \`terraform apply\` against dev (no task restart — both changes are service-level metadata)
- [ ] Reviewer: confirm we want \`enable_execute_command\` to flip back to false in dev (vs. keeping it as a separately-tracked variable for future functional ECS Exec). If the latter, leave a comment and I will split that into a follow-up PR.