### PR TITLE
debug(outbox): instrument lock_takeover flake — DO NOT MERGE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,7 @@ dependencies = [
  "sqlx",
  "testcontainers",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/ahand-hub-store/Cargo.toml
+++ b/crates/ahand-hub-store/Cargo.toml
@@ -25,6 +25,7 @@ serde_json.workspace = true
 sqlx.workspace = true
 testcontainers = { workspace = true, optional = true }
 tokio.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/ahand-hub-store/src/outbox_store.rs
+++ b/crates/ahand-hub-store/src/outbox_store.rs
@@ -92,20 +92,33 @@ impl OutboxStore for RedisOutboxStore {
 
     async fn kick(&self, device_id: &str, new_session_id: &str) -> Result<()> {
         let mut conn = self.conn.lock().await;
-        let _: i64 = conn
+        // DEBUG: keep the PUBLISH return value so we can see how many
+        // subscribers were actually notified. 0 = the previous holder's
+        // SUBSCRIBE hadn't fully landed on the Redis server; a non-zero
+        // count means the kick reached someone. This is the key signal
+        // for the lock_takeover_via_kick investigation.
+        let delivered: i64 = conn
             .publish(Self::kick_channel(device_id), new_session_id)
             .await
             .map_err(redis_err)?;
+        tracing::info!(
+            device_id = %device_id,
+            new_session_id = %new_session_id,
+            delivered,
+            "outbox kick PUBLISHed"
+        );
         Ok(())
     }
 
     async fn subscribe_kick(&self, device_id: &str) -> Result<KickSubscription> {
         let channel = Self::kick_channel(device_id);
+        tracing::info!(device_id = %device_id, "subscribe_kick: opening pubsub");
         let mut pubsub = self.client.get_async_pubsub().await.map_err(redis_err)?;
         pubsub
             .subscribe(channel.as_str())
             .await
             .map_err(redis_err)?;
+        tracing::info!(device_id = %device_id, "subscribe_kick: SUBSCRIBE acknowledged");
 
         let (tx, rx) = watch::channel(0u64);
 
@@ -114,12 +127,22 @@ impl OutboxStore for RedisOutboxStore {
         // owns the pubsub connection and lives until either:
         //   - the watch receiver is dropped (we exit the loop on send error)
         //   - AbortOnDropHandle::drop fires when KickSubscription is dropped
+        let device_id_inner = device_id.to_string();
         let join = tokio::spawn(async move {
             let mut stream = pubsub.on_message();
             let mut counter: u64 = 0;
             while let Some(_msg) = stream.next().await {
                 counter = counter.wrapping_add(1);
+                tracing::info!(
+                    device_id = %device_id_inner,
+                    counter,
+                    "subscribe_kick: received kick message"
+                );
                 if tx.send(counter).is_err() {
+                    tracing::info!(
+                        device_id = %device_id_inner,
+                        "subscribe_kick: watch receiver dropped, exiting"
+                    );
                     break;
                 }
             }

--- a/crates/ahand-hub/src/ws/device_gateway.rs
+++ b/crates/ahand-hub/src/ws/device_gateway.rs
@@ -79,6 +79,7 @@ impl ConnectionRegistry {
         HubError,
     > {
         let session_id = uuid::Uuid::new_v4().to_string();
+        tracing::info!(device_id = %device_id, session_id = %session_id, "register: start");
 
         // 1) Acquire the lock with a kick-then-retry dance. The kick is
         //    addressed to the *previous* holder, but we publish ours as the
@@ -87,20 +88,29 @@ impl ConnectionRegistry {
             .outbox
             .try_acquire_lock(&device_id, &session_id)
             .await?;
+        tracing::info!(device_id = %device_id, session_id = %session_id, acquired, "register: initial try_acquire_lock");
         if !acquired {
             self.outbox.kick(&device_id, &session_id).await?;
-            for _ in 0..LOCK_ACQUIRE_RETRIES {
+            for attempt in 0..LOCK_ACQUIRE_RETRIES {
                 tokio::time::sleep(LOCK_ACQUIRE_BACKOFF).await;
                 acquired = self
                     .outbox
                     .try_acquire_lock(&device_id, &session_id)
                     .await?;
+                tracing::info!(
+                    device_id = %device_id,
+                    session_id = %session_id,
+                    attempt,
+                    acquired,
+                    "register: retry try_acquire_lock"
+                );
                 if acquired {
                     break;
                 }
             }
         }
         if !acquired {
+            tracing::warn!(device_id = %device_id, session_id = %session_id, "register: lock contention, giving up");
             return Err(HubError::OutboxLockContention(device_id));
         }
 
@@ -175,18 +185,31 @@ impl ConnectionRegistry {
         };
         let kick_task = {
             let device_id_inner = device_id.clone();
+            let session_id_inner = session_id.clone();
             let close_tx = close_tx.clone();
             tokio::spawn(async move {
                 let ahand_hub_core::traits::KickSubscription {
                     recv: mut kick_rx,
                     _drop_guard,
                 } = kick_sub;
+                tracing::info!(
+                    device_id = %device_id_inner,
+                    session_id = %session_id_inner,
+                    "kick_task: parked on kick_rx.changed()"
+                );
                 if kick_rx.changed().await.is_ok() {
                     tracing::info!(
                         device_id = %device_id_inner,
-                        "received kick, signalling close",
+                        session_id = %session_id_inner,
+                        "kick_task: watch changed, signalling close",
                     );
                     let _ = close_tx.send(true);
+                } else {
+                    tracing::info!(
+                        device_id = %device_id_inner,
+                        session_id = %session_id_inner,
+                        "kick_task: watch closed without kick"
+                    );
                 }
             })
         };

--- a/crates/ahand-hub/tests/outbox_persistence.rs
+++ b/crates/ahand-hub/tests/outbox_persistence.rs
@@ -5,6 +5,7 @@
 //! key invariants from the design spec.
 
 use std::sync::Arc;
+use std::sync::Once;
 use std::time::Duration;
 
 use ahand_hub::ws::device_gateway::ConnectionRegistry;
@@ -15,6 +16,26 @@ use testcontainers::{
     core::{IntoContainerPort, WaitFor},
     runners::AsyncRunner,
 };
+
+/// DEBUG: route `tracing::info!(...)` events from ahand_hub / ahand_hub_store
+/// to stderr so CI captures the full kick/subscribe/release timeline when
+/// `lock_takeover_via_kick` flakes. Without this the calls we just added in
+/// device_gateway::register / outbox_store::{kick,subscribe_kick} vanish and
+/// we have zero signal to diagnose from. Remove with the actual fix once
+/// the root cause is pinned down.
+fn init_debug_logs() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        use tracing_subscriber::{EnvFilter, fmt};
+        let filter = EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| EnvFilter::new("ahand_hub=info,ahand_hub_store=info"));
+        let _ = fmt()
+            .with_env_filter(filter)
+            .with_test_writer()
+            .with_target(true)
+            .try_init();
+    });
+}
 
 async fn redis_container() -> anyhow::Result<(ContainerAsync<GenericImage>, String)> {
     let container = GenericImage::new("redis", "7-alpine")
@@ -71,30 +92,67 @@ async fn replay_after_simulated_hub_restart() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn lock_takeover_via_kick() -> anyhow::Result<()> {
+    init_debug_logs();
+    let t0 = tokio::time::Instant::now();
+    eprintln!("[{:>6}ms] test: start", t0.elapsed().as_millis());
+
     let (_redis, url) = redis_container().await?;
+    eprintln!("[{:>6}ms] test: redis ready", t0.elapsed().as_millis());
     let store_a = Arc::new(RedisOutboxStore::new(&url).await?) as Arc<dyn OutboxStore>;
     let store_b = Arc::new(RedisOutboxStore::new(&url).await?) as Arc<dyn OutboxStore>;
     let registry_a = Arc::new(ConnectionRegistry::new(store_a.clone()));
     let registry_b = ConnectionRegistry::new(store_b.clone());
 
+    eprintln!(
+        "[{:>6}ms] test: registry_a.register(dev-2) enter",
+        t0.elapsed().as_millis()
+    );
     let (conn_a, _rx_a, mut close_a) = registry_a.register("dev-2".into(), 0).await?;
+    eprintln!(
+        "[{:>6}ms] test: registry_a.register(dev-2) returned",
+        t0.elapsed().as_millis()
+    );
 
     // In production, the WS handler watches close_rx and on close runs
     // the unregister teardown (which calls release_lock). Simulate that
     // by spawning a task that bridges close_a → unregister.
     let cleanup_registry = registry_a.clone();
+    let t_cleanup = t0;
     let cleanup = tokio::spawn(async move {
+        eprintln!(
+            "[{:>6}ms] cleanup: parked on close_a.changed()",
+            t_cleanup.elapsed().as_millis()
+        );
         let _ = close_a.changed().await;
+        eprintln!(
+            "[{:>6}ms] cleanup: close_a fired, calling unregister",
+            t_cleanup.elapsed().as_millis()
+        );
         cleanup_registry
             .unregister("dev-2", conn_a)
             .await
             .expect("unregister after kick");
+        eprintln!(
+            "[{:>6}ms] cleanup: unregister returned",
+            t_cleanup.elapsed().as_millis()
+        );
     });
 
     // B's register should kick A; A's kick subscriber fires close_a;
     // the cleanup task above unregisters A; B's retry succeeds.
     let started = tokio::time::Instant::now();
-    let (_conn_b, _rx_b, _close_b) = registry_b.register("dev-2".into(), 0).await?;
+    eprintln!(
+        "[{:>6}ms] test: registry_b.register(dev-2) enter",
+        t0.elapsed().as_millis()
+    );
+    let b_result = registry_b.register("dev-2".into(), 0).await;
+    eprintln!(
+        "[{:>6}ms] test: registry_b.register(dev-2) returned {:?} (elapsed {:?})",
+        t0.elapsed().as_millis(),
+        b_result.as_ref().map(|_| "ok"),
+        started.elapsed()
+    );
+    let (_conn_b, _rx_b, _close_b) = b_result?;
     assert!(
         started.elapsed() < Duration::from_secs(5),
         "kick-and-acquire took {:?}, expected <5s",


### PR DESCRIPTION
## Purpose

Diagnostic-only PR to extract a timeline from the failing
`lock_takeover_via_kick` testcontainers test that's blocking multiple
PRs on \`dev\`. **Do not merge.** Once CI here prints the log, we close
this, open the real fix, and the real fix includes reverts of every
\`tracing::info!\` / \`eprintln!\` added here.

## Instrumentation added

- \`outbox_store::kick\`: log the PUBLISH \`delivered\` count. 0 is the
  smoking-gun signal that the previous holder's SUBSCRIBE hadn't
  fully registered on Redis by the time the kick fired.
- \`outbox_store::subscribe_kick\`: log at SUBSCRIBE ack + at each
  inbound pubsub message.
- \`device_gateway::register\`: log every \`try_acquire_lock\` attempt
  with its \`acquired\` result.
- \`device_gateway::kick_task\`: log park + wake.
- \`tests/outbox_persistence.rs\`: add a once-inited tracing subscriber
  with \`with_test_writer()\` so the above events reach test output,
  and add \`eprintln!\` timestamps at each key boundary in the test
  body (cleanup parking, register entry/exit, etc.).

## What we expect the log to tell us

- **Delivered = 0 on kick**: SUBSCRIBE race; fix is probably
  subscribe-before-register-returns ordering, not a retry budget
  bump.
- **Delivered = 1 but kick_task never fires**: something broken in
  the pubsub stream path or watch channel plumbing.
- **kick_task fires but cleanup takes > 1s**: unregister / release_lock
  is slow; fix is to bump the retry budget or move release off the
  critical path.
- **Everything fires quickly but try_acquire_lock still sees the old
  holder for 1s**: Redis propagation latency inside testcontainers
  is higher than assumed; fix is raising the budget with a cleaner
  justification.

## Next step

Read CI log → open a proper fix PR off \`dev\` → close this one.