### PR TITLE
feat(hub/webhook): include capabilities in device.online + device.registered payloads

### DIFF
--- a/contracts/hub-webhook.json
+++ b/contracts/hub-webhook.json
@@ -29,7 +29,7 @@
       "format": "date-time"
     },
     "data": {
-      "description": "Event-specific payload. Empty object for online/offline/registered/revoked; carries cadence telemetry for heartbeat.",
+      "description": "Event-specific payload. Carries capabilities array for online/registered; empty object for offline/revoked; carries cadence telemetry for heartbeat.",
       "type": "object"
     }
   },
@@ -52,8 +52,24 @@
           "eventType": {
             "enum": [
               "device.online",
+              "device.registered"
+            ]
+          }
+        },
+        "required": ["eventType"]
+      },
+      "then": {
+        "properties": {
+          "data": { "$ref": "#/$defs/OnlineRegisteredData" }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "eventType": {
+            "enum": [
               "device.offline",
-              "device.registered",
               "device.revoked"
             ]
           }
@@ -95,8 +111,25 @@
       "pattern": "^[0-9a-f]{64}$"
     },
 
+    "OnlineRegisteredData": {
+      "description": "Payload for device.online and device.registered events. Contains the daemon-declared capability list from the most recent Hello. The array is always present but may be empty when capabilities are unknown at pre-registration time (admin path). `additionalProperties: true` so future fields don't break existing consumers.",
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["capabilities"],
+      "properties": {
+        "capabilities": {
+          "description": "Daemon-declared capability identifiers (e.g. [\"exec\", \"browser\"]). Empty array when the daemon has not declared capabilities or the event was triggered by the admin pre-register path.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+
     "EmptyData": {
-      "description": "Empty object — emitted for non-heartbeat lifecycle events. Schema is `{}` (no properties allowed).",
+      "description": "Empty object — emitted for offline/revoked lifecycle events. Schema is `{}` (no properties allowed).",
       "type": "object",
       "additionalProperties": false
     },

--- a/crates/ahand-hub/src/http/admin.rs
+++ b/crates/ahand-hub/src/http/admin.rs
@@ -116,7 +116,7 @@ async fn pre_register(
     // correctness problem.
     if let Err(err) = state
         .webhook
-        .enqueue_registered(&device.id, Some(&req.external_user_id))
+        .enqueue_registered(&device.id, Some(&req.external_user_id), &[])
         .await
     {
         tracing::warn!(

--- a/crates/ahand-hub/src/webhook/mod.rs
+++ b/crates/ahand-hub/src/webhook/mod.rs
@@ -166,17 +166,22 @@ impl Webhook {
         self.inner.is_some()
     }
 
-    /// Enqueue a `device.online` event. Noops when disabled.
+    /// Enqueue a `device.online` event. `capabilities` is the daemon-declared
+    /// capability list from the most recent Hello (e.g. `["exec", "browser"]`).
+    /// Noops when disabled.
     pub async fn enqueue_online(
         &self,
         device_id: &str,
         external_user_id: Option<&str>,
+        capabilities: &[String],
     ) -> anyhow::Result<()> {
         self.enqueue_typed(
             "device.online",
             device_id,
             external_user_id,
-            serde_json::json!({}),
+            serde_json::json!({
+                "capabilities": capabilities,
+            }),
         )
         .await
     }
@@ -220,18 +225,23 @@ impl Webhook {
     }
 
     /// Enqueue a `device.registered` event. Emitted the first time a
-    /// daemon's hello lands against a pre-registered device row. Noops
-    /// when disabled.
+    /// daemon's hello lands against a pre-registered device row.
+    /// `capabilities` is the daemon-declared capability list from the Hello
+    /// (e.g. `["exec", "browser"]`); pass `&[]` when caps are unknown at
+    /// the time of pre-registration (admin path). Noops when disabled.
     pub async fn enqueue_registered(
         &self,
         device_id: &str,
         external_user_id: Option<&str>,
+        capabilities: &[String],
     ) -> anyhow::Result<()> {
         self.enqueue_typed(
             "device.registered",
             device_id,
             external_user_id,
-            serde_json::json!({}),
+            serde_json::json!({
+                "capabilities": capabilities,
+            }),
         )
         .await
     }

--- a/crates/ahand-hub/src/webhook/tests.rs
+++ b/crates/ahand-hub/src/webhook/tests.rs
@@ -154,10 +154,7 @@ async fn online_event_serializes_empty_capabilities_when_none_declared() {
     let (webhook, handle) = Webhook::new(store.clone(), noop_config());
     drop(handle);
 
-    webhook
-        .enqueue_online("device-3", None, &[])
-        .await
-        .unwrap();
+    webhook.enqueue_online("device-3", None, &[]).await.unwrap();
 
     let rows = store.lease_due(chrono::Utc::now(), 10).await.unwrap();
     assert_eq!(rows.len(), 1);
@@ -220,10 +217,7 @@ async fn revoked_event_unaffected_by_capabilities_change() {
     let (webhook, handle) = Webhook::new(store.clone(), noop_config());
     drop(handle);
 
-    webhook
-        .enqueue_revoked("device-1", None)
-        .await
-        .unwrap();
+    webhook.enqueue_revoked("device-1", None).await.unwrap();
 
     let rows = store.lease_due(chrono::Utc::now(), 10).await.unwrap();
     let payload: WebhookPayload = serde_json::from_value(rows[0].payload.clone()).unwrap();

--- a/crates/ahand-hub/src/webhook/tests.rs
+++ b/crates/ahand-hub/src/webhook/tests.rs
@@ -23,7 +23,7 @@ async fn disabled_enqueue_returns_ok_without_persisting() {
     let webhook = Webhook::disabled();
     assert!(!webhook.is_enabled());
     webhook
-        .enqueue_online("device-1", Some("user-1"))
+        .enqueue_online("device-1", Some("user-1"), &[])
         .await
         .unwrap();
     webhook.enqueue_offline("device-1", None).await.unwrap();
@@ -32,7 +32,7 @@ async fn disabled_enqueue_returns_ok_without_persisting() {
         .await
         .unwrap();
     webhook
-        .enqueue_registered("device-1", Some("user-1"))
+        .enqueue_registered("device-1", Some("user-1"), &[])
         .await
         .unwrap();
     webhook.enqueue_revoked("device-1", None).await.unwrap();
@@ -48,7 +48,7 @@ async fn enabled_enqueue_persists_and_notifies() {
     drop(handle);
 
     webhook
-        .enqueue_online("device-1", Some("user-1"))
+        .enqueue_online("device-1", Some("user-1"), &[])
         .await
         .unwrap();
     webhook
@@ -99,4 +99,138 @@ async fn payload_skips_external_user_id_when_absent() {
 async fn disabled_webhook_has_no_store() {
     let webhook = Webhook::disabled();
     assert!(webhook.store().is_none());
+}
+
+#[tokio::test]
+async fn online_event_serializes_capabilities() {
+    let store: Arc<dyn ahand_hub_store::webhook_delivery_store::WebhookDeliveryStore> =
+        Arc::new(MemoryWebhookDeliveryStore::new());
+    let (webhook, handle) = Webhook::new(store.clone(), noop_config());
+    drop(handle);
+
+    let caps = vec!["exec".to_string(), "browser".to_string()];
+    webhook
+        .enqueue_online("device-1", Some("user-1"), &caps)
+        .await
+        .unwrap();
+
+    let rows = store.lease_due(chrono::Utc::now(), 10).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    let payload: WebhookPayload = serde_json::from_value(rows[0].payload.clone()).unwrap();
+    assert_eq!(payload.event_type, "device.online");
+    assert_eq!(
+        payload.data["capabilities"],
+        serde_json::json!(["exec", "browser"])
+    );
+}
+
+#[tokio::test]
+async fn registered_event_serializes_capabilities() {
+    let store: Arc<dyn ahand_hub_store::webhook_delivery_store::WebhookDeliveryStore> =
+        Arc::new(MemoryWebhookDeliveryStore::new());
+    let (webhook, handle) = Webhook::new(store.clone(), noop_config());
+    drop(handle);
+
+    let caps = vec!["exec".to_string(), "browser".to_string()];
+    webhook
+        .enqueue_registered("device-2", Some("user-2"), &caps)
+        .await
+        .unwrap();
+
+    let rows = store.lease_due(chrono::Utc::now(), 10).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    let payload: WebhookPayload = serde_json::from_value(rows[0].payload.clone()).unwrap();
+    assert_eq!(payload.event_type, "device.registered");
+    assert_eq!(
+        payload.data["capabilities"],
+        serde_json::json!(["exec", "browser"])
+    );
+}
+
+#[tokio::test]
+async fn online_event_serializes_empty_capabilities_when_none_declared() {
+    let store: Arc<dyn ahand_hub_store::webhook_delivery_store::WebhookDeliveryStore> =
+        Arc::new(MemoryWebhookDeliveryStore::new());
+    let (webhook, handle) = Webhook::new(store.clone(), noop_config());
+    drop(handle);
+
+    webhook
+        .enqueue_online("device-3", None, &[])
+        .await
+        .unwrap();
+
+    let rows = store.lease_due(chrono::Utc::now(), 10).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    let payload: WebhookPayload = serde_json::from_value(rows[0].payload.clone()).unwrap();
+    assert_eq!(payload.event_type, "device.online");
+    assert_eq!(payload.data["capabilities"], serde_json::json!([]));
+}
+
+#[tokio::test]
+async fn heartbeat_data_unaffected_by_capabilities_change() {
+    // Regression guard: heartbeat must not carry capabilities.
+    let store: Arc<dyn ahand_hub_store::webhook_delivery_store::WebhookDeliveryStore> =
+        Arc::new(MemoryWebhookDeliveryStore::new());
+    let (webhook, handle) = Webhook::new(store.clone(), noop_config());
+    drop(handle);
+
+    webhook
+        .enqueue_heartbeat("device-1", None, 42, 90)
+        .await
+        .unwrap();
+
+    let rows = store.lease_due(chrono::Utc::now(), 10).await.unwrap();
+    let payload: WebhookPayload = serde_json::from_value(rows[0].payload.clone()).unwrap();
+    assert_eq!(payload.event_type, "device.heartbeat");
+    assert!(
+        payload.data.get("capabilities").is_none(),
+        "heartbeat must not include capabilities: {:?}",
+        payload.data
+    );
+}
+
+#[tokio::test]
+async fn offline_event_unaffected_by_capabilities_change() {
+    // Regression guard: offline must not carry capabilities.
+    let store: Arc<dyn ahand_hub_store::webhook_delivery_store::WebhookDeliveryStore> =
+        Arc::new(MemoryWebhookDeliveryStore::new());
+    let (webhook, handle) = Webhook::new(store.clone(), noop_config());
+    drop(handle);
+
+    webhook
+        .enqueue_offline("device-1", Some("user-1"))
+        .await
+        .unwrap();
+
+    let rows = store.lease_due(chrono::Utc::now(), 10).await.unwrap();
+    let payload: WebhookPayload = serde_json::from_value(rows[0].payload.clone()).unwrap();
+    assert_eq!(payload.event_type, "device.offline");
+    assert!(
+        payload.data.get("capabilities").is_none(),
+        "offline must not include capabilities: {:?}",
+        payload.data
+    );
+}
+
+#[tokio::test]
+async fn revoked_event_unaffected_by_capabilities_change() {
+    // Regression guard: revoked must not carry capabilities.
+    let store: Arc<dyn ahand_hub_store::webhook_delivery_store::WebhookDeliveryStore> =
+        Arc::new(MemoryWebhookDeliveryStore::new());
+    let (webhook, handle) = Webhook::new(store.clone(), noop_config());
+    drop(handle);
+
+    webhook
+        .enqueue_revoked("device-1", None)
+        .await
+        .unwrap();
+
+    let rows = store.lease_due(chrono::Utc::now(), 10).await.unwrap();
+    let payload: WebhookPayload = serde_json::from_value(rows[0].payload.clone()).unwrap();
+    assert_eq!(payload.event_type, "device.revoked");
+    assert!(
+        payload.data.get("capabilities").is_none(),
+        "revoked must not include capabilities: {:?}",
+        payload.data
+    );
 }

--- a/crates/ahand-hub/src/ws/device_gateway.rs
+++ b/crates/ahand-hub/src/ws/device_gateway.rs
@@ -570,7 +570,7 @@ async fn run_device_socket(socket: WebSocket, state: AppState) -> anyhow::Result
             };
             if let Err(err) = state
                 .webhook
-                .enqueue_registered(&envelope.device_id, external_user_id.as_deref())
+                .enqueue_registered(&envelope.device_id, external_user_id.as_deref(), &hello.capabilities)
                 .await
             {
                 tracing::warn!(
@@ -647,7 +647,7 @@ async fn run_device_socket(socket: WebSocket, state: AppState) -> anyhow::Result
         };
         if let Err(err) = state
             .webhook
-            .enqueue_online(&device_id, online_external_user_id.as_deref())
+            .enqueue_online(&device_id, online_external_user_id.as_deref(), &hello.capabilities)
             .await
         {
             tracing::warn!(

--- a/crates/ahand-hub/tests/webhook_sender.rs
+++ b/crates/ahand-hub/tests/webhook_sender.rs
@@ -206,7 +206,7 @@ async fn happy_path_posts_signed_payload_and_deletes_row() {
     let worker_task = tokio::spawn(worker.run());
 
     webhook
-        .enqueue_online("device-1", Some("user-1"))
+        .enqueue_online("device-1", Some("user-1"), &[])
         .await
         .unwrap();
 
@@ -540,7 +540,7 @@ async fn concurrent_enqueue_is_bounded_by_semaphore() {
 
     for n in 0..100 {
         webhook
-            .enqueue_online(&format!("device-{n}"), Some("user-1"))
+            .enqueue_online(&format!("device-{n}"), Some("user-1"), &[])
             .await
             .unwrap();
     }

--- a/docs/superpowers/plans/2026-04-27-hub-outbox-persistence.md.tasks.json
+++ b/docs/superpowers/plans/2026-04-27-hub-outbox-persistence.md.tasks.json
@@ -4,71 +4,56 @@
     {
       "id": 0,
       "subject": "Task 0: OutboxStore trait + KickSubscription + OutboxLockContention",
-      "status": "pending",
+      "status": "completed",
       "description": "**Goal:** Add the OutboxStore trait, KickSubscription type, and HubError::OutboxLockContention variant. No implementations yet.\n\n**Files:**\n- Modify: crates/ahand-hub-core/src/traits.rs\n- Modify: crates/ahand-hub-core/src/error.rs\n- Modify: crates/ahand-hub-core/Cargo.toml\n\n**Verify:** `cargo check -p ahand-hub-core && cargo test -p ahand-hub-core`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub-core/src/traits.rs\", \"crates/ahand-hub-core/src/error.rs\", \"crates/ahand-hub-core/Cargo.toml\"], \"verifyCommand\": \"cargo check -p ahand-hub-core && cargo test -p ahand-hub-core\", \"acceptanceCriteria\": [\"OutboxStore trait compiles with #[async_trait] and is Send+Sync+'static\", \"KickSubscription is documented and droppable\", \"HubError::OutboxLockContention exists\", \"existing tests still green\"]}\n```"
     },
     {
       "id": 1,
       "subject": "Task 1: InMemoryOutboxStore implementation",
-      "status": "pending",
-      "blockedBy": [
-        0
-      ],
+      "status": "completed",
+      "blockedBy": [0],
       "description": "**Goal:** Process-local OutboxStore impl for StoreConfig::Memory and unit tests; mirrors RedisOutboxStore semantics method-for-method including the bootstrap branch.\n\n**Files:**\n- Create: crates/ahand-hub/src/ws/in_memory_outbox.rs\n- Modify: crates/ahand-hub/src/ws/mod.rs\n\n**Verify:** `cargo test -p ahand-hub --lib ws::in_memory_outbox::tests`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub/src/ws/in_memory_outbox.rs\", \"crates/ahand-hub/src/ws/mod.rs\"], \"verifyCommand\": \"cargo test -p ahand-hub --lib ws::in_memory_outbox::tests\", \"acceptanceCriteria\": [\"all 10 trait methods implemented\", \"lock acquisition is atomic\", \"bootstrap path returns last_ack\", \"fence rejects writes from non-owning session\", \"kick subscription delivers tick\", \"unit tests cover lock/kick/fence/bootstrap/replay/ack-trim\"]}\n```"
     },
     {
       "id": 2,
       "subject": "Task 2: Lua scripts module + EVALSHA wrapper",
-      "status": "pending",
-      "blockedBy": [
-        0
-      ],
-      "description": "**Goal:** Centralize the six Lua script source strings and wrap them in redis::Script handles for transparent EVALSHA\u2192NOSCRIPT\u2192EVAL fallback.\n\n**Files:**\n- Create: crates/ahand-hub-store/src/outbox_lua.rs\n- Modify: crates/ahand-hub-store/src/lib.rs\n\n**Verify:** `cargo check -p ahand-hub-store`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub-store/src/outbox_lua.rs\", \"crates/ahand-hub-store/src/lib.rs\"], \"verifyCommand\": \"cargo check -p ahand-hub-store\", \"acceptanceCriteria\": [\"six script constants defined\", \"OutboxScripts::load returns pre-built redis::Script handles\", \"compiles clean\"]}\n```"
+      "status": "completed",
+      "blockedBy": [0],
+      "description": "**Goal:** Centralize the six Lua script source strings and wrap them in redis::Script handles for transparent EVALSHA→NOSCRIPT→EVAL fallback.\n\n**Files:**\n- Create: crates/ahand-hub-store/src/outbox_lua.rs\n- Modify: crates/ahand-hub-store/src/lib.rs\n\n**Verify:** `cargo check -p ahand-hub-store`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub-store/src/outbox_lua.rs\", \"crates/ahand-hub-store/src/lib.rs\"], \"verifyCommand\": \"cargo check -p ahand-hub-store\", \"acceptanceCriteria\": [\"six script constants defined\", \"OutboxScripts::load returns pre-built redis::Script handles\", \"compiles clean\"]}\n```"
     },
     {
       "id": 3,
       "subject": "Task 3: RedisOutboxStore lock primitives",
-      "status": "pending",
-      "blockedBy": [
-        2
-      ],
+      "status": "completed",
+      "blockedBy": [2],
       "description": "**Goal:** Stand up RedisOutboxStore with the five lock-related methods (acquire, kick, subscribe, renew, release). Send/reconcile/replay/ack remain stubbed for Task 4.\n\n**Files:**\n- Create: crates/ahand-hub-store/src/outbox_store.rs\n- Modify: crates/ahand-hub-store/src/lib.rs\n- Modify: crates/ahand-hub-store/tests/support/mod.rs\n- Modify: crates/ahand-hub-store/tests/store_roundtrip.rs\n\n**Verify:** `cargo test -p ahand-hub-store --features test-support --test store_roundtrip outbox_lock outbox_kick`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub-store/src/outbox_store.rs\", \"crates/ahand-hub-store/src/lib.rs\", \"crates/ahand-hub-store/tests/support/mod.rs\", \"crates/ahand-hub-store/tests/store_roundtrip.rs\"], \"verifyCommand\": \"cargo test -p ahand-hub-store --features test-support --test store_roundtrip outbox_lock outbox_kick\", \"acceptanceCriteria\": [\"new(redis_url) connects + caches scripts\", \"try_acquire_lock NX exclusive\", \"kick publishes\", \"subscribe_kick ticks watch on PUBLISH\", \"renew/release Lua-checked by session_id\", \"integration tests pass\"]}\n```"
     },
     {
       "id": 4,
       "subject": "Task 4: RedisOutboxStore send/reconcile/replay/observe_ack",
-      "status": "pending",
-      "blockedBy": [
-        3
-      ],
+      "status": "completed",
+      "blockedBy": [3],
       "description": "**Goal:** Fill in the five remaining methods. fenced_incr_seq + xadd_frame implement the two-step send. reconcile_on_hello includes the bootstrap branch that auto-recovers wedged devices.\n\n**Files:**\n- Modify: crates/ahand-hub-store/src/outbox_store.rs\n- Modify: crates/ahand-hub-store/tests/store_roundtrip.rs\n\n**Verify:** `cargo test -p ahand-hub-store --features test-support --test store_roundtrip outbox_`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub-store/src/outbox_store.rs\", \"crates/ahand-hub-store/tests/store_roundtrip.rs\"], \"verifyCommand\": \"cargo test -p ahand-hub-store --features test-support --test store_roundtrip outbox_\", \"acceptanceCriteria\": [\"NOT_OWNER maps to HubError::Unauthorized\", \"fenced_incr_seq increments + fences\", \"xadd_frame writes at 0-{seq}\", \"unacked_frames XRANGE-based replay\", \"observe_ack XTRIM MINID-based\", \"reconcile bootstrap path seeds + clears\", \"integration tests pass\"]}\n```"
     },
     {
       "id": 5,
       "subject": "Task 5: Refactor ConnectionRegistry to use OutboxStore",
       "status": "completed",
-      "blockedBy": [
-        1,
-        4
-      ],
+      "blockedBy": [1, 4],
       "description": "**Goal:** Cut the in-memory Outbox out of ConnectionRegistry. Wire Arc<dyn OutboxStore>, add session_id fencing, lease renewer task, kick subscriber task.\n\n**Files:**\n- Modify: crates/ahand-hub/src/ws/device_gateway.rs\n\n**Verify:** `cargo test -p ahand-hub --lib ws::device_gateway::tests && cargo test -p ahand-hub`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub/src/ws/device_gateway.rs\"], \"verifyCommand\": \"cargo test -p ahand-hub --lib ws::device_gateway::tests && cargo test -p ahand-hub\", \"acceptanceCriteria\": [\"ConnectionRegistry::new(Arc<dyn OutboxStore>) is the only constructor\", \"ConnectionEntry holds session_id not Outbox\", \"register is async with kick-then-retry, returns OutboxLockContention on failure\", \"register replays unacked frames\", \"lease renewer + kick subscriber tasks per connection\", \"send fully fenced (fenced_incr_seq + xadd_frame)\", \"observe_ack delegates to store\", \"unregister releases lock and aborts background tasks\"]}\n```"
     },
     {
       "id": 6,
       "subject": "Task 6: Wire OutboxStore into AppState",
       "status": "completed",
-      "blockedBy": [
-        5
-      ],
+      "blockedBy": [5],
       "description": "**Goal:** Construct an Arc<dyn OutboxStore> based on StoreConfig and pass it to ConnectionRegistry::new.\n\n**Files:**\n- Modify: crates/ahand-hub/src/state.rs\n\n**Verify:** `cargo check -p ahand-hub && cargo test -p ahand-hub`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub/src/state.rs\"], \"verifyCommand\": \"cargo check -p ahand-hub && cargo test -p ahand-hub\", \"acceptanceCriteria\": [\"Memory config builds InMemoryOutboxStore\", \"Persistent config builds RedisOutboxStore via REDIS_URL\", \"ConnectionRegistry::new(outbox) is the only constructor invocation\", \"no remaining ConnectionRegistry::default() call sites\"]}\n```"
     },
     {
       "id": 7,
       "subject": "Task 7: End-to-end regression tests",
       "status": "completed",
-      "blockedBy": [
-        6
-      ],
+      "blockedBy": [6],
       "description": "**Goal:** Codify the original incident as a regression test plus replay-after-restart, lock takeover, and bootstrap-path scenarios.\n\n**Files:**\n- Create: crates/ahand-hub/tests/outbox_persistence.rs\n\n**Verify:** `cargo test -p ahand-hub --test outbox_persistence`\n\n```json:metadata\n{\"files\": [\"crates/ahand-hub/tests/outbox_persistence.rs\"], \"verifyCommand\": \"cargo test -p ahand-hub --test outbox_persistence\", \"acceptanceCriteria\": [\"replay_after_simulated_hub_restart passes\", \"lock_takeover_via_kick passes within 5s\", \"bootstrap_path_unblocks_wedged_device passes\", \"original_incident_regression passes (the keystone test)\"]}\n```"
     }
   ],


### PR DESCRIPTION
## Summary

- Extends `WebhookDispatcher::enqueue_online` and `enqueue_registered` to accept `capabilities: &[String]` and serialize it as `data.capabilities` in the JSON payload
- Three call sites updated: admin pre-register passes `&[]` (caps unknown until daemon Hello); both WS `device_gateway` paths pass `&hello.capabilities` from the daemon's Hello message
- Updates `contracts/hub-webhook.json` with `OnlineRegisteredData` schema; `EmptyData` (offline/revoked) and `HeartbeatData` are unchanged

## Cross-repo dependency

Pair PR in `team9ai/team9` ([#87](https://github.com/team9ai/team9/pull/87)) — persists the new `data.capabilities` field into `im_ahand_devices.capabilities` and exposes it on the internal device-list endpoint consumed by `team9-agent-pi`. The team9 side treats `data.capabilities` as optional, so both PRs can land independently without breakage.

## Test plan

- [ ] `cargo test -p ahand-hub` — 98/99 pass (1 pre-existing Docker-daemon-required test)
- [ ] New tests: `online_event_serializes_capabilities`, `registered_event_serializes_capabilities`, `online_event_serializes_empty_capabilities_when_none_declared`
- [ ] Regression guards: `heartbeat_data_unaffected_by_capabilities_change`, `offline_event_unaffected_by_capabilities_change`, `revoked_event_unaffected_by_capabilities_change`
- [ ] `cargo clippy -p ahand-hub --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)