### PR TITLE
fix(infra/prod): point hub webhook at api.team9.ai

### DIFF
--- a/infra/envs/prod/main.tf
+++ b/infra/envs/prod/main.tf
@@ -18,7 +18,10 @@ module "ahand_hub" {
   vpc_id                         = var.vpc_id
   subnet_ids                     = var.subnet_ids
   traefik_security_group_id      = var.traefik_security_group_id
-  gateway_public_url             = "https://gateway.team9.ai"
+  # Prod team9 gateway is published at api.team9.ai (Railway public domain).
+  # gateway.team9.ai does not resolve — the hub's outbound WEBHOOK_URL is
+  # built from this value and posts events to ${gateway_public_url}/api/v1/ahand/hub-webhook.
+  gateway_public_url             = "https://api.team9.ai"
   redis_mode                     = "create"
 }
 


### PR DESCRIPTION
## Summary

- Changes \`gateway_public_url\` in \`infra/envs/prod/main.tf\` from
  \`https://gateway.team9.ai\` (does not resolve) to \`https://api.team9.ai\`
  (actual prod team9 gateway domain).
- The hub module derives \`/ahand-hub/prod/WEBHOOK_URL\` from this value as
  \`\${gateway_public_url}/api/v1/ahand/hub-webhook\`. With the wrong domain,
  prod hub's outbound webhook pushes (\`device.online\`, \`device.registered\`,
  job events) fail DNS resolution and prod gateway receives nothing.
- Dev uses \`api.dev.team9.ai\` correctly; this aligns prod with the same
  pattern.

## Behavior change

\`aws_ssm_parameter.webhook_url\` has \`lifecycle { ignore_changes = [value] }\`,
so a \`terraform apply\` is a no-op against this PR. The live SSM value is
being updated separately via \`aws ssm put-parameter --overwrite\`, which is
the explicit operator-override path the lifecycle block is there to permit.

This PR's value is documentation + a correct default for any future SSM
parameter recreation.

## Test plan

- [x] \`curl -X POST https://api.team9.ai/api/v1/ahand/hub-webhook\` → HTTP 400 (route exists, auth/validation gate kicks in)
- [x] \`curl https://gateway.team9.ai/\` → DNS failure (domain doesn't resolve)
- [x] \`terraform plan\` — "No changes" (ignore_changes kicks in as designed)
- [ ] Out of band: put-parameter + ECS redeploy + end-to-end webhook verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)