### PR TITLE
chore(hub): surface offending job_id + payload variant in WS-close warn

### DIFF
--- a/crates/ahand-hub-store/src/job_store.rs
+++ b/crates/ahand-hub-store/src/job_store.rs
@@ -54,8 +54,14 @@ impl JobStore for PgJobStore {
     }
 
     async fn get(&self, job_id: &str) -> Result<Option<Job>> {
-        let parsed =
-            Uuid::parse_str(job_id).map_err(|err| HubError::InvalidToken(err.to_string()))?;
+        let parsed = Uuid::parse_str(job_id).map_err(|err| {
+            // Include the offending job_id so the upstream WS-close
+            // log shows what the daemon actually sent. uuid crate's
+            // own message only carries the byte position, which is
+            // useless for tracing the origin (e.g. is this a ULID
+            // from /api/control/jobs replayed across hub restarts?).
+            HubError::InvalidToken(format!("{err}: job_id={job_id:?}"))
+        })?;
         let row = sqlx::query(
             r#"
             SELECT id, device_id, tool, args, cwd, env, timeout_ms, interactive, status, exit_code, error,
@@ -98,8 +104,14 @@ impl JobStore for PgJobStore {
         job_id: &str,
         status: JobStatus,
     ) -> Result<Option<JobStatus>> {
-        let parsed =
-            Uuid::parse_str(job_id).map_err(|err| HubError::InvalidToken(err.to_string()))?;
+        let parsed = Uuid::parse_str(job_id).map_err(|err| {
+            // Include the offending job_id so the upstream WS-close
+            // log shows what the daemon actually sent. uuid crate's
+            // own message only carries the byte position, which is
+            // useless for tracing the origin (e.g. is this a ULID
+            // from /api/control/jobs replayed across hub restarts?).
+            HubError::InvalidToken(format!("{err}: job_id={job_id:?}"))
+        })?;
         let mut tx = self
             .pool
             .begin()
@@ -176,8 +188,14 @@ impl JobStore for PgJobStore {
         error: &str,
         output_summary: &str,
     ) -> Result<()> {
-        let parsed =
-            Uuid::parse_str(job_id).map_err(|err| HubError::InvalidToken(err.to_string()))?;
+        let parsed = Uuid::parse_str(job_id).map_err(|err| {
+            // Include the offending job_id so the upstream WS-close
+            // log shows what the daemon actually sent. uuid crate's
+            // own message only carries the byte position, which is
+            // useless for tracing the origin (e.g. is this a ULID
+            // from /api/control/jobs replayed across hub restarts?).
+            HubError::InvalidToken(format!("{err}: job_id={job_id:?}"))
+        })?;
         let result = sqlx::query(
             r#"
             UPDATE jobs

--- a/crates/ahand-hub/src/ws/device_gateway.rs
+++ b/crates/ahand-hub/src/ws/device_gateway.rs
@@ -455,7 +455,13 @@ impl ConnectionRegistry {
 pub async fn handle_device_socket(ws: WebSocketUpgrade, State(state): State<AppState>) -> Response {
     ws.on_upgrade(move |socket| async move {
         if let Err(err) = run_device_socket(socket, state).await {
-            tracing::warn!(error = %err, "device socket ended with error");
+            // {:?} dumps the full anyhow cause chain. The outermost
+            // message is often a generic InvalidToken; the offending
+            // wire value (e.g. job_id="01KQ...") is attached deeper
+            // by the originating call site. Without the chain, the
+            // operator can't tell which envelope killed the connection
+            // and has to redeploy with extra logging.
+            tracing::warn!(error = ?err, "device socket ended with error");
         }
     })
 }
@@ -852,7 +858,23 @@ async fn run_device_socket(socket: WebSocket, state: AppState) -> anyhow::Result
                             .observe_inbound(&device_id, envelope.seq, envelope.ack)
                             .await?;
                     } else {
-                        state.jobs.handle_device_frame(&device_id, &frame).await?;
+                        // Tag the payload variant onto the error chain.
+                        // If JobRuntime bails (e.g. JobStore::get hits a
+                        // non-UUID job_id), the operator-facing log will
+                        // show both `payload_variant=JobFinished` and
+                        // the inner `job_id="..."`, so they can trace
+                        // the killing envelope without redeploying.
+                        let payload_variant = envelope_payload_variant_name(&envelope.payload);
+                        state
+                            .jobs
+                            .handle_device_frame(&device_id, &frame)
+                            .await
+                            .map_err(|e| {
+                                e.context(format!(
+                                    "handle_device_frame: payload_variant={payload_variant}, seq={}, ack={}",
+                                    envelope.seq, envelope.ack
+                                ))
+                            })?;
                     }
                 }
                 WsMessage::Ping(payload) => {
@@ -921,6 +943,38 @@ async fn run_device_socket(socket: WebSocket, state: AppState) -> anyhow::Result
     }
 
     run_result
+}
+
+fn envelope_payload_variant_name(p: &Option<ahand_protocol::envelope::Payload>) -> &'static str {
+    use ahand_protocol::envelope::Payload::*;
+    match p {
+        None => "<none>",
+        Some(HelloChallenge(_)) => "HelloChallenge",
+        Some(Hello(_)) => "Hello",
+        Some(JobRequest(_)) => "JobRequest",
+        Some(JobEvent(_)) => "JobEvent",
+        Some(JobFinished(_)) => "JobFinished",
+        Some(JobRejected(_)) => "JobRejected",
+        Some(CancelJob(_)) => "CancelJob",
+        Some(ApprovalRequest(_)) => "ApprovalRequest",
+        Some(ApprovalResponse(_)) => "ApprovalResponse",
+        Some(PolicyQuery(_)) => "PolicyQuery",
+        Some(PolicyState(_)) => "PolicyState",
+        Some(PolicyUpdate(_)) => "PolicyUpdate",
+        Some(SetSessionMode(_)) => "SetSessionMode",
+        Some(SessionState(_)) => "SessionState",
+        Some(SessionQuery(_)) => "SessionQuery",
+        Some(BrowserRequest(_)) => "BrowserRequest",
+        Some(BrowserResponse(_)) => "BrowserResponse",
+        Some(HelloAccepted(_)) => "HelloAccepted",
+        Some(UpdateCommand(_)) => "UpdateCommand",
+        Some(UpdateStatus(_)) => "UpdateStatus",
+        Some(StdinChunk(_)) => "StdinChunk",
+        Some(TerminalResize(_)) => "TerminalResize",
+        Some(Heartbeat(_)) => "Heartbeat",
+        Some(FileRequest(_)) => "FileRequest",
+        Some(FileResponse(_)) => "FileResponse",
+    }
 }
 
 /// Publish any job-related envelope received from a daemon to the


### PR DESCRIPTION
## Summary

Adds context to the existing `device socket ended with error` WARN log so the next post-merge dev flap can be root-caused from CloudWatch alone, no deploy round-trip needed. Zero behaviour change — log-only.

## Why

Dev has been flapping since the \`feat/hub-outbox-persistence\` merge with this WARN every ~5–10s on the team9 daemon's connection:

\`\`\`
device socket ended with error
error: invalid token: invalid character: expected an optional prefix of \`urn:uuid:\` followed by [0-9a-fA-F-], found \`K\` at 3
target: ahand_hub::ws::device_gateway
\`\`\`

The message names a byte position but not the actual string, and the \`%err\` Display only renders the outermost layer. The current strongest hypothesis is that \`JobStore::get\` (newly Postgres-backed in #20-ish) is being handed a ULID job_id from a daemon-replayed \`JobFinished\` after \`control_jobs.finalize\` has already removed the entry — but the evidence chain is circumstantial without seeing the wire value.

## What changes

- \`JobStore::get / transition_status / record_terminal_summary\`: bake the offending \`job_id\` into the \`InvalidToken\` message itself (\`"...: job_id=\\"01KQ...\\""\`). Only call site that runs \`Uuid::parse_str\` on a daemon-supplied string, so this is sufficient to surface the wire value.
- \`device_gateway::handle_device_socket\`: switch \`error = %err\` → \`error = ?err\` so anyhow's full cause chain renders.
- \`device_gateway::run_device_socket\`: wrap the \`handle_device_frame\` call with \`.context(format!("payload_variant=..., seq=..., ack=..."))\` so the WARN names the envelope variant even when the inner error is silent.

Adds \`envelope_payload_variant_name(&Option<envelope::Payload>) -> &'static str\` as a free function next to \`dispatch_control_plane_event\` for the variant naming.

## Test plan

- [x] \`cargo check --workspace\` — clean
- [x] \`cargo test -p ahand-hub --lib\` — 92/93 (the 1 failure is the pre-existing \`output_stream::persistent_subscribe...\` that needs a local Docker daemon for a Postgres testcontainer; unrelated)
- [x] \`cargo test -p ahand-hub-store --lib\` — 9/10 (same Docker-testcontainer failure, unrelated)
- [ ] After merge: confirm next \`device socket ended with error\` WARN on the dev hub stream now carries \`payload_variant=...\` + \`job_id=\\"...\\"\` so the actual wire value of the killing envelope is visible

## Notes

- Pure observability change — no new error paths, no new short-circuits, no recovery behaviour. The flap continues until the underlying root cause is fixed; this PR just makes the next round of triage cheap.
- Once we have the actual job_id from a CloudWatch sample, follow-up will land hub-side robustness (probably making \`JobStore::get\` return \`Ok(None)\` on non-UUID job_ids and \`handle_device_frame\` graceful-skip "job not found" instead of bailing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)