### PR TITLE
feat(dashboard): Files tab on device detail page

### DIFF
--- a/.github/workflows/hub-ci.yml
+++ b/.github/workflows/hub-ci.yml
@@ -65,6 +65,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build shared TS packages
+        # proto-ts exposes its types via dist/ (main/types point there).
+        # hub-dashboard now imports @ahandai/proto, so the package needs to
+        # be built before lint / test / build can resolve it.
+        run: pnpm --filter @ahandai/proto build
+
       - name: Lint hub dashboard
         run: pnpm --filter @ahand/hub-dashboard lint
 

--- a/apps/hub-dashboard/package.json
+++ b/apps/hub-dashboard/package.json
@@ -10,9 +10,11 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@ahandai/proto": "workspace:*",
     "@tanstack/react-query": "^5.90.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
+    "buffer": "^6.0.3",
     "jose": "^6.1.3",
     "next": "16.1.6",
     "next-themes": "^0.4.6",

--- a/apps/hub-dashboard/package.json
+++ b/apps/hub-dashboard/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20.19.17",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",

--- a/apps/hub-dashboard/src/app/api/proxy/[...path]/route.ts
+++ b/apps/hub-dashboard/src/app/api/proxy/[...path]/route.ts
@@ -85,8 +85,18 @@ export async function POST(
     return dashboardErrorResponse("hub_unavailable", "Unable to reach the hub right now.", 503);
   }
 
+  // Allowlist upstream response headers to avoid silently relaying
+  // set-cookie or other sensitive headers onto the dashboard origin.
+  // GET deliberately keeps full passthrough because SSE resume needs it;
+  // POST is a mutation path where a leaked Set-Cookie would be a silent
+  // session-injection primitive.
+  const forwardedHeaders = new Headers();
+  for (const key of ["content-type", "content-length", "cache-control", "etag"]) {
+    const value = response.headers.get(key);
+    if (value) forwardedHeaders.set(key, value);
+  }
   return new NextResponse(response.body, {
     status: response.status,
-    headers: response.headers,
+    headers: forwardedHeaders,
   });
 }

--- a/apps/hub-dashboard/src/app/api/proxy/[...path]/route.ts
+++ b/apps/hub-dashboard/src/app/api/proxy/[...path]/route.ts
@@ -47,3 +47,46 @@ export async function GET(
     headers: response.headers,
   });
 }
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  const { path } = await params;
+  const session = request.cookies.get("ahand_hub_session")?.value ?? "";
+  const baseUrl = process.env.AHAND_HUB_BASE_URL;
+
+  if (!session) {
+    return dashboardErrorResponse("unauthorized", "Sign in required.", 401);
+  }
+
+  if (!baseUrl) {
+    return dashboardErrorResponse("hub_unavailable", "Unable to reach the hub right now.", 503);
+  }
+
+  const upstream = new URL(path.join("/"), `${baseUrl.replace(/\/?$/, "/")}`);
+  upstream.search = request.nextUrl.search;
+
+  let response: Response;
+  try {
+    const bodyBuffer = await request.arrayBuffer();
+    const headers: Record<string, string> = {
+      authorization: `Bearer ${session}`,
+      "content-type": request.headers.get("content-type") ?? "application/octet-stream",
+      accept: request.headers.get("accept") ?? "application/octet-stream",
+    };
+    response = await fetch(upstream.toString(), {
+      method: "POST",
+      headers,
+      body: bodyBuffer,
+      cache: "no-store",
+    });
+  } catch {
+    return dashboardErrorResponse("hub_unavailable", "Unable to reach the hub right now.", 503);
+  }
+
+  return new NextResponse(response.body, {
+    status: response.status,
+    headers: response.headers,
+  });
+}

--- a/apps/hub-dashboard/src/app/globals.css
+++ b/apps/hub-dashboard/src/app/globals.css
@@ -956,3 +956,246 @@ input {
   max-height: 300px;
   overflow-y: auto;
 }
+
+/* ---- Files tab ---- */
+.files-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 16px;
+}
+.files-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.files-form-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.files-label {
+  min-width: 96px;
+  color: var(--muted);
+  font-size: 13px;
+}
+.files-input {
+  flex: 1 1 320px;
+  min-width: 0;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface-soft);
+  color: var(--text);
+}
+.files-actions-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.files-breadcrumbs {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  font-size: 13px;
+  color: var(--muted);
+}
+.files-breadcrumb {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 6px;
+}
+.files-breadcrumb:hover,
+.files-breadcrumb:focus-visible {
+  background: var(--surface-soft);
+  outline: none;
+}
+.files-btn {
+  padding: 6px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--surface-soft);
+  color: var(--text);
+  font-size: 13px;
+  cursor: pointer;
+}
+.files-btn:hover:not(:disabled) {
+  background: rgba(148, 163, 184, 0.16);
+}
+.files-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.files-btn-primary {
+  background: var(--accent-strong);
+  color: #0b111b;
+  border-color: var(--accent-strong);
+}
+.files-btn-sm {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+.files-btn-danger {
+  color: #fca5a5;
+  border-color: rgba(252, 165, 165, 0.4);
+}
+.files-upload-label {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+.files-upload-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+.files-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.files-empty {
+  padding: 16px;
+  color: var(--muted);
+  text-align: center;
+}
+.files-entry {
+  display: flex;
+  gap: 8px;
+  padding: 6px 12px;
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+}
+.files-entry:last-child {
+  border-bottom: none;
+}
+.files-entry-btn {
+  flex: 1 1 auto;
+  display: grid;
+  grid-template-columns: 52px 1fr auto auto;
+  gap: 12px;
+  align-items: center;
+  background: none;
+  border: none;
+  color: var(--text);
+  cursor: pointer;
+  padding: 4px 0;
+  text-align: left;
+}
+.files-entry-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  border-radius: 6px;
+}
+.files-badge {
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: var(--surface-soft);
+  color: var(--muted);
+  text-align: center;
+}
+.files-badge-dir {
+  color: var(--accent);
+}
+.files-entry-size,
+.files-entry-time {
+  color: var(--muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+.files-entry-actions {
+  display: flex;
+  gap: 4px;
+}
+.files-error {
+  border: 1px solid rgba(252, 165, 165, 0.4);
+  background: rgba(252, 165, 165, 0.08);
+  color: #fecaca;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 13px;
+}
+.files-viewer {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  background: var(--surface-soft);
+}
+.files-viewer-header {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.files-viewer-path {
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  color: var(--muted);
+  word-break: break-all;
+}
+.files-viewer-text {
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  max-height: 60vh;
+  overflow: auto;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.files-viewer-image {
+  max-width: 100%;
+  max-height: 60vh;
+  display: block;
+  margin: 0 auto;
+}
+.files-viewer-binary,
+.files-viewer-loading {
+  color: var(--muted);
+  font-size: 13px;
+}
+.files-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 15, 29, 0.6);
+  display: grid;
+  place-items: center;
+  z-index: 50;
+}
+.files-dialog {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  width: min(420px, 90vw);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.files-dialog-title {
+  margin: 0;
+  font-size: 16px;
+}
+.files-dialog-option {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 13px;
+  color: var(--muted);
+}
+.files-dialog-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}

--- a/apps/hub-dashboard/src/app/globals.css
+++ b/apps/hub-dashboard/src/app/globals.css
@@ -1108,6 +1108,12 @@ input {
 .files-badge-dir {
   color: var(--accent);
 }
+.files-entry-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
 .files-entry-size,
 .files-entry-time {
   color: var(--muted);

--- a/apps/hub-dashboard/src/app/globals.css
+++ b/apps/hub-dashboard/src/app/globals.css
@@ -1205,3 +1205,52 @@ input {
   gap: 8px;
   justify-content: flex-end;
 }
+.files-btn-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+.files-debug {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.files-debug-panel {
+  margin-top: 8px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 8px;
+  background: var(--surface-soft);
+  overflow-x: auto;
+}
+.files-debug-empty {
+  padding: 8px;
+  color: var(--muted);
+  text-align: center;
+}
+.files-debug-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: ui-monospace, monospace;
+  font-size: 11px;
+}
+.files-debug-table th,
+.files-debug-table td {
+  text-align: left;
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+.files-debug-table th {
+  color: var(--muted);
+  font-weight: 600;
+}
+.files-debug-path {
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.files-debug-error td {
+  color: #fca5a5;
+}

--- a/apps/hub-dashboard/src/components/device-files.tsx
+++ b/apps/hub-dashboard/src/components/device-files.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
-import { FileType, type FileEntry } from "@ahandai/proto";
+import { FileType, ImageFormat, type FileEntry } from "@ahandai/proto";
 import {
   FileOpsError,
   listFiles,
@@ -10,7 +10,7 @@ import {
 } from "@/lib/file-ops-client";
 
 interface ViewerState {
-  kind: "text" | "image" | "binary";
+  kind: "text" | "image" | "binary" | "loading";
   path: string;
   text?: string;
   imageSrc?: string;
@@ -57,7 +57,7 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
   const openFile = useCallback(
     async (entryPath: string, entryName: string) => {
       setError(null);
-      setViewer({ kind: "text", path: entryPath, text: "Loading..." });
+      setViewer({ kind: "loading", path: entryPath });
       if (isImage(entryName)) {
         try {
           const r = await readImage(deviceId, { path: entryPath });
@@ -65,10 +65,6 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
           const src = `data:${mime};base64,${uint8ToBase64(r.content)}`;
           setViewer({ kind: "image", path: entryPath, imageSrc: src, imageMime: mime });
         } catch (e) {
-          if (e instanceof FileOpsError && e.code === "FILE_ERROR_CODE_ENCODING") {
-            setViewer({ kind: "binary", path: entryPath });
-            return;
-          }
           setViewer(null);
           setError(toErrorState(e));
         }
@@ -77,12 +73,16 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
       try {
         const r = await readText(deviceId, { path: entryPath });
         const joined = r.lines.map((l) => l.content).join("\n");
-        setViewer({ kind: "text", path: entryPath, text: joined });
-      } catch (e) {
-        if (e instanceof FileOpsError && e.code === "FILE_ERROR_CODE_ENCODING") {
+        // Daemon decodes even binary files via chardetng and returns text,
+        // so a proto-level ENCODING error is never what we want to check.
+        // NUL bytes in the joined string are the strongest client-side signal
+        // that the file is not really text.
+        if (joined.includes("\0")) {
           setViewer({ kind: "binary", path: entryPath });
           return;
         }
+        setViewer({ kind: "text", path: entryPath, text: joined });
+      } catch (e) {
         setViewer(null);
         setError(toErrorState(e));
       }
@@ -158,7 +158,7 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
                 </span>
                 <span className="files-entry-name">{e.name}</span>
                 <span className="files-entry-size">
-                  {e.fileType === FileType.FILE_TYPE_REGULAR ? humanSize(e.size) : ""}
+                  {e.fileType === FileType.FILE_TYPE_FILE ? humanSize(e.size) : ""}
                 </span>
                 <span className="files-entry-time">{formatMtime(e.modifiedMs)}</span>
               </button>
@@ -179,6 +179,9 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
               Close
             </button>
           </div>
+          {viewer.kind === "loading" && (
+            <p className="files-viewer-loading">Loading...</p>
+          )}
           {viewer.kind === "text" && (
             <pre className="files-viewer-text">{viewer.text}</pre>
           )}
@@ -210,7 +213,7 @@ function typeLabel(t: FileType): "DIR" | "FILE" | "LNK" | "OTHER" {
   switch (t) {
     case FileType.FILE_TYPE_DIRECTORY:
       return "DIR";
-    case FileType.FILE_TYPE_REGULAR:
+    case FileType.FILE_TYPE_FILE:
       return "FILE";
     case FileType.FILE_TYPE_SYMLINK:
       return "LNK";
@@ -258,11 +261,11 @@ function isImage(name: string): boolean {
   return /\.(png|jpe?g|gif|webp|bmp|ico|svg)$/i.test(name);
 }
 
-function imageMimeFor(fmt: number): string {
+function imageMimeFor(fmt: ImageFormat): string {
   switch (fmt) {
-    case 1: return "image/jpeg";
-    case 2: return "image/png";
-    case 3: return "image/webp";
+    case ImageFormat.IMAGE_FORMAT_JPEG: return "image/jpeg";
+    case ImageFormat.IMAGE_FORMAT_PNG: return "image/png";
+    case ImageFormat.IMAGE_FORMAT_WEBP: return "image/webp";
     default: return "image/png";
   }
 }

--- a/apps/hub-dashboard/src/components/device-files.tsx
+++ b/apps/hub-dashboard/src/components/device-files.tsx
@@ -27,18 +27,45 @@ interface ErrorState {
   message: string;
 }
 
+interface DebugEntry {
+  id: number;
+  op: string;
+  path: string;
+  latencyMs: number;
+  status: "ok" | "error";
+  detail: string;
+  ts: number;
+}
+
+let debugSeq = 0;
+
 export function DeviceFiles({ deviceId }: { deviceId: string }) {
   const [path, setPath] = useState("/tmp");
   const [entries, setEntries] = useState<FileEntry[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<ErrorState | null>(null);
   const [viewer, setViewer] = useState<ViewerState | null>(null);
+  const [debugLog, setDebugLog] = useState<DebugEntry[]>([]);
+  const [showDebug, setShowDebug] = useState(false);
+
+  const recordDebug = useCallback(
+    (entry: Omit<DebugEntry, "id" | "ts">) => {
+      setDebugLog((prev) => {
+        const next: DebugEntry = { ...entry, id: debugSeq++, ts: Date.now() };
+        // Keep the last 20 entries — enough to eyeball recent activity
+        // without unbounded memory growth on long operator sessions.
+        return [next, ...prev].slice(0, 20);
+      });
+    },
+    [],
+  );
 
   const openDirectory = useCallback(
     async (target: string) => {
       setLoading(true);
       setError(null);
       setViewer(null);
+      const started = performance.now();
       try {
         const result = await listFiles(deviceId, { path: target });
         const sorted = [...result.entries].sort((a, b) => {
@@ -49,29 +76,58 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
         });
         setEntries(sorted);
         setPath(target);
+        recordDebug({
+          op: "list",
+          path: target,
+          latencyMs: Math.round(performance.now() - started),
+          status: "ok",
+          detail: `${result.entries.length} entries`,
+        });
       } catch (e) {
         setEntries(null);
         setError(toErrorState(e));
+        recordDebug({
+          op: "list",
+          path: target,
+          latencyMs: Math.round(performance.now() - started),
+          status: "error",
+          detail: toErrorState(e).code,
+        });
       } finally {
         setLoading(false);
       }
     },
-    [deviceId],
+    [deviceId, recordDebug],
   );
 
   const openFile = useCallback(
     async (entryPath: string, entryName: string) => {
       setError(null);
       setViewer({ kind: "loading", path: entryPath });
+      const started = performance.now();
       if (isImage(entryName)) {
         try {
           const r = await readImage(deviceId, { path: entryPath });
           const mime = imageMimeFor(r.format);
           const src = `data:${mime};base64,${uint8ToBase64(r.content)}`;
           setViewer({ kind: "image", path: entryPath, imageSrc: src, imageMime: mime });
+          recordDebug({
+            op: "read_image",
+            path: entryPath,
+            latencyMs: Math.round(performance.now() - started),
+            status: "ok",
+            detail: `${r.width}x${r.height}, ${r.outputBytes}B`,
+          });
         } catch (e) {
           setViewer(null);
           setError(toErrorState(e));
+          recordDebug({
+            op: "read_image",
+            path: entryPath,
+            latencyMs: Math.round(performance.now() - started),
+            status: "error",
+            detail: toErrorState(e).code,
+          });
         }
         return;
       }
@@ -82,17 +138,32 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
         // so a proto-level ENCODING error is never what we want to check.
         // NUL bytes in the joined string are the strongest client-side signal
         // that the file is not really text.
-        if (joined.includes("\0")) {
-          setViewer({ kind: "binary", path: entryPath });
-          return;
-        }
-        setViewer({ kind: "text", path: entryPath, text: joined });
+        const binary = joined.includes("\0");
+        setViewer(
+          binary
+            ? { kind: "binary", path: entryPath }
+            : { kind: "text", path: entryPath, text: joined },
+        );
+        recordDebug({
+          op: "read_text",
+          path: entryPath,
+          latencyMs: Math.round(performance.now() - started),
+          status: "ok",
+          detail: binary ? "binary (NUL)" : `${r.lines.length} lines`,
+        });
       } catch (e) {
         setViewer(null);
         setError(toErrorState(e));
+        recordDebug({
+          op: "read_text",
+          path: entryPath,
+          latencyMs: Math.round(performance.now() - started),
+          status: "error",
+          detail: toErrorState(e).code,
+        });
       }
     },
-    [deviceId],
+    [deviceId, recordDebug],
   );
 
   const [mkdirName, setMkdirName] = useState<string | null>(null);
@@ -114,39 +185,73 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
     if (!name) return;
     setBusy("mkdir");
     setError(null);
+    const target = joinPath(path, name);
+    const started = performance.now();
     try {
-      await mkdir(deviceId, { path: joinPath(path, name), recursive: true });
+      const r = await mkdir(deviceId, { path: target, recursive: true });
       setMkdirName(null);
       await openDirectory(path);
+      recordDebug({
+        op: "mkdir",
+        path: target,
+        latencyMs: Math.round(performance.now() - started),
+        status: "ok",
+        detail: r.alreadyExisted ? "already existed" : "created",
+      });
     } catch (e) {
       setError(toErrorState(e));
+      recordDebug({
+        op: "mkdir",
+        path: target,
+        latencyMs: Math.round(performance.now() - started),
+        status: "error",
+        detail: toErrorState(e).code,
+      });
     } finally {
       setBusy(null);
     }
-  }, [mkdirName, deviceId, path, openDirectory]);
+  }, [mkdirName, deviceId, path, openDirectory, recordDebug]);
 
   const handleDelete = useCallback(async () => {
     if (!pendingDelete) return;
     const { name, recursive } = pendingDelete;
     setBusy("delete");
     setError(null);
+    const target = joinPath(path, name);
+    const started = performance.now();
     try {
-      await deleteFile(deviceId, { path: joinPath(path, name), recursive });
+      const r = await deleteFile(deviceId, { path: target, recursive });
       setPendingDelete(null);
       await openDirectory(path);
+      recordDebug({
+        op: "delete",
+        path: target,
+        latencyMs: Math.round(performance.now() - started),
+        status: "ok",
+        detail: `${r.itemsDeleted} items`,
+      });
     } catch (e) {
       setError(toErrorState(e));
+      recordDebug({
+        op: "delete",
+        path: target,
+        latencyMs: Math.round(performance.now() - started),
+        status: "error",
+        detail: toErrorState(e).code,
+      });
     } finally {
       setBusy(null);
     }
-  }, [pendingDelete, deviceId, path, openDirectory]);
+  }, [pendingDelete, deviceId, path, openDirectory, recordDebug]);
 
   const handleDownload = useCallback(
     async (name: string) => {
       setBusy(`download:${name}`);
       setError(null);
+      const target = joinPath(path, name);
+      const started = performance.now();
       try {
-        const r = await readBinary(deviceId, { path: joinPath(path, name) });
+        const r = await readBinary(deviceId, { path: target });
         const view = new Uint8Array(r.content);
         const blob = new Blob([view], { type: "application/octet-stream" });
         const url = URL.createObjectURL(blob);
@@ -162,13 +267,27 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
         // Safari drops the download if we revoke synchronously — let the
         // download dialog attach first.
         setTimeout(() => URL.revokeObjectURL(url), 0);
+        recordDebug({
+          op: "download",
+          path: target,
+          latencyMs: Math.round(performance.now() - started),
+          status: "ok",
+          detail: `${r.bytesRead}B${r.remainingBytes > 0 ? ` (+${r.remainingBytes}B left)` : ""}`,
+        });
       } catch (e) {
         setError(toErrorState(e));
+        recordDebug({
+          op: "download",
+          path: target,
+          latencyMs: Math.round(performance.now() - started),
+          status: "error",
+          detail: toErrorState(e).code,
+        });
       } finally {
         setBusy(null);
       }
     },
-    [deviceId, path],
+    [deviceId, path, recordDebug],
   );
 
   const handleUpload = useCallback(
@@ -176,6 +295,12 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
       if (!file) return;
       setBusy("upload");
       setError(null);
+      // Strip any directory separators from the browser-provided filename so
+      // a malicious user-agent can't trick the UI into writing outside the
+      // current directory. The daemon's file_policy is still authoritative,
+      // but the displayed target path should match what actually happens.
+      const target = joinPath(path, basename(file.name));
+      const started = performance.now();
       try {
         if (file.size > MAX_INLINE_WRITE_BYTES) {
           throw new FileOpsError(
@@ -185,22 +310,29 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
           );
         }
         const bytes = new Uint8Array(await file.arrayBuffer());
-        // Strip any directory separators from the browser-provided filename so
-        // a malicious user-agent can't trick the UI into writing outside the
-        // current directory. The daemon's file_policy is still authoritative,
-        // but the displayed target path should match what actually happens.
-        await writeFile(deviceId, {
-          path: joinPath(path, basename(file.name)),
-          content: bytes,
-        });
+        const r = await writeFile(deviceId, { path: target, content: bytes });
         await openDirectory(path);
+        recordDebug({
+          op: "upload",
+          path: target,
+          latencyMs: Math.round(performance.now() - started),
+          status: "ok",
+          detail: `${r.bytesWritten}B written`,
+        });
       } catch (e) {
         setError(toErrorState(e));
+        recordDebug({
+          op: "upload",
+          path: target,
+          latencyMs: Math.round(performance.now() - started),
+          status: "error",
+          detail: toErrorState(e).code,
+        });
       } finally {
         setBusy(null);
       }
     },
-    [deviceId, path, openDirectory],
+    [deviceId, path, openDirectory, recordDebug],
   );
 
   const crumbs = useMemo(() => buildBreadcrumbs(path), [path]);
@@ -250,7 +382,11 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
           >
             New folder
           </button>
-          <label className="files-btn files-upload-label">
+          <label
+            className={`files-btn files-upload-label${
+              busy !== null ? " files-btn-disabled" : ""
+            }`}
+          >
             Upload file
             <input
               type="file"
@@ -393,9 +529,11 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
             className="files-dialog"
             role="dialog"
             aria-modal="true"
-            aria-label={`Delete ${pendingDelete.name}`}
+            aria-labelledby="files-dialog-title"
           >
-            <h3 className="files-dialog-title">Delete {pendingDelete.name}?</h3>
+            <h3 id="files-dialog-title" className="files-dialog-title">
+              Delete {pendingDelete.name}?
+            </h3>
             <label className="files-dialog-option">
               <input
                 type="checkbox"
@@ -429,6 +567,49 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
           </div>
         </div>
       )}
+
+      <div className="files-debug">
+        <button
+          type="button"
+          className="files-btn files-btn-sm"
+          onClick={() => setShowDebug((v) => !v)}
+          aria-expanded={showDebug}
+        >
+          {showDebug ? "Hide" : "Show"} debug ({debugLog.length})
+        </button>
+        {showDebug && (
+          <div className="files-debug-panel" aria-label="Files debug log">
+            {debugLog.length === 0 ? (
+              <div className="files-debug-empty">No ops recorded yet.</div>
+            ) : (
+              <table className="files-debug-table">
+                <thead>
+                  <tr>
+                    <th>When</th>
+                    <th>Op</th>
+                    <th>Path</th>
+                    <th>Latency</th>
+                    <th>Status</th>
+                    <th>Detail</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {debugLog.map((d) => (
+                    <tr key={d.id} className={`files-debug-${d.status}`}>
+                      <td>{formatMtime(d.ts)}</td>
+                      <td>{d.op}</td>
+                      <td className="files-debug-path">{d.path}</td>
+                      <td>{d.latencyMs}ms</td>
+                      <td>{d.status}</td>
+                      <td>{d.detail}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/hub-dashboard/src/components/device-files.tsx
+++ b/apps/hub-dashboard/src/components/device-files.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { FileType, type FileEntry } from "@ahandai/proto";
+import {
+  FileOpsError,
+  listFiles,
+  readImage,
+  readText,
+} from "@/lib/file-ops-client";
+
+interface ViewerState {
+  kind: "text" | "image" | "binary";
+  path: string;
+  text?: string;
+  imageSrc?: string;
+  imageMime?: string;
+}
+
+interface ErrorState {
+  code: string;
+  message: string;
+}
+
+export function DeviceFiles({ deviceId }: { deviceId: string }) {
+  const [path, setPath] = useState("/tmp");
+  const [entries, setEntries] = useState<FileEntry[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<ErrorState | null>(null);
+  const [viewer, setViewer] = useState<ViewerState | null>(null);
+
+  const openDirectory = useCallback(
+    async (target: string) => {
+      setLoading(true);
+      setError(null);
+      setViewer(null);
+      try {
+        const result = await listFiles(deviceId, { path: target });
+        const sorted = [...result.entries].sort((a, b) => {
+          const aDir = a.fileType === FileType.FILE_TYPE_DIRECTORY ? 0 : 1;
+          const bDir = b.fileType === FileType.FILE_TYPE_DIRECTORY ? 0 : 1;
+          if (aDir !== bDir) return aDir - bDir;
+          return a.name.localeCompare(b.name);
+        });
+        setEntries(sorted);
+        setPath(target);
+      } catch (e) {
+        setEntries(null);
+        setError(toErrorState(e));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [deviceId],
+  );
+
+  const openFile = useCallback(
+    async (entryPath: string, entryName: string) => {
+      setError(null);
+      setViewer({ kind: "text", path: entryPath, text: "Loading..." });
+      if (isImage(entryName)) {
+        try {
+          const r = await readImage(deviceId, { path: entryPath });
+          const mime = imageMimeFor(r.format);
+          const src = `data:${mime};base64,${uint8ToBase64(r.content)}`;
+          setViewer({ kind: "image", path: entryPath, imageSrc: src, imageMime: mime });
+        } catch (e) {
+          if (e instanceof FileOpsError && e.code === "FILE_ERROR_CODE_ENCODING") {
+            setViewer({ kind: "binary", path: entryPath });
+            return;
+          }
+          setViewer(null);
+          setError(toErrorState(e));
+        }
+        return;
+      }
+      try {
+        const r = await readText(deviceId, { path: entryPath });
+        const joined = r.lines.map((l) => l.content).join("\n");
+        setViewer({ kind: "text", path: entryPath, text: joined });
+      } catch (e) {
+        if (e instanceof FileOpsError && e.code === "FILE_ERROR_CODE_ENCODING") {
+          setViewer({ kind: "binary", path: entryPath });
+          return;
+        }
+        setViewer(null);
+        setError(toErrorState(e));
+      }
+    },
+    [deviceId],
+  );
+
+  const crumbs = useMemo(() => buildBreadcrumbs(path), [path]);
+
+  return (
+    <div className="files-panel">
+      <div className="files-section">
+        <div className="files-form-row">
+          <label className="files-label" htmlFor="files-path-input">
+            Path
+          </label>
+          <input
+            id="files-path-input"
+            className="files-input"
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+            placeholder="/home/user"
+            onKeyDown={(e) => e.key === "Enter" && openDirectory(path)}
+          />
+          <button
+            type="button"
+            className="files-btn files-btn-primary"
+            onClick={() => openDirectory(path)}
+            disabled={loading}
+          >
+            {loading ? "Loading..." : "Open"}
+          </button>
+        </div>
+        <nav aria-label="Directory breadcrumbs" className="files-breadcrumbs">
+          {crumbs.map((c, i) => (
+            <button
+              key={`${c.path}-${i}`}
+              type="button"
+              className="files-breadcrumb"
+              onClick={() => openDirectory(c.path)}
+            >
+              {c.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {error && (
+        <div className="files-error" role="alert">
+          <strong>{error.code}</strong>: {error.message}
+        </div>
+      )}
+
+      {entries && (
+        <ul className="files-list" aria-label="Directory entries">
+          {entries.length === 0 && (
+            <li className="files-empty">(empty directory)</li>
+          )}
+          {entries.map((e) => (
+            <li key={e.name} className="files-entry">
+              <button
+                type="button"
+                className="files-entry-btn"
+                onClick={() =>
+                  e.fileType === FileType.FILE_TYPE_DIRECTORY
+                    ? openDirectory(joinPath(path, e.name))
+                    : openFile(joinPath(path, e.name), e.name)
+                }
+                aria-label={`${typeLabel(e.fileType)} ${e.name}`}
+              >
+                <span className={`files-badge files-badge-${typeLabel(e.fileType).toLowerCase()}`}>
+                  {typeLabel(e.fileType)}
+                </span>
+                <span className="files-entry-name">{e.name}</span>
+                <span className="files-entry-size">
+                  {e.fileType === FileType.FILE_TYPE_REGULAR ? humanSize(e.size) : ""}
+                </span>
+                <span className="files-entry-time">{formatMtime(e.modifiedMs)}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {viewer && (
+        <div className="files-viewer" role="region" aria-label={`Viewer for ${viewer.path}`}>
+          <div className="files-viewer-header">
+            <span className="files-viewer-path">{viewer.path}</span>
+            <button
+              type="button"
+              className="files-btn files-btn-sm"
+              onClick={() => setViewer(null)}
+            >
+              Close
+            </button>
+          </div>
+          {viewer.kind === "text" && (
+            <pre className="files-viewer-text">{viewer.text}</pre>
+          )}
+          {viewer.kind === "image" && (
+            <img
+              className="files-viewer-image"
+              src={viewer.imageSrc}
+              alt={viewer.path}
+            />
+          )}
+          {viewer.kind === "binary" && (
+            <p className="files-viewer-binary">
+              Binary file — use Download to save it locally.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function toErrorState(e: unknown): ErrorState {
+  if (e instanceof FileOpsError) return { code: e.code, message: e.message };
+  if (e instanceof Error) return { code: "ClientError", message: e.message };
+  return { code: "ClientError", message: String(e) };
+}
+
+function typeLabel(t: FileType): "DIR" | "FILE" | "LNK" | "OTHER" {
+  switch (t) {
+    case FileType.FILE_TYPE_DIRECTORY:
+      return "DIR";
+    case FileType.FILE_TYPE_REGULAR:
+      return "FILE";
+    case FileType.FILE_TYPE_SYMLINK:
+      return "LNK";
+    default:
+      return "OTHER";
+  }
+}
+
+function humanSize(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MiB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(1)} GiB`;
+}
+
+function formatMtime(ms: number): string {
+  if (!ms) return "";
+  return new Date(ms).toLocaleString();
+}
+
+function joinPath(base: string, name: string): string {
+  if (base === "/") return `/${name}`;
+  if (base.endsWith("/")) return `${base}${name}`;
+  return `${base}/${name}`;
+}
+
+function buildBreadcrumbs(p: string): { label: string; path: string }[] {
+  const trimmed = p.replace(/\/+$/, "");
+  if (!trimmed || trimmed === "") {
+    return [{ label: "/", path: "/" }];
+  }
+  const isAbs = trimmed.startsWith("/");
+  const parts = trimmed.split("/").filter(Boolean);
+  const crumbs: { label: string; path: string }[] = [];
+  if (isAbs) crumbs.push({ label: "/", path: "/" });
+  let cursor = "";
+  for (const part of parts) {
+    cursor = isAbs ? `${cursor}/${part}` : cursor ? `${cursor}/${part}` : part;
+    crumbs.push({ label: part, path: cursor || "/" });
+  }
+  return crumbs;
+}
+
+function isImage(name: string): boolean {
+  return /\.(png|jpe?g|gif|webp|bmp|ico|svg)$/i.test(name);
+}
+
+function imageMimeFor(fmt: number): string {
+  switch (fmt) {
+    case 1: return "image/jpeg";
+    case 2: return "image/png";
+    case 3: return "image/webp";
+    default: return "image/png";
+  }
+}
+
+function uint8ToBase64(bytes: Uint8Array): string {
+  let s = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    s += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK) as unknown as number[]);
+  }
+  return btoa(s);
+}

--- a/apps/hub-dashboard/src/components/device-files.tsx
+++ b/apps/hub-dashboard/src/components/device-files.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { FileType, ImageFormat, type FileEntry } from "@ahandai/proto";
 import {
   FileOpsError,
@@ -98,6 +98,15 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
   const [pendingDelete, setPendingDelete] = useState<{ name: string; recursive: boolean } | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
 
+  useEffect(() => {
+    if (!pendingDelete) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setPendingDelete(null);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [pendingDelete]);
+
   const handleMkdir = useCallback(async () => {
     if (mkdirName === null) return;
     const name = mkdirName.trim();
@@ -146,7 +155,9 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
         document.body.appendChild(a);
         a.click();
         a.remove();
-        URL.revokeObjectURL(url);
+        // Safari drops the download if we revoke synchronously — let the
+        // download dialog attach first.
+        setTimeout(() => URL.revokeObjectURL(url), 0);
       } catch (e) {
         setError(toErrorState(e));
       } finally {
@@ -234,7 +245,12 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
               type="file"
               className="files-upload-input"
               aria-label="Upload file"
-              onChange={(e) => handleUpload(e.target.files?.[0])}
+              disabled={busy !== null}
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                e.target.value = "";
+                handleUpload(file);
+              }}
             />
           </label>
         </div>

--- a/apps/hub-dashboard/src/components/device-files.tsx
+++ b/apps/hub-dashboard/src/components/device-files.tsx
@@ -4,9 +4,13 @@ import { useCallback, useMemo, useState } from "react";
 import { FileType, ImageFormat, type FileEntry } from "@ahandai/proto";
 import {
   FileOpsError,
+  deleteFile,
   listFiles,
+  mkdir,
+  readBinary,
   readImage,
   readText,
+  writeFile,
 } from "@/lib/file-ops-client";
 
 interface ViewerState {
@@ -90,6 +94,93 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
     [deviceId],
   );
 
+  const [mkdirName, setMkdirName] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<{ name: string; recursive: boolean } | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const handleMkdir = useCallback(async () => {
+    if (mkdirName === null) return;
+    const name = mkdirName.trim();
+    if (!name) return;
+    setBusy("mkdir");
+    setError(null);
+    try {
+      await mkdir(deviceId, { path: joinPath(path, name), recursive: true });
+      setMkdirName(null);
+      await openDirectory(path);
+    } catch (e) {
+      setError(toErrorState(e));
+    } finally {
+      setBusy(null);
+    }
+  }, [mkdirName, deviceId, path, openDirectory]);
+
+  const handleDelete = useCallback(async () => {
+    if (!pendingDelete) return;
+    const { name, recursive } = pendingDelete;
+    setBusy("delete");
+    setError(null);
+    try {
+      await deleteFile(deviceId, { path: joinPath(path, name), recursive });
+      setPendingDelete(null);
+      await openDirectory(path);
+    } catch (e) {
+      setError(toErrorState(e));
+    } finally {
+      setBusy(null);
+    }
+  }, [pendingDelete, deviceId, path, openDirectory]);
+
+  const handleDownload = useCallback(
+    async (name: string) => {
+      setBusy(`download:${name}`);
+      setError(null);
+      try {
+        const r = await readBinary(deviceId, { path: joinPath(path, name) });
+        const view = new Uint8Array(r.content);
+        const blob = new Blob([view], { type: "application/octet-stream" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = name;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+      } catch (e) {
+        setError(toErrorState(e));
+      } finally {
+        setBusy(null);
+      }
+    },
+    [deviceId, path],
+  );
+
+  const handleUpload = useCallback(
+    async (file: File | null | undefined) => {
+      if (!file) return;
+      setBusy("upload");
+      setError(null);
+      try {
+        if (file.size > 1_048_576) {
+          throw new FileOpsError(
+            "content_too_large",
+            "Uploads larger than 1 MiB require the S3 path, which is not implemented yet.",
+            0,
+          );
+        }
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        await writeFile(deviceId, { path: joinPath(path, file.name), content: bytes });
+        await openDirectory(path);
+      } catch (e) {
+        setError(toErrorState(e));
+      } finally {
+        setBusy(null);
+      }
+    },
+    [deviceId, path, openDirectory],
+  );
+
   const crumbs = useMemo(() => buildBreadcrumbs(path), [path]);
 
   return (
@@ -128,6 +219,54 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
             </button>
           ))}
         </nav>
+        <div className="files-actions-row">
+          <button
+            type="button"
+            className="files-btn"
+            onClick={() => setMkdirName("")}
+            disabled={busy !== null}
+          >
+            New folder
+          </button>
+          <label className="files-btn files-upload-label">
+            Upload file
+            <input
+              type="file"
+              className="files-upload-input"
+              aria-label="Upload file"
+              onChange={(e) => handleUpload(e.target.files?.[0])}
+            />
+          </label>
+        </div>
+        {mkdirName !== null && (
+          <div className="files-form-row">
+            <label className="files-label" htmlFor="files-mkdir-input">
+              Folder name
+            </label>
+            <input
+              id="files-mkdir-input"
+              className="files-input"
+              value={mkdirName}
+              onChange={(e) => setMkdirName(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleMkdir()}
+            />
+            <button
+              type="button"
+              className="files-btn files-btn-primary"
+              onClick={handleMkdir}
+              disabled={busy === "mkdir"}
+            >
+              Create
+            </button>
+            <button
+              type="button"
+              className="files-btn"
+              onClick={() => setMkdirName(null)}
+            >
+              Cancel
+            </button>
+          </div>
+        )}
       </div>
 
       {error && (
@@ -162,6 +301,28 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
                 </span>
                 <span className="files-entry-time">{formatMtime(e.modifiedMs)}</span>
               </button>
+              <div className="files-entry-actions">
+                {e.fileType === FileType.FILE_TYPE_FILE && (
+                  <button
+                    type="button"
+                    className="files-btn files-btn-sm"
+                    onClick={() => handleDownload(e.name)}
+                    disabled={busy === `download:${e.name}`}
+                    aria-label={`Download ${e.name}`}
+                  >
+                    Download
+                  </button>
+                )}
+                <button
+                  type="button"
+                  className="files-btn files-btn-sm files-btn-danger"
+                  onClick={() => setPendingDelete({ name: e.name, recursive: false })}
+                  disabled={busy === "delete"}
+                  aria-label={`Delete ${e.name}`}
+                >
+                  Delete
+                </button>
+              </div>
             </li>
           ))}
         </ul>
@@ -197,6 +358,48 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
               Binary file — use Download to save it locally.
             </p>
           )}
+        </div>
+      )}
+      {pendingDelete && (
+        <div className="files-dialog-backdrop">
+          <div
+            className="files-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-label={`Delete ${pendingDelete.name}`}
+          >
+            <h3 className="files-dialog-title">Delete {pendingDelete.name}?</h3>
+            <label className="files-dialog-option">
+              <input
+                type="checkbox"
+                checked={pendingDelete.recursive}
+                onChange={(e) =>
+                  setPendingDelete({
+                    name: pendingDelete.name,
+                    recursive: e.target.checked,
+                  })
+                }
+              />
+              Recursive (delete contents)
+            </label>
+            <div className="files-dialog-actions">
+              <button
+                type="button"
+                className="files-btn"
+                onClick={() => setPendingDelete(null)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="files-btn files-btn-danger"
+                onClick={handleDelete}
+                disabled={busy === "delete"}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/apps/hub-dashboard/src/components/device-files.tsx
+++ b/apps/hub-dashboard/src/components/device-files.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { FileType, ImageFormat, type FileEntry } from "@ahandai/proto";
 import {
   FileOpsError,
+  MAX_INLINE_WRITE_BYTES,
   deleteFile,
   listFiles,
   mkdir,
@@ -151,7 +152,10 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
         const url = URL.createObjectURL(blob);
         const a = document.createElement("a");
         a.href = url;
-        a.download = name;
+        // Force the suggested filename to a basename so a listing entry whose
+        // name somehow contains slashes cannot trick the browser into writing
+        // outside the user's intended download folder.
+        a.download = basename(name);
         document.body.appendChild(a);
         a.click();
         a.remove();
@@ -173,15 +177,22 @@ export function DeviceFiles({ deviceId }: { deviceId: string }) {
       setBusy("upload");
       setError(null);
       try {
-        if (file.size > 1_048_576) {
+        if (file.size > MAX_INLINE_WRITE_BYTES) {
           throw new FileOpsError(
             "content_too_large",
-            "Uploads larger than 1 MiB require the S3 path, which is not implemented yet.",
+            `Uploads larger than ${MAX_INLINE_WRITE_BYTES} bytes require the S3 path, which is not implemented yet.`,
             0,
           );
         }
         const bytes = new Uint8Array(await file.arrayBuffer());
-        await writeFile(deviceId, { path: joinPath(path, file.name), content: bytes });
+        // Strip any directory separators from the browser-provided filename so
+        // a malicious user-agent can't trick the UI into writing outside the
+        // current directory. The daemon's file_policy is still authoritative,
+        // but the displayed target path should match what actually happens.
+        await writeFile(deviceId, {
+          path: joinPath(path, basename(file.name)),
+          content: bytes,
+        });
         await openDirectory(path);
       } catch (e) {
         setError(toErrorState(e));
@@ -476,8 +487,16 @@ function buildBreadcrumbs(p: string): { label: string; path: string }[] {
   return crumbs;
 }
 
+// Only formats the Rust image crate can decode on the daemon side. Adding
+// others (svg/gif/bmp/ico) just routes them through readImage → proto error →
+// error banner, which is a worse UX than falling back to the binary viewer.
 function isImage(name: string): boolean {
-  return /\.(png|jpe?g|gif|webp|bmp|ico|svg)$/i.test(name);
+  return /\.(png|jpe?g|webp)$/i.test(name);
+}
+
+function basename(name: string): string {
+  const parts = name.split(/[\\/]/);
+  return parts[parts.length - 1] || "download";
 }
 
 function imageMimeFor(fmt: ImageFormat): string {

--- a/apps/hub-dashboard/src/components/device-tabs.tsx
+++ b/apps/hub-dashboard/src/components/device-tabs.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { DeviceJobsPanel } from "./device-jobs-panel";
 import { DeviceTerminal } from "./device-terminal";
 import { DeviceBrowser } from "./device-browser";
+import { DeviceFiles } from "./device-files";
 
 export function DeviceTabs({
   deviceId,
@@ -15,7 +16,7 @@ export function DeviceTabs({
   capabilities: string[];
 }) {
   const hasBrowser = online && capabilities.includes("browser");
-  const [tab, setTab] = useState<"jobs" | "terminal" | "browser">(
+  const [tab, setTab] = useState<"jobs" | "terminal" | "browser" | "files">(
     hasBrowser ? "browser" : online ? "terminal" : "jobs",
   );
 
@@ -44,6 +45,14 @@ export function DeviceTabs({
             Browser
           </button>
         )}
+        {online && (
+          <button
+            className={`device-tab ${tab === "files" ? "device-tab-active" : ""}`}
+            onClick={() => setTab("files")}
+          >
+            Files
+          </button>
+        )}
       </div>
 
       {tab === "jobs" && (
@@ -58,6 +67,12 @@ export function DeviceTabs({
 
       {tab === "browser" && hasBrowser && (
         <DeviceBrowser deviceId={deviceId} />
+      )}
+
+      {tab === "files" && online && (
+        <div className="device-tab-content">
+          <DeviceFiles deviceId={deviceId} />
+        </div>
       )}
     </article>
   );

--- a/apps/hub-dashboard/src/components/device-tabs.tsx
+++ b/apps/hub-dashboard/src/components/device-tabs.tsx
@@ -24,6 +24,7 @@ export function DeviceTabs({
     <article className="surface-panel device-tabs-panel">
       <div className="device-tabs-header">
         <button
+          type="button"
           className={`device-tab ${tab === "jobs" ? "device-tab-active" : ""}`}
           onClick={() => setTab("jobs")}
         >
@@ -31,6 +32,7 @@ export function DeviceTabs({
         </button>
         {online && (
           <button
+            type="button"
             className={`device-tab ${tab === "terminal" ? "device-tab-active" : ""}`}
             onClick={() => setTab("terminal")}
           >
@@ -39,6 +41,7 @@ export function DeviceTabs({
         )}
         {hasBrowser && (
           <button
+            type="button"
             className={`device-tab ${tab === "browser" ? "device-tab-active" : ""}`}
             onClick={() => setTab("browser")}
           >
@@ -47,6 +50,7 @@ export function DeviceTabs({
         )}
         {online && (
           <button
+            type="button"
             className={`device-tab ${tab === "files" ? "device-tab-active" : ""}`}
             onClick={() => setTab("files")}
           >

--- a/apps/hub-dashboard/src/lib/file-ops-client.ts
+++ b/apps/hub-dashboard/src/lib/file-ops-client.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "buffer";
+import { buildProxyUrl } from "@/lib/hub-paths";
 import {
   FileRequest,
   FileResponse,
@@ -31,7 +32,7 @@ export class FileOpsError extends Error {
 }
 
 function proxyUrl(deviceId: string): string {
-  return `/api/proxy/api/devices/${encodeURIComponent(deviceId)}/files`;
+  return buildProxyUrl(`/api/devices/${encodeURIComponent(deviceId)}/files`);
 }
 
 function newRequestId(): string {
@@ -71,6 +72,14 @@ async function sendRequest(deviceId: string, req: FileRequest): Promise<FileResp
       }
     }
     throw new FileOpsError(code, message, res.status);
+  }
+  const contentType = res.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().startsWith("application/x-protobuf")) {
+    throw new FileOpsError(
+      "unexpected_response",
+      `Proxy returned ${res.status} with non-protobuf content-type "${contentType}".`,
+      res.status,
+    );
   }
   const raw = new Uint8Array(await res.arrayBuffer());
   const resp = FileResponse.decode(raw);

--- a/apps/hub-dashboard/src/lib/file-ops-client.ts
+++ b/apps/hub-dashboard/src/lib/file-ops-client.ts
@@ -10,6 +10,7 @@ import {
   FileReadImageResult,
   FileReadBinaryResult,
   FileWriteResult,
+  DeleteMode,
   fileErrorCodeToJSON,
 } from "@ahandai/proto";
 
@@ -18,7 +19,7 @@ if (typeof globalThis.Buffer === "undefined") {
   (globalThis as { Buffer: typeof Buffer }).Buffer = Buffer;
 }
 
-const MAX_INLINE_WRITE_BYTES = 1_048_576;
+export const MAX_INLINE_WRITE_BYTES = 1_048_576;
 
 export class FileOpsError extends Error {
   readonly code: string;
@@ -183,7 +184,10 @@ export async function readBinary(
       path: args.path,
       byteOffset: 0,
       byteLength: 0,
-      maxBytes: args.maxBytes ?? MAX_INLINE_WRITE_BYTES,
+      // Only pass maxBytes if the caller explicitly set one; otherwise let the
+      // daemon use its policy budget. Previously we defaulted to 1 MiB which
+      // silently truncated downloads of larger files with no user indication.
+      maxBytes: args.maxBytes,
       noFollowSymlink: false,
     },
   });
@@ -225,7 +229,10 @@ export async function deleteFile(
     delete: {
       path: args.path,
       recursive: args.recursive ?? false,
-      mode: 0, // DELETE_MODE_UNSPECIFIED — daemon picks safe default
+      // Proto enum has only TRASH (0) and PERMANENT (1); the default-0-wire
+      // value would silently route through the daemon's trash path. The UI
+      // button says "Delete" (not "Move to Trash"), so send PERMANENT.
+      mode: DeleteMode.DELETE_MODE_PERMANENT,
       noFollowSymlink: false,
     },
   });

--- a/apps/hub-dashboard/src/lib/file-ops-client.ts
+++ b/apps/hub-dashboard/src/lib/file-ops-client.ts
@@ -1,0 +1,261 @@
+import { Buffer } from "buffer";
+import {
+  FileRequest,
+  FileResponse,
+  FileListResult,
+  FileMkdirResult,
+  FileDeleteResult,
+  FileReadTextResult,
+  FileReadImageResult,
+  FileReadBinaryResult,
+  FileWriteResult,
+  fileErrorCodeToJSON,
+} from "@ahandai/proto";
+
+// Polyfill Buffer for ts-proto generated code (Next.js 16 does not polyfill it)
+if (typeof globalThis.Buffer === "undefined") {
+  (globalThis as { Buffer: typeof Buffer }).Buffer = Buffer;
+}
+
+const MAX_INLINE_WRITE_BYTES = 1_048_576;
+
+export class FileOpsError extends Error {
+  readonly code: string;
+  readonly httpStatus: number;
+  constructor(code: string, message: string, httpStatus: number) {
+    super(message);
+    this.name = "FileOpsError";
+    this.code = code;
+    this.httpStatus = httpStatus;
+  }
+}
+
+function proxyUrl(deviceId: string): string {
+  return `/api/proxy/api/devices/${encodeURIComponent(deviceId)}/files`;
+}
+
+function newRequestId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `req-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+}
+
+async function sendRequest(deviceId: string, req: FileRequest): Promise<FileResponse> {
+  const body = FileRequest.encode(req).finish();
+  const res = await fetch(proxyUrl(deviceId), {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-protobuf",
+      accept: "application/x-protobuf",
+    },
+    body,
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    let code = `http_${res.status}`;
+    let message = `Hub returned HTTP ${res.status}`;
+    try {
+      const envelope = (await res.clone().json()) as {
+        error?: { code?: string; message?: string };
+      };
+      if (envelope?.error) {
+        code = envelope.error.code ?? code;
+        message = envelope.error.message ?? message;
+      }
+    } catch {
+      try {
+        message = (await res.text()) || message;
+      } catch {
+        // swallow — keep default
+      }
+    }
+    throw new FileOpsError(code, message, res.status);
+  }
+  const raw = new Uint8Array(await res.arrayBuffer());
+  const resp = FileResponse.decode(raw);
+  if (resp.error) {
+    throw new FileOpsError(
+      fileErrorCodeToJSON(resp.error.code),
+      resp.error.message || "file operation failed",
+      200,
+    );
+  }
+  return resp;
+}
+
+export interface ListFilesArgs {
+  path: string;
+  includeHidden?: boolean;
+  maxResults?: number;
+  offset?: number;
+}
+
+export async function listFiles(deviceId: string, args: ListFilesArgs): Promise<FileListResult> {
+  const req = FileRequest.fromPartial({
+    requestId: newRequestId(),
+    list: {
+      path: args.path,
+      includeHidden: args.includeHidden ?? false,
+      maxResults: args.maxResults,
+      offset: args.offset,
+    },
+  });
+  const resp = await sendRequest(deviceId, req);
+  if (!resp.list) {
+    throw new FileOpsError("malformed_response", "list response missing", 200);
+  }
+  return resp.list;
+}
+
+export interface ReadTextArgs {
+  path: string;
+  maxLines?: number;
+  maxBytes?: number;
+}
+
+export async function readText(
+  deviceId: string,
+  args: ReadTextArgs,
+): Promise<FileReadTextResult> {
+  const req = FileRequest.fromPartial({
+    requestId: newRequestId(),
+    readText: {
+      path: args.path,
+      maxLines: args.maxLines ?? 2000,
+      maxBytes: args.maxBytes ?? 65_536,
+      lineNumbers: false,
+      noFollowSymlink: false,
+    },
+  });
+  const resp = await sendRequest(deviceId, req);
+  if (!resp.readText) {
+    throw new FileOpsError("malformed_response", "read_text response missing", 200);
+  }
+  return resp.readText;
+}
+
+export interface ReadImageArgs {
+  path: string;
+  maxBytes?: number;
+}
+
+export async function readImage(
+  deviceId: string,
+  args: ReadImageArgs,
+): Promise<FileReadImageResult> {
+  const req = FileRequest.fromPartial({
+    requestId: newRequestId(),
+    readImage: {
+      path: args.path,
+      maxBytes: args.maxBytes ?? 1_048_576,
+      noFollowSymlink: false,
+    },
+  });
+  const resp = await sendRequest(deviceId, req);
+  if (!resp.readImage) {
+    throw new FileOpsError("malformed_response", "read_image response missing", 200);
+  }
+  return resp.readImage;
+}
+
+export interface ReadBinaryArgs {
+  path: string;
+  maxBytes?: number;
+}
+
+export async function readBinary(
+  deviceId: string,
+  args: ReadBinaryArgs,
+): Promise<FileReadBinaryResult> {
+  const req = FileRequest.fromPartial({
+    requestId: newRequestId(),
+    readBinary: {
+      path: args.path,
+      byteOffset: 0,
+      byteLength: 0,
+      maxBytes: args.maxBytes ?? MAX_INLINE_WRITE_BYTES,
+      noFollowSymlink: false,
+    },
+  });
+  const resp = await sendRequest(deviceId, req);
+  if (!resp.readBinary) {
+    throw new FileOpsError("malformed_response", "read_binary response missing", 200);
+  }
+  return resp.readBinary;
+}
+
+export interface MkdirArgs {
+  path: string;
+  recursive?: boolean;
+}
+
+export async function mkdir(deviceId: string, args: MkdirArgs): Promise<FileMkdirResult> {
+  const req = FileRequest.fromPartial({
+    requestId: newRequestId(),
+    mkdir: { path: args.path, recursive: args.recursive ?? true },
+  });
+  const resp = await sendRequest(deviceId, req);
+  if (!resp.mkdir) {
+    throw new FileOpsError("malformed_response", "mkdir response missing", 200);
+  }
+  return resp.mkdir;
+}
+
+export interface DeleteArgs {
+  path: string;
+  recursive?: boolean;
+}
+
+export async function deleteFile(
+  deviceId: string,
+  args: DeleteArgs,
+): Promise<FileDeleteResult> {
+  const req = FileRequest.fromPartial({
+    requestId: newRequestId(),
+    delete: {
+      path: args.path,
+      recursive: args.recursive ?? false,
+      mode: 0, // DELETE_MODE_UNSPECIFIED — daemon picks safe default
+      noFollowSymlink: false,
+    },
+  });
+  const resp = await sendRequest(deviceId, req);
+  if (!resp.delete) {
+    throw new FileOpsError("malformed_response", "delete response missing", 200);
+  }
+  return resp.delete;
+}
+
+export interface WriteArgs {
+  path: string;
+  content: Uint8Array;
+  createParents?: boolean;
+}
+
+export async function writeFile(
+  deviceId: string,
+  args: WriteArgs,
+): Promise<FileWriteResult> {
+  if (args.content.byteLength > MAX_INLINE_WRITE_BYTES) {
+    throw new FileOpsError(
+      "content_too_large",
+      `Uploads larger than ${MAX_INLINE_WRITE_BYTES} bytes require the S3 path, which is not implemented yet.`,
+      0,
+    );
+  }
+  const req = FileRequest.fromPartial({
+    requestId: newRequestId(),
+    write: {
+      path: args.path,
+      createParents: args.createParents ?? true,
+      fullWrite: { content: Buffer.from(args.content) },
+      noFollowSymlink: false,
+    },
+  });
+  const resp = await sendRequest(deviceId, req);
+  if (!resp.write) {
+    throw new FileOpsError("malformed_response", "write response missing", 200);
+  }
+  return resp.write;
+}

--- a/apps/hub-dashboard/tests/auth-server.test.ts
+++ b/apps/hub-dashboard/tests/auth-server.test.ts
@@ -66,6 +66,40 @@ describe("POST /api/proxy/*", () => {
     expect(response.headers.get("content-type")).toBe("application/x-protobuf");
   });
 
+  it("strips upstream set-cookie from the proxied response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(new Uint8Array([0x01]), {
+        status: 200,
+        headers: {
+          "content-type": "application/x-protobuf",
+          "set-cookie": "hub_plant=evil; Path=/; HttpOnly",
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { POST: proxyPost } = await import("@/app/api/proxy/[...path]/route");
+    const request = new NextRequest(
+      "http://localhost/api/proxy/api/devices/dev-1/files",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-protobuf",
+          cookie: "ahand_hub_session=session-token",
+        },
+        body: new Uint8Array([0x00]),
+      },
+    );
+
+    const response = await proxyPost(request, {
+      params: Promise.resolve({ path: ["api", "devices", "dev-1", "files"] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(response.headers.get("content-type")).toBe("application/x-protobuf");
+  });
+
   it("returns 401 JSON envelope when session cookie is missing", async () => {
     const { POST: proxyPost } = await import("@/app/api/proxy/[...path]/route");
     const request = new NextRequest("http://localhost/api/proxy/api/devices/x/files", {

--- a/apps/hub-dashboard/tests/auth-server.test.ts
+++ b/apps/hub-dashboard/tests/auth-server.test.ts
@@ -7,6 +7,122 @@ import { POST as logoutPost } from "@/app/api/auth/logout/route";
 import { GET as proxyGet } from "@/app/api/proxy/[...path]/route";
 import { middleware } from "@/middleware";
 
+describe("POST /api/proxy/*", () => {
+  const HUB_BASE_URL = "http://hub.internal:8080";
+
+  beforeEach(() => {
+    vi.stubEnv("AHAND_HUB_BASE_URL", HUB_BASE_URL);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("forwards protobuf bodies with content-type preserved", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(new Uint8Array([0x0a, 0x03, 0x66, 0x6f, 0x6f]), {
+        status: 200,
+        headers: { "content-type": "application/x-protobuf" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { POST: proxyPost } = await import("@/app/api/proxy/[...path]/route");
+    const bodyBytes = new Uint8Array([0x08, 0x01, 0x12, 0x04, 0x74, 0x65, 0x73, 0x74]);
+    const request = new NextRequest(
+      "http://localhost/api/proxy/api/devices/dev-1/files",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-protobuf",
+          accept: "application/x-protobuf",
+          cookie: "ahand_hub_session=session-token",
+        },
+        body: bodyBytes,
+      },
+    );
+
+    const response = await proxyPost(request, {
+      params: Promise.resolve({ path: ["api", "devices", "dev-1", "files"] }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0];
+    expect(calledUrl).toBe(`${HUB_BASE_URL}/api/devices/dev-1/files`);
+    expect(calledInit.method).toBe("POST");
+    expect(calledInit.headers).toMatchObject({
+      authorization: "Bearer session-token",
+      "content-type": "application/x-protobuf",
+      accept: "application/x-protobuf",
+    });
+    const forwarded = new Uint8Array(
+      calledInit.body instanceof ArrayBuffer
+        ? calledInit.body
+        : (calledInit.body as Uint8Array).buffer,
+    );
+    expect(Array.from(forwarded)).toEqual(Array.from(bodyBytes));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/x-protobuf");
+  });
+
+  it("returns 401 JSON envelope when session cookie is missing", async () => {
+    const { POST: proxyPost } = await import("@/app/api/proxy/[...path]/route");
+    const request = new NextRequest("http://localhost/api/proxy/api/devices/x/files", {
+      method: "POST",
+      headers: { "content-type": "application/x-protobuf" },
+      body: new Uint8Array([0x00]),
+    });
+    const response = await proxyPost(request, {
+      params: Promise.resolve({ path: ["api", "devices", "x", "files"] }),
+    });
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.error.code).toBe("unauthorized");
+  });
+
+  it("returns 503 when AHAND_HUB_BASE_URL is missing", async () => {
+    vi.unstubAllEnvs();
+    const { POST: proxyPost } = await import("@/app/api/proxy/[...path]/route");
+    const request = new NextRequest("http://localhost/api/proxy/api/devices/x/files", {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-protobuf",
+        cookie: "ahand_hub_session=session-token",
+      },
+      body: new Uint8Array([0x00]),
+    });
+    const response = await proxyPost(request, {
+      params: Promise.resolve({ path: ["api", "devices", "x", "files"] }),
+    });
+    expect(response.status).toBe(503);
+    const body = await response.json();
+    expect(body.error.code).toBe("hub_unavailable");
+  });
+
+  it("returns 503 when the upstream fetch throws", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
+    );
+    const { POST: proxyPost } = await import("@/app/api/proxy/[...path]/route");
+    const request = new NextRequest("http://localhost/api/proxy/api/devices/x/files", {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-protobuf",
+        cookie: "ahand_hub_session=session-token",
+      },
+      body: new Uint8Array([0x00]),
+    });
+    const response = await proxyPost(request, {
+      params: Promise.resolve({ path: ["api", "devices", "x", "files"] }),
+    });
+    expect(response.status).toBe(503);
+    const body = await response.json();
+    expect(body.error.code).toBe("hub_unavailable");
+  });
+});
+
 const HUB_BASE_URL = "https://hub.example";
 
 describe("hub dashboard auth server flow", () => {

--- a/apps/hub-dashboard/tests/device-files.test.tsx
+++ b/apps/hub-dashboard/tests/device-files.test.tsx
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FileResponse, FileType } from "@ahandai/proto";
+
+import { DeviceFiles } from "@/components/device-files";
+
+function stubProto(resp: FileResponse) {
+  const bytes = FileResponse.encode(resp).finish();
+  (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+    new Response(bytes, {
+      status: 200,
+      headers: { "content-type": "application/x-protobuf" },
+    }),
+  );
+}
+
+function stubErrorEnvelope(code: string, message: string, status = 403) {
+  (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+    new Response(JSON.stringify({ error: { code, message } }), {
+      status,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+}
+
+describe("DeviceFiles", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("lists directory entries and shows dirs before files", async () => {
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        list: {
+          entries: [
+            { name: "readme.txt", fileType: FileType.FILE_TYPE_REGULAR, size: 12, modifiedMs: 0 },
+            { name: "src", fileType: FileType.FILE_TYPE_DIRECTORY, size: 0, modifiedMs: 0 },
+          ],
+          totalCount: 2,
+          hasMore: false,
+        },
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<DeviceFiles deviceId="dev-1" />);
+
+    await user.clear(screen.getByLabelText(/path/i));
+    await user.type(screen.getByLabelText(/path/i), "/home/user");
+    await user.click(screen.getByRole("button", { name: /open/i }));
+
+    const entries = await screen.findAllByRole("listitem");
+    expect(entries[0]).toHaveTextContent("src");
+    expect(entries[1]).toHaveTextContent("readme.txt");
+  });
+
+  it("displays 4xx error envelope from hub", async () => {
+    stubErrorEnvelope("POLICY_DENIED", "/etc/passwd is in dangerous_paths", 403);
+
+    const user = userEvent.setup();
+    render(<DeviceFiles deviceId="dev-1" />);
+
+    await user.clear(screen.getByLabelText(/path/i));
+    await user.type(screen.getByLabelText(/path/i), "/etc");
+    await user.click(screen.getByRole("button", { name: /open/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/POLICY_DENIED/);
+    expect(alert).toHaveTextContent(/dangerous_paths/);
+  });
+});

--- a/apps/hub-dashboard/tests/device-files.test.tsx
+++ b/apps/hub-dashboard/tests/device-files.test.tsx
@@ -110,7 +110,7 @@ describe("DeviceFiles", () => {
     const user = userEvent.setup();
     render(<DeviceFiles deviceId="dev-1" />);
     await user.click(screen.getByRole("button", { name: /open/i }));
-    const entry = await screen.findByRole("button", { name: /data\.bin/i });
+    const entry = await screen.findByRole("button", { name: /^file data\.bin$/i });
     await user.click(entry);
 
     expect(await screen.findByText(/binary file/i)).toBeInTheDocument();
@@ -148,11 +148,103 @@ describe("DeviceFiles", () => {
     const user = userEvent.setup();
     render(<DeviceFiles deviceId="dev-1" />);
     await user.click(screen.getByRole("button", { name: /open/i }));
-    const entry = await screen.findByRole("button", { name: /pic\.png/i });
+    const entry = await screen.findByRole("button", { name: /^file pic\.png$/i });
     await user.click(entry);
 
     const img = await screen.findByAltText("/tmp/pic.png");
     expect(img).toBeInstanceOf(HTMLImageElement);
     expect(img.getAttribute("src")).toMatch(/^data:image\/png;base64,/);
+  });
+
+  it("creates a new directory via mkdir", async () => {
+    // Initial list: empty dir.
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        list: { entries: [], totalCount: 0, hasMore: false },
+      }),
+    );
+    // mkdir result.
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        mkdir: { path: "/tmp/newfolder", alreadyExisted: false },
+      }),
+    );
+    // Re-list after mkdir: newfolder now present.
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        list: {
+          entries: [
+            { name: "newfolder", fileType: FileType.FILE_TYPE_DIRECTORY, size: 0, modifiedMs: 0 },
+          ],
+          totalCount: 1,
+          hasMore: false,
+        },
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<DeviceFiles deviceId="dev-1" />);
+    await user.click(screen.getByRole("button", { name: /^open$/i }));
+    await screen.findByText(/empty directory/i);
+
+    await user.click(screen.getByRole("button", { name: /new folder/i }));
+    const nameInput = await screen.findByLabelText(/folder name/i);
+    await user.type(nameInput, "newfolder");
+    await user.click(screen.getByRole("button", { name: /^create$/i }));
+
+    expect(await screen.findByText("newfolder")).toBeInTheDocument();
+  });
+
+  it("shows a confirm dialog before delete and respects Cancel", async () => {
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        list: {
+          entries: [
+            { name: "old.txt", fileType: FileType.FILE_TYPE_FILE, size: 3, modifiedMs: 0 },
+          ],
+          totalCount: 1,
+          hasMore: false,
+        },
+      }),
+    );
+    const user = userEvent.setup();
+    render(<DeviceFiles deviceId="dev-1" />);
+    await user.click(screen.getByRole("button", { name: /^open$/i }));
+    await screen.findByText("old.txt");
+
+    await user.click(screen.getByRole("button", { name: /^delete old\.txt$/i }));
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveTextContent(/delete/i);
+    expect(screen.getByLabelText(/recursive/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+    // Only the initial list fetch — no delete call.
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+  });
+
+  it("rejects uploads larger than 1 MiB without calling the network", async () => {
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        list: { entries: [], totalCount: 0, hasMore: false },
+      }),
+    );
+    const user = userEvent.setup();
+    render(<DeviceFiles deviceId="dev-1" />);
+    await user.click(screen.getByRole("button", { name: /^open$/i }));
+    await screen.findByText(/empty directory/i);
+
+    const big = new File([new Uint8Array(1_048_577)], "big.bin", { type: "application/octet-stream" });
+    const uploadInput = screen.getByLabelText(/upload file/i) as HTMLInputElement;
+    await user.upload(uploadInput, big);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/S3/i);
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
   });
 });

--- a/apps/hub-dashboard/tests/device-files.test.tsx
+++ b/apps/hub-dashboard/tests/device-files.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { Buffer } from "buffer";
 import { FileResponse, FileType } from "@ahandai/proto";
 
 import { DeviceFiles } from "@/components/device-files";
@@ -73,5 +74,85 @@ describe("DeviceFiles", () => {
     const alert = await screen.findByRole("alert");
     expect(alert).toHaveTextContent(/POLICY_DENIED/);
     expect(alert).toHaveTextContent(/dangerous_paths/);
+  });
+
+  it("shows a 'Binary file' placeholder when readText returns NUL-containing content", async () => {
+    // Seed the initial list.
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        list: {
+          entries: [
+            { name: "data.bin", fileType: FileType.FILE_TYPE_FILE, size: 3, modifiedMs: 0 },
+          ],
+          totalCount: 1,
+          hasMore: false,
+        },
+      }),
+    );
+    // readText succeeds but returns a line containing a NUL byte.
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        readText: {
+          lines: [
+            { content: "\0garble", lineNumber: 1, truncated: false, remainingBytes: 0 },
+          ],
+          stopReason: 4,
+          remainingBytes: 0,
+          totalFileBytes: 3,
+          totalLines: 1,
+          detectedEncoding: "utf-8",
+        },
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<DeviceFiles deviceId="dev-1" />);
+    await user.click(screen.getByRole("button", { name: /open/i }));
+    const entry = await screen.findByRole("button", { name: /data\.bin/i });
+    await user.click(entry);
+
+    expect(await screen.findByText(/binary file/i)).toBeInTheDocument();
+  });
+
+  it("renders an image via readImage when the entry has an image extension", async () => {
+    // Seed the initial list.
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        list: {
+          entries: [
+            { name: "pic.png", fileType: FileType.FILE_TYPE_FILE, size: 4, modifiedMs: 0 },
+          ],
+          totalCount: 1,
+          hasMore: false,
+        },
+      }),
+    );
+    // readImage returns a small PNG payload.
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        readImage: {
+          content: Buffer.from(new Uint8Array([0x89, 0x50, 0x4e, 0x47])),
+          format: 2, // IMAGE_FORMAT_PNG
+          width: 8,
+          height: 8,
+          originalBytes: 4,
+          outputBytes: 4,
+        },
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<DeviceFiles deviceId="dev-1" />);
+    await user.click(screen.getByRole("button", { name: /open/i }));
+    const entry = await screen.findByRole("button", { name: /pic\.png/i });
+    await user.click(entry);
+
+    const img = await screen.findByAltText("/tmp/pic.png");
+    expect(img).toBeInstanceOf(HTMLImageElement);
+    expect(img.getAttribute("src")).toMatch(/^data:image\/png;base64,/);
   });
 });

--- a/apps/hub-dashboard/tests/device-files.test.tsx
+++ b/apps/hub-dashboard/tests/device-files.test.tsx
@@ -40,7 +40,7 @@ describe("DeviceFiles", () => {
         requestId: "r",
         list: {
           entries: [
-            { name: "readme.txt", fileType: FileType.FILE_TYPE_REGULAR, size: 12, modifiedMs: 0 },
+            { name: "readme.txt", fileType: FileType.FILE_TYPE_FILE, size: 12, modifiedMs: 0 },
             { name: "src", fileType: FileType.FILE_TYPE_DIRECTORY, size: 0, modifiedMs: 0 },
           ],
           totalCount: 2,

--- a/apps/hub-dashboard/tests/device-files.test.tsx
+++ b/apps/hub-dashboard/tests/device-files.test.tsx
@@ -227,6 +227,34 @@ describe("DeviceFiles", () => {
     expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
   });
 
+  it("closes the delete dialog when Escape is pressed", async () => {
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        list: {
+          entries: [
+            { name: "old.txt", fileType: FileType.FILE_TYPE_FILE, size: 3, modifiedMs: 0 },
+          ],
+          totalCount: 1,
+          hasMore: false,
+        },
+      }),
+    );
+    const user = userEvent.setup();
+    render(<DeviceFiles deviceId="dev-1" />);
+    await user.click(screen.getByRole("button", { name: /^open$/i }));
+    await screen.findByText("old.txt");
+
+    await user.click(screen.getByRole("button", { name: /^delete old\.txt$/i }));
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    // Only the initial list fetch — Esc did not issue a network call.
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+  });
+
   it("rejects uploads larger than 1 MiB without calling the network", async () => {
     stubProto(
       FileResponse.fromPartial({

--- a/apps/hub-dashboard/tests/device-files.test.tsx
+++ b/apps/hub-dashboard/tests/device-files.test.tsx
@@ -465,4 +465,84 @@ describe("DeviceFiles", () => {
 
     clickSpy.mockRestore();
   });
+
+  it("navigates to a parent directory when a breadcrumb is clicked", async () => {
+    // First list: /var/log
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        list: {
+          entries: [
+            { name: "syslog", fileType: FileType.FILE_TYPE_FILE, size: 0, modifiedMs: 0 },
+          ],
+          totalCount: 1,
+          hasMore: false,
+        },
+      }),
+    );
+    // Second list (after clicking "var" crumb): /var
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        list: {
+          entries: [
+            { name: "log", fileType: FileType.FILE_TYPE_DIRECTORY, size: 0, modifiedMs: 0 },
+          ],
+          totalCount: 1,
+          hasMore: false,
+        },
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<DeviceFiles deviceId="dev-1" />);
+    await user.clear(screen.getByLabelText(/path/i));
+    await user.type(screen.getByLabelText(/path/i), "/var/log");
+    await user.click(screen.getByRole("button", { name: /^open$/i }));
+    await screen.findByText("syslog");
+
+    // Click the "var" breadcrumb.
+    const nav = screen.getByRole("navigation", { name: /breadcrumbs/i });
+    await user.click(within(nav).getByRole("button", { name: /^var$/i }));
+
+    // After the second fetch resolves, /var's entry ("log") should appear.
+    expect(await screen.findByText("log")).toBeInTheDocument();
+
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    // 2 list calls: /var/log, then /var.
+    expect(fetchMock.mock.calls).toHaveLength(2);
+    const parentBody = fetchMock.mock.calls[1][1].body as Uint8Array;
+    const parentReq = FileRequest.decode(parentBody);
+    expect(parentReq.list?.path).toBe("/var");
+  });
+
+  it("records debug entries for successful ops and exposes them via the panel", async () => {
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        list: {
+          entries: [
+            { name: "a.txt", fileType: FileType.FILE_TYPE_FILE, size: 0, modifiedMs: 0 },
+          ],
+          totalCount: 1,
+          hasMore: false,
+        },
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<DeviceFiles deviceId="dev-1" />);
+    await user.click(screen.getByRole("button", { name: /^open$/i }));
+    await screen.findByText("a.txt");
+
+    // Debug toggle starts at 1 entry (the list call we just made).
+    const toggle = screen.getByRole("button", { name: /show debug/i });
+    expect(toggle).toHaveTextContent("(1)");
+    await user.click(toggle);
+
+    // Panel shows the operation row.
+    const panel = await screen.findByLabelText(/files debug log/i);
+    expect(within(panel).getByText("list")).toBeInTheDocument();
+    expect(within(panel).getByText(/1 entries/i)).toBeInTheDocument();
+  });
 });

--- a/apps/hub-dashboard/tests/device-files.test.tsx
+++ b/apps/hub-dashboard/tests/device-files.test.tsx
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Buffer } from "buffer";
-import { FileResponse, FileType } from "@ahandai/proto";
+import { FileRequest, FileResponse, FileType } from "@ahandai/proto";
 
 import { DeviceFiles } from "@/components/device-files";
 
@@ -274,5 +274,195 @@ describe("DeviceFiles", () => {
     const alert = await screen.findByRole("alert");
     expect(alert).toHaveTextContent(/S3/i);
     expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+  });
+
+  it("deletes an entry after confirm and re-lists the directory", async () => {
+    // Initial list: one file.
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        list: {
+          entries: [
+            { name: "old.txt", fileType: FileType.FILE_TYPE_FILE, size: 3, modifiedMs: 0 },
+          ],
+          totalCount: 1,
+          hasMore: false,
+        },
+      }),
+    );
+    // delete response.
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        delete: { path: "/tmp/old.txt", mode: 1, itemsDeleted: 1 },
+      }),
+    );
+    // Re-list: now empty.
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        list: { entries: [], totalCount: 0, hasMore: false },
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<DeviceFiles deviceId="dev-1" />);
+    await user.click(screen.getByRole("button", { name: /^open$/i }));
+    await screen.findByText("old.txt");
+
+    await user.click(screen.getByRole("button", { name: /^delete old\.txt$/i }));
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    // Click the Delete button INSIDE the dialog (aria-label is "Delete old.txt"
+    // on the entry button; the dialog's Delete button has text "Delete").
+    const dialog = screen.getByRole("dialog");
+    const dialogDelete = within(dialog).getByRole("button", { name: /^delete$/i });
+    await user.click(dialogDelete);
+
+    expect(await screen.findByText(/empty directory/i)).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    // 3 network calls: initial list + delete + re-list.
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    expect(fetchMock.mock.calls).toHaveLength(3);
+    // The second call was the delete — decode its body to verify the
+    // PERMANENT mode (value 1) is sent, not TRASH (0).
+    const deleteBody = fetchMock.mock.calls[1][1].body as Uint8Array;
+    const deleteReq = FileRequest.decode(deleteBody);
+    expect(deleteReq.delete?.path).toBe("/tmp/old.txt");
+    expect(deleteReq.delete?.mode).toBe(1); // DELETE_MODE_PERMANENT
+  });
+
+  it("uploads a small file, posts FullWrite.content, and re-lists", async () => {
+    // Initial list: empty.
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        list: { entries: [], totalCount: 0, hasMore: false },
+      }),
+    );
+    // write response.
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        write: { path: "/tmp/note.txt", action: 0, bytesWritten: 5, finalSize: 5 },
+      }),
+    );
+    // Re-list: file now present.
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        list: {
+          entries: [
+            { name: "note.txt", fileType: FileType.FILE_TYPE_FILE, size: 5, modifiedMs: 0 },
+          ],
+          totalCount: 1,
+          hasMore: false,
+        },
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<DeviceFiles deviceId="dev-1" />);
+    await user.click(screen.getByRole("button", { name: /^open$/i }));
+    await screen.findByText(/empty directory/i);
+
+    // Directory-traversal filename — the component must strip to basename
+    // before sending the target path.
+    const smallBytes = new Uint8Array([1, 2, 3, 4, 5]);
+    const small = new File([smallBytes], "../../evil.txt", {
+      type: "application/octet-stream",
+    });
+    // jsdom's File implementation does not provide arrayBuffer(); shim it.
+    Object.defineProperty(small, "arrayBuffer", {
+      value: async () => smallBytes.buffer.slice(
+        smallBytes.byteOffset,
+        smallBytes.byteOffset + smallBytes.byteLength,
+      ),
+    });
+    const uploadInput = screen.getByLabelText(/upload file/i) as HTMLInputElement;
+    await user.upload(uploadInput, small);
+
+    expect(await screen.findByText("note.txt")).toBeInTheDocument();
+
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    // 3 calls: initial list + write + re-list.
+    expect(fetchMock.mock.calls).toHaveLength(3);
+    const writeBody = fetchMock.mock.calls[1][1].body as Uint8Array;
+    const writeReq = FileRequest.decode(writeBody);
+    // basename("../../evil.txt") → "evil.txt"; joined with "/tmp" → "/tmp/evil.txt"
+    expect(writeReq.write?.path).toBe("/tmp/evil.txt");
+    expect(writeReq.write?.createParents).toBe(true);
+    expect(writeReq.write?.fullWrite?.content).toBeDefined();
+  });
+
+  it("downloads a file by calling readBinary and triggering an anchor click", async () => {
+    // Initial list: one file.
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        list: {
+          entries: [
+            { name: "log.txt", fileType: FileType.FILE_TYPE_FILE, size: 4, modifiedMs: 0 },
+          ],
+          totalCount: 1,
+          hasMore: false,
+        },
+      }),
+    );
+    // readBinary response.
+    const payload = Buffer.from(new Uint8Array([0x68, 0x69, 0x21, 0x0a])); // "hi!\n"
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        readBinary: {
+          content: payload,
+          byteOffset: 0,
+          bytesRead: 4,
+          totalFileBytes: 4,
+          remainingBytes: 0,
+        },
+      }),
+    );
+
+    // jsdom doesn't implement URL.createObjectURL / revokeObjectURL; stub them.
+    const createObjectURL = vi.fn(() => "blob:mock-url");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL,
+      revokeObjectURL,
+    });
+
+    // Spy on anchor click so we can verify the download was triggered.
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    const user = userEvent.setup();
+    render(<DeviceFiles deviceId="dev-1" />);
+    await user.click(screen.getByRole("button", { name: /^open$/i }));
+    await screen.findByText("log.txt");
+
+    await user.click(screen.getByRole("button", { name: /^download log\.txt$/i }));
+
+    // Anchor click fired → download triggered.
+    await vi.waitFor(() => {
+      expect(clickSpy).toHaveBeenCalled();
+    });
+    expect(createObjectURL).toHaveBeenCalled();
+    // revokeObjectURL is scheduled via setTimeout(0) — flush the task.
+    await vi.waitFor(() => {
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+    });
+
+    // 2 network calls: initial list + readBinary.
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    expect(fetchMock.mock.calls).toHaveLength(2);
+    const readBody = fetchMock.mock.calls[1][1].body as Uint8Array;
+    const readReq = FileRequest.decode(readBody);
+    expect(readReq.readBinary?.path).toBe("/tmp/log.txt");
+    // maxBytes must NOT be clamped to the 1 MiB write cap — should be unset
+    // so the daemon uses its policy budget and we never silently truncate.
+    expect(readReq.readBinary?.maxBytes ?? 0).toBe(0);
+
+    clickSpy.mockRestore();
   });
 });

--- a/apps/hub-dashboard/tests/file-ops-client.test.ts
+++ b/apps/hub-dashboard/tests/file-ops-client.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FileRequest, FileResponse, FileType } from "@ahandai/proto";
+
+import {
+  FileOpsError,
+  listFiles,
+  mkdir,
+  readText,
+  writeFile,
+} from "@/lib/file-ops-client";
+
+describe("file-ops-client", () => {
+  const deviceId = "dev-1";
+  const expectedUrl = "/api/proxy/api/devices/dev-1/files";
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function respondWith(resp: FileResponse) {
+    const bytes = FileResponse.encode(resp).finish();
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(bytes, {
+        status: 200,
+        headers: { "content-type": "application/x-protobuf" },
+      }),
+    );
+  }
+
+  it("listFiles encodes FileList and decodes FileListResult", async () => {
+    respondWith(
+      FileResponse.fromPartial({
+        requestId: "req-1",
+        list: {
+          entries: [
+            {
+              name: "hello.txt",
+              fileType: FileType.FILE_TYPE_REGULAR,
+              size: 42,
+              modifiedMs: 1_700_000_000_000,
+            },
+          ],
+          totalCount: 1,
+          hasMore: false,
+        },
+      }),
+    );
+
+    const result = await listFiles(deviceId, { path: "/tmp" });
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].name).toBe("hello.txt");
+
+    const mock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    expect(mock).toHaveBeenCalledWith(
+      expectedUrl,
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "content-type": "application/x-protobuf",
+          accept: "application/x-protobuf",
+        }),
+      }),
+    );
+    const body = mock.mock.calls[0][1].body as Uint8Array;
+    const decoded = FileRequest.decode(body);
+    expect(decoded.list?.path).toBe("/tmp");
+  });
+
+  it("maps HTTP 4xx JSON envelope to FileOpsError", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: { code: "POLICY_DENIED", message: "/etc/passwd is in dangerous_paths" },
+        }),
+        { status: 403, headers: { "content-type": "application/json" } },
+      ),
+    );
+    await expect(listFiles(deviceId, { path: "/etc" })).rejects.toMatchObject({
+      code: "POLICY_DENIED",
+      message: expect.stringContaining("dangerous_paths"),
+      httpStatus: 403,
+    });
+  });
+
+  it("maps FileResponse.error (200 OK with proto error) to FileOpsError", async () => {
+    respondWith(
+      FileResponse.fromPartial({
+        requestId: "req-1",
+        error: {
+          code: 12, // FILE_ERROR_CODE_POLICY_DENIED
+          message: "blocked by policy",
+          path: "/etc/shadow",
+        },
+      }),
+    );
+    await expect(readText(deviceId, { path: "/etc/shadow" })).rejects.toMatchObject({
+      code: "FILE_ERROR_CODE_POLICY_DENIED",
+      message: expect.stringContaining("blocked"),
+      httpStatus: 200,
+    });
+  });
+
+  it("mkdir succeeds and decodes result", async () => {
+    respondWith(
+      FileResponse.fromPartial({
+        requestId: "req-1",
+        mkdir: { path: "/tmp/new", alreadyExisted: false },
+      }),
+    );
+    const r = await mkdir(deviceId, { path: "/tmp/new", recursive: true });
+    expect(r.path).toBe("/tmp/new");
+    expect(r.alreadyExisted).toBe(false);
+  });
+
+  it("writeFile rejects payloads > 1 MiB with content_too_large", async () => {
+    const big = new Uint8Array(1_048_577);
+    await expect(
+      writeFile(deviceId, { path: "/tmp/big.bin", content: big }),
+    ).rejects.toMatchObject({
+      code: "content_too_large",
+      message: expect.stringContaining("S3"),
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("FileOpsError is an Error subclass", () => {
+    const e = new FileOpsError("X", "y", 400);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe("X");
+    expect(e.httpStatus).toBe(400);
+  });
+});

--- a/apps/hub-dashboard/tests/file-ops-client.test.ts
+++ b/apps/hub-dashboard/tests/file-ops-client.test.ts
@@ -138,8 +138,7 @@ describe("file-ops-client", () => {
   });
 
   it("readText returns decoded text lines", async () => {
-    const { readText } = await import("@/lib/file-ops-client");
-    respondWith(
+respondWith(
       FileResponse.fromPartial({
         requestId: "r",
         readText: {
@@ -161,8 +160,7 @@ describe("file-ops-client", () => {
   });
 
   it("readBinary returns bytes payload", async () => {
-    const { readBinary } = await import("@/lib/file-ops-client");
-    const payload = new Uint8Array([1, 2, 3, 4]);
+const payload = new Uint8Array([1, 2, 3, 4]);
     respondWith(
       FileResponse.fromPartial({
         requestId: "r",
@@ -181,8 +179,7 @@ describe("file-ops-client", () => {
   });
 
   it("readImage returns image content and format", async () => {
-    const { readImage } = await import("@/lib/file-ops-client");
-    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
     respondWith(
       FileResponse.fromPartial({
         requestId: "r",
@@ -203,8 +200,7 @@ describe("file-ops-client", () => {
   });
 
   it("deleteFile sends a FileDelete request with recursive flag and decodes result", async () => {
-    const { deleteFile } = await import("@/lib/file-ops-client");
-    respondWith(
+respondWith(
       FileResponse.fromPartial({
         requestId: "r",
         delete: { path: "/tmp/a", mode: 0, itemsDeleted: 1 },

--- a/apps/hub-dashboard/tests/file-ops-client.test.ts
+++ b/apps/hub-dashboard/tests/file-ops-client.test.ts
@@ -219,6 +219,9 @@ describe("file-ops-client", () => {
     const decoded = FileRequest.decode(body);
     expect(decoded.delete?.path).toBe("/tmp/a");
     expect(decoded.delete?.recursive).toBe(true);
+    // Default-0 is DELETE_MODE_TRASH on the daemon; the client MUST send
+    // DELETE_MODE_PERMANENT (1) since the UI button says "Delete".
+    expect(decoded.delete?.mode).toBe(1);
   });
 
   it("rejects when the proxy returns 200 with non-protobuf content-type", async () => {

--- a/apps/hub-dashboard/tests/file-ops-client.test.ts
+++ b/apps/hub-dashboard/tests/file-ops-client.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Buffer } from "buffer";
 import { FileRequest, FileResponse, FileType } from "@ahandai/proto";
 
 import {
@@ -6,6 +7,9 @@ import {
   listFiles,
   mkdir,
   readText,
+  readBinary,
+  readImage,
+  deleteFile,
   writeFile,
 } from "@/lib/file-ops-client";
 
@@ -131,5 +135,102 @@ describe("file-ops-client", () => {
     expect(e).toBeInstanceOf(Error);
     expect(e.code).toBe("X");
     expect(e.httpStatus).toBe(400);
+  });
+
+  it("readText returns decoded text lines", async () => {
+    const { readText } = await import("@/lib/file-ops-client");
+    respondWith(
+      FileResponse.fromPartial({
+        requestId: "r",
+        readText: {
+          lines: [
+            { content: "hello", lineNumber: 1, truncated: false, remainingBytes: 0 },
+            { content: "world", lineNumber: 2, truncated: false, remainingBytes: 0 },
+          ],
+          stopReason: 4, // STOP_REASON_FILE_END
+          remainingBytes: 0,
+          totalFileBytes: 11,
+          totalLines: 2,
+          detectedEncoding: "utf-8",
+        },
+      }),
+    );
+    const r = await readText(deviceId, { path: "/tmp/a.txt" });
+    expect(r.lines).toHaveLength(2);
+    expect(r.lines[0].content).toBe("hello");
+  });
+
+  it("readBinary returns bytes payload", async () => {
+    const { readBinary } = await import("@/lib/file-ops-client");
+    const payload = new Uint8Array([1, 2, 3, 4]);
+    respondWith(
+      FileResponse.fromPartial({
+        requestId: "r",
+        readBinary: {
+          content: Buffer.from(payload),
+          byteOffset: 0,
+          bytesRead: payload.length,
+          totalFileBytes: payload.length,
+          remainingBytes: 0,
+        },
+      }),
+    );
+    const r = await readBinary(deviceId, { path: "/tmp/a.bin" });
+    expect(r.bytesRead).toBe(4);
+    expect(Array.from(r.content)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("readImage returns image content and format", async () => {
+    const { readImage } = await import("@/lib/file-ops-client");
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    respondWith(
+      FileResponse.fromPartial({
+        requestId: "r",
+        readImage: {
+          content: Buffer.from(png),
+          format: 2, // IMAGE_FORMAT_PNG
+          width: 8,
+          height: 8,
+          originalBytes: 4,
+          outputBytes: 4,
+        },
+      }),
+    );
+    const r = await readImage(deviceId, { path: "/tmp/a.png" });
+    expect(r.format).toBe(2);
+    expect(r.width).toBe(8);
+    expect(Array.from(r.content)).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+
+  it("deleteFile sends a FileDelete request with recursive flag and decodes result", async () => {
+    const { deleteFile } = await import("@/lib/file-ops-client");
+    respondWith(
+      FileResponse.fromPartial({
+        requestId: "r",
+        delete: { path: "/tmp/a", mode: 0, itemsDeleted: 1 },
+      }),
+    );
+    const r = await deleteFile(deviceId, { path: "/tmp/a", recursive: true });
+    expect(r.path).toBe("/tmp/a");
+    expect(r.itemsDeleted).toBe(1);
+
+    const mock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    const body = mock.mock.calls.at(-1)?.[1]?.body as Uint8Array;
+    const decoded = FileRequest.decode(body);
+    expect(decoded.delete?.path).toBe("/tmp/a");
+    expect(decoded.delete?.recursive).toBe(true);
+  });
+
+  it("rejects when the proxy returns 200 with non-protobuf content-type", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response("<html>login</html>", {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    await expect(listFiles(deviceId, { path: "/tmp" })).rejects.toMatchObject({
+      code: "unexpected_response",
+      httpStatus: 200,
+    });
   });
 });

--- a/apps/hub-dashboard/tests/file-ops-client.test.ts
+++ b/apps/hub-dashboard/tests/file-ops-client.test.ts
@@ -42,7 +42,7 @@ describe("file-ops-client", () => {
           entries: [
             {
               name: "hello.txt",
-              fileType: FileType.FILE_TYPE_REGULAR,
+              fileType: FileType.FILE_TYPE_FILE,
               size: 42,
               modifiedMs: 1_700_000_000_000,
             },

--- a/deploy/hub/Dockerfile
+++ b/deploy/hub/Dockerfile
@@ -40,6 +40,9 @@ COPY crates crates
 COPY proto proto
 
 RUN pnpm install --frozen-lockfile
+# hub-dashboard imports @ahandai/proto, which exposes its types via dist/.
+# Build proto-ts first so the dashboard's next build can resolve it.
+RUN pnpm --filter @ahandai/proto build
 RUN pnpm --filter @ahand/hub-dashboard build
 
 FROM node:${NODE_VERSION} AS dashboard

--- a/docs/superpowers/plans/2026-04-30-dashboard-files-tab.md
+++ b/docs/superpowers/plans/2026-04-30-dashboard-files-tab.md
@@ -1,0 +1,2063 @@
+# Dashboard Files Tab Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Files" tab to the hub-dashboard device detail page so operators can browse, view, create, delete, download, and upload files on a connected device via the existing `POST /api/devices/{id}/files` protobuf endpoint.
+
+**Architecture:** A new client component `DeviceFiles` drives the flow. It calls `POST /api/proxy/api/devices/{id}/files` with a protobuf-encoded `FileRequest` body (`application/x-protobuf`) and decodes the `FileResponse`. A thin `file-ops-client.ts` helper handles encode/decode, fetch, and the 4xx/5xx JSON-error-envelope path. The dashboard proxy route gains a POST handler that passes body bytes + `content-type` through to the hub. The backend is already v1 — no hub changes.
+
+**Tech Stack:** Next.js 16 (App Router, React 19), TypeScript, `@ahandai/proto` (ts-proto generated), vitest + @testing-library/react + jsdom. No new UI libraries — reuse existing `.surface-panel` / `.browser-*` / Tailwind utility patterns from `globals.css`.
+
+**Spec:** Inline in PR description (no separate spec file — this is a UI-only feature aligned with already-shipped backend).
+
+---
+
+## Scope & Constraints
+
+**In scope (v1):**
+- `list`, `mkdir`, `delete` (with `recursive` toggle)
+- `read_text` for text files, `read_image` for images, binary placeholder
+- `download` (via `read_binary` → Blob)
+- `upload` via `FullWrite.content` (inline) with **hard 1 MiB ceiling** — anything larger shows "S3 path not implemented yet" (PR #22 tracks the S3 e2e flow per `docs/superpowers/specs/2026-04-12-device-file-operations-design.md`)
+
+**Out of scope:**
+- `edit` / `chmod` / `copy` / `move` / `create_symlink` — no UI
+- `stat` / `glob` — no dedicated UI (list is sufficient for v1)
+- Permission / approval UI — server-side STRICT-mode handles approvals; 4xx error envelope is enough
+- Large-file S3 transfer — blocked on PR #22
+- Client-side path validation — backend `file_policy` is authoritative, we only display its errors
+
+---
+
+## File Structure
+
+### New files
+| File | Responsibility |
+|------|---------------|
+| `apps/hub-dashboard/src/lib/file-ops-client.ts` | Typed request builders + encode/decode + fetch + error-envelope handling |
+| `apps/hub-dashboard/src/components/device-files.tsx` | Files panel UI: breadcrumb, entry list, action bar, viewer, dialogs |
+| `apps/hub-dashboard/tests/device-files.test.tsx` | Component tests (list/mkdir/delete/upload/error envelope) |
+| `apps/hub-dashboard/tests/file-ops-client.test.ts` | Helper tests (encode roundtrip + error envelope parsing + >1MB guard) |
+
+### Modified files
+| File | Change |
+|------|--------|
+| `apps/hub-dashboard/package.json` | Add `@ahandai/proto: workspace:*` + `buffer: ^6.0.3` runtime deps |
+| `packages/proto-ts/src/index.ts` | Re-export `FileRequest`, `FileResponse`, `FileError`, `FileEntry`, `FileType`, `FileErrorCode`, `FileListResult`, and related types from `./generated/ahand/v1/file_ops.ts` |
+| `apps/hub-dashboard/src/app/api/proxy/[...path]/route.ts` | Add POST handler that forwards body bytes + `content-type` / `accept` headers (pass-through for protobuf) |
+| `apps/hub-dashboard/src/components/device-tabs.tsx` | Add "Files" tab (visible when `online === true`) |
+| `apps/hub-dashboard/src/app/globals.css` | Add `.files-*` styles, reusing `.surface-panel` / `.device-tabs-*` tokens |
+| `apps/hub-dashboard/tests/auth-server.test.ts` | Add a POST-proxy test case (protobuf body passthrough + session/baseurl branches) |
+
+---
+
+## Known Gotchas
+
+1. **`Buffer` in browser bundle.** `packages/proto-ts/src/generated/ahand/v1/file_ops.ts` calls `Buffer.from(...)` and `Buffer.alloc(0)` directly. Next.js 16 does NOT polyfill Node `Buffer` for client bundles. We add the `buffer` npm package and polyfill `globalThis.Buffer` once at module load inside `file-ops-client.ts`. This is the least-invasive fix.
+2. **`Uint8Array` vs `Buffer` at call sites.** ts-proto writes use `writer.bytes(...)`; passing a `Uint8Array` works at runtime but the types insist on `Buffer`. We pass through the polyfilled `Buffer.from(uint8)` to stay type-safe.
+3. **Proxy content-type preservation.** The existing GET proxy strips body. POST must preserve `content-type: application/x-protobuf` and forward body as a `ReadableStream` / `ArrayBuffer` (not `request.text()`, which corrupts binary).
+4. **`FileResponse.error` vs HTTP error envelope.** Two error paths:
+   - Hub returns HTTP 4xx/5xx → JSON body `{error: {code, message}}` (per `crates/ahand-hub/src/http/api_error.rs`).
+   - Hub returns HTTP 200 with a `FileResponse` whose `error` oneof is set (policy denied, path not found, etc.).
+   Both paths must surface the message in the UI.
+5. **`FileEntry.fileType` is a proto enum.** Values are `FILE_TYPE_REGULAR / DIRECTORY / SYMLINK / OTHER`. UI uses numeric comparisons via the exported `FileType` enum — do NOT stringify server-side.
+6. **`modifiedMs` is a number (long).** ts-proto emits it as `number` (loses precision past 2^53 ms ≈ year 287396). Safe to pass to `new Date(ms)`.
+7. **`@ahandai/proto` package is not currently a dep of hub-dashboard.** This is the first app-level consumer of proto-ts in the dashboard — confirm `tsc` sees the types before hitting runtime.
+
+---
+
+### Task 0: Workspace wiring — add proto dep + re-export file_ops types + Buffer polyfill
+
+**Goal:** Make `FileRequest` / `FileResponse` and related types importable from `@ahandai/proto` inside `apps/hub-dashboard`, and ensure `Buffer` works in the browser bundle.
+
+**Files:**
+- Modify: `apps/hub-dashboard/package.json`
+- Modify: `packages/proto-ts/src/index.ts`
+
+**Acceptance Criteria:**
+- [ ] `import { FileRequest, FileResponse, FileEntry, FileType, FileErrorCode } from "@ahandai/proto";` type-checks inside `apps/hub-dashboard/src/**`
+- [ ] `pnpm install` succeeds from repo root
+- [ ] `pnpm --filter @ahandai/proto build` succeeds
+- [ ] `pnpm --filter @ahand/hub-dashboard exec tsc --noEmit` succeeds
+
+**Verify:** `pnpm --filter @ahand/hub-dashboard exec tsc --noEmit` → zero errors
+
+**Steps:**
+
+- [ ] **Step 1: Add `@ahandai/proto` and `buffer` to hub-dashboard deps**
+
+Edit `apps/hub-dashboard/package.json`. In `"dependencies"`, add (alphabetically):
+
+```json
+"@ahandai/proto": "workspace:*",
+"buffer": "^6.0.3",
+```
+
+- [ ] **Step 2: Re-export file_ops types from `@ahandai/proto`**
+
+Edit `packages/proto-ts/src/index.ts`. Append to the file:
+
+```ts
+export {
+  FileRequest,
+  FileResponse,
+  FileError,
+  FileEntry,
+  FileType,
+  FileErrorCode,
+  FileReadText,
+  FileReadTextResult,
+  FileReadBinary,
+  FileReadBinaryResult,
+  FileReadImage,
+  FileReadImageResult,
+  FileWrite,
+  FullWrite,
+  FileDelete,
+  FileDeleteResult,
+  FileList,
+  FileListResult,
+  FileMkdir,
+  FileMkdirResult,
+  ImageFormat,
+  DeleteMode,
+  WriteAction,
+  fileErrorCodeToJSON,
+  fileTypeToJSON,
+} from "./generated/ahand/v1/file_ops.ts";
+
+export type {
+  FileRequest as FileRequestMsg,
+  FileResponse as FileResponseMsg,
+} from "./generated/ahand/v1/file_ops.ts";
+```
+
+- [ ] **Step 3: Install and build proto package**
+
+Run from repo root:
+```bash
+pnpm install
+pnpm --filter @ahandai/proto build
+```
+Expected: clean install, `packages/proto-ts/dist/index.js` and `index.d.ts` present, no type errors.
+
+- [ ] **Step 4: Verify dashboard sees the new types**
+
+Create a scratch file `apps/hub-dashboard/src/lib/_proto_smoke.ts` (temporary):
+
+```ts
+import { FileRequest, FileType, FileErrorCode } from "@ahandai/proto";
+export const _smoke = { FileRequest, FileType, FileErrorCode };
+```
+
+Run: `pnpm --filter @ahand/hub-dashboard exec tsc --noEmit`
+Expected: zero errors.
+
+Delete the scratch file:
+```bash
+rm apps/hub-dashboard/src/lib/_proto_smoke.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/hub-dashboard/package.json packages/proto-ts/src/index.ts pnpm-lock.yaml
+git commit -m "feat(dashboard): wire @ahandai/proto + buffer deps for file ops"
+```
+
+---
+
+### Task 1: Dashboard proxy POST handler for protobuf
+
+**Goal:** Teach the dashboard proxy route to forward POST requests (protobuf or JSON) through to the hub with body + `content-type` preserved.
+
+**Files:**
+- Modify: `apps/hub-dashboard/src/app/api/proxy/[...path]/route.ts`
+- Modify: `apps/hub-dashboard/tests/auth-server.test.ts`
+
+**Acceptance Criteria:**
+- [ ] `POST /api/proxy/<path>` forwards body as raw `ArrayBuffer` (no text coercion)
+- [ ] `content-type` header is forwarded verbatim; `accept` is forwarded (default `application/octet-stream` for protobuf responses)
+- [ ] `authorization: Bearer <session>` is added
+- [ ] Missing cookie → 401 JSON `{error: {code: "unauthorized", message}}`
+- [ ] Missing `AHAND_HUB_BASE_URL` → 503 JSON `{error: {code: "hub_unavailable", message}}`
+- [ ] Upstream `fetch` error → 503 `{error: {code: "hub_unavailable", message}}`
+- [ ] Response body, status, and `content-type` header are proxied back
+
+**Verify:** `pnpm --filter @ahand/hub-dashboard test -- auth-server` → all tests pass
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/hub-dashboard/tests/auth-server.test.ts` inside the existing `describe("GET /api/proxy/*", ...)` sibling scope — add a new `describe`:
+
+```ts
+describe("POST /api/proxy/*", () => {
+  const HUB_BASE_URL = "http://hub.internal:8080";
+
+  beforeEach(() => {
+    vi.stubEnv("AHAND_HUB_BASE_URL", HUB_BASE_URL);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("forwards protobuf bodies with content-type preserved", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(new Uint8Array([0x0a, 0x03, 0x66, 0x6f, 0x6f]), {
+        status: 200,
+        headers: { "content-type": "application/x-protobuf" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { POST: proxyPost } = await import("@/app/api/proxy/[...path]/route");
+    const bodyBytes = new Uint8Array([0x08, 0x01, 0x12, 0x04, 0x74, 0x65, 0x73, 0x74]);
+    const request = new NextRequest(
+      "http://localhost/api/proxy/api/devices/dev-1/files",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-protobuf",
+          accept: "application/x-protobuf",
+          cookie: "ahand_hub_session=session-token",
+        },
+        body: bodyBytes,
+      },
+    );
+
+    const response = await proxyPost(request, {
+      params: Promise.resolve({ path: ["api", "devices", "dev-1", "files"] }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0];
+    expect(calledUrl).toBe(`${HUB_BASE_URL}/api/devices/dev-1/files`);
+    expect(calledInit.method).toBe("POST");
+    expect(calledInit.headers).toMatchObject({
+      authorization: "Bearer session-token",
+      "content-type": "application/x-protobuf",
+      accept: "application/x-protobuf",
+    });
+    // Body must be forwarded verbatim as bytes.
+    const forwarded = new Uint8Array(
+      calledInit.body instanceof ArrayBuffer
+        ? calledInit.body
+        : (calledInit.body as Uint8Array).buffer,
+    );
+    expect(Array.from(forwarded)).toEqual(Array.from(bodyBytes));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/x-protobuf");
+  });
+
+  it("returns 401 JSON envelope when session cookie is missing", async () => {
+    const { POST: proxyPost } = await import("@/app/api/proxy/[...path]/route");
+    const request = new NextRequest("http://localhost/api/proxy/api/devices/x/files", {
+      method: "POST",
+      headers: { "content-type": "application/x-protobuf" },
+      body: new Uint8Array([0x00]),
+    });
+    const response = await proxyPost(request, {
+      params: Promise.resolve({ path: ["api", "devices", "x", "files"] }),
+    });
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.error.code).toBe("unauthorized");
+  });
+
+  it("returns 503 when AHAND_HUB_BASE_URL is missing", async () => {
+    vi.unstubAllEnvs();
+    const { POST: proxyPost } = await import("@/app/api/proxy/[...path]/route");
+    const request = new NextRequest("http://localhost/api/proxy/api/devices/x/files", {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-protobuf",
+        cookie: "ahand_hub_session=session-token",
+      },
+      body: new Uint8Array([0x00]),
+    });
+    const response = await proxyPost(request, {
+      params: Promise.resolve({ path: ["api", "devices", "x", "files"] }),
+    });
+    expect(response.status).toBe(503);
+    const body = await response.json();
+    expect(body.error.code).toBe("hub_unavailable");
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing test**
+
+```bash
+pnpm --filter @ahand/hub-dashboard test -- auth-server
+```
+Expected: FAIL — `POST` is not exported from the route.
+
+- [ ] **Step 3: Add the POST handler**
+
+Edit `apps/hub-dashboard/src/app/api/proxy/[...path]/route.ts`. Append after the existing `GET` function:
+
+```ts
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  const { path } = await params;
+  const session = request.cookies.get("ahand_hub_session")?.value ?? "";
+  const baseUrl = process.env.AHAND_HUB_BASE_URL;
+
+  if (!session) {
+    return dashboardErrorResponse("unauthorized", "Sign in required.", 401);
+  }
+
+  if (!baseUrl) {
+    return dashboardErrorResponse("hub_unavailable", "Unable to reach the hub right now.", 503);
+  }
+
+  const upstream = new URL(path.join("/"), `${baseUrl.replace(/\/?$/, "/")}`);
+  upstream.search = request.nextUrl.search;
+
+  let response: Response;
+  try {
+    const bodyBuffer = await request.arrayBuffer();
+    const headers: Record<string, string> = {
+      authorization: `Bearer ${session}`,
+      "content-type": request.headers.get("content-type") ?? "application/octet-stream",
+      accept: request.headers.get("accept") ?? "application/octet-stream",
+    };
+    response = await fetch(upstream.toString(), {
+      method: "POST",
+      headers,
+      body: bodyBuffer,
+      cache: "no-store",
+    });
+  } catch {
+    return dashboardErrorResponse("hub_unavailable", "Unable to reach the hub right now.", 503);
+  }
+
+  return new NextResponse(response.body, {
+    status: response.status,
+    headers: response.headers,
+  });
+}
+```
+
+- [ ] **Step 4: Rerun the test**
+
+```bash
+pnpm --filter @ahand/hub-dashboard test -- auth-server
+```
+Expected: all POST cases pass, existing GET cases still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/hub-dashboard/src/app/api/proxy apps/hub-dashboard/tests/auth-server.test.ts
+git commit -m "feat(dashboard): add pass-through POST handler for /api/proxy"
+```
+
+---
+
+### Task 2: `file-ops-client.ts` — typed request builders + encode/decode + error handling
+
+**Goal:** Provide one small, well-tested module the React component can call. It hides protobuf serialization, the Buffer polyfill, and the two error-envelope paths.
+
+**Files:**
+- Create: `apps/hub-dashboard/src/lib/file-ops-client.ts`
+- Create: `apps/hub-dashboard/tests/file-ops-client.test.ts`
+
+**Acceptance Criteria:**
+- [ ] Exports named async functions: `listFiles`, `readText`, `readImage`, `readBinary`, `mkdir`, `deleteFile`, `writeFile`
+- [ ] Each function accepts a `deviceId` + operation-specific args and returns the parsed `FileResponse` oneof payload (or throws a typed error)
+- [ ] Exports `FileOpsError extends Error` with `code: string`, `message: string`, and optional `httpStatus: number`
+- [ ] Maps HTTP 4xx/5xx with JSON `{error: {code, message}}` → `FileOpsError(code, message, httpStatus)`
+- [ ] Maps `FileResponse.error` (proto-level) → `FileOpsError(fileErrorCodeToJSON(code), message, 200)`
+- [ ] `writeFile` rejects with `FileOpsError("content_too_large", "S3 path not implemented yet", 0)` when `content.byteLength > 1_048_576`
+- [ ] Polyfills `globalThis.Buffer` at module-load via `import { Buffer } from "buffer"` (idempotent)
+
+**Verify:** `pnpm --filter @ahand/hub-dashboard test -- file-ops-client` → all tests pass
+
+**Steps:**
+
+- [ ] **Step 1: Write failing tests**
+
+Create `apps/hub-dashboard/tests/file-ops-client.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FileRequest, FileResponse, FileType } from "@ahandai/proto";
+
+import {
+  FileOpsError,
+  listFiles,
+  mkdir,
+  readText,
+  writeFile,
+} from "@/lib/file-ops-client";
+
+describe("file-ops-client", () => {
+  const deviceId = "dev-1";
+  const expectedUrl = "/api/proxy/api/devices/dev-1/files";
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function respondWith(resp: FileResponse) {
+    const bytes = FileResponse.encode(resp).finish();
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(bytes, {
+        status: 200,
+        headers: { "content-type": "application/x-protobuf" },
+      }),
+    );
+  }
+
+  it("listFiles encodes FileList and decodes FileListResult", async () => {
+    respondWith(
+      FileResponse.fromPartial({
+        requestId: "req-1",
+        list: {
+          entries: [
+            {
+              name: "hello.txt",
+              fileType: FileType.FILE_TYPE_REGULAR,
+              size: 42,
+              modifiedMs: 1_700_000_000_000,
+            },
+          ],
+          totalCount: 1,
+          hasMore: false,
+        },
+      }),
+    );
+
+    const result = await listFiles(deviceId, { path: "/tmp" });
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].name).toBe("hello.txt");
+
+    const mock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    expect(mock).toHaveBeenCalledWith(
+      expectedUrl,
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "content-type": "application/x-protobuf",
+          accept: "application/x-protobuf",
+        }),
+      }),
+    );
+    const body = mock.mock.calls[0][1].body as Uint8Array;
+    const decoded = FileRequest.decode(body);
+    expect(decoded.list?.path).toBe("/tmp");
+  });
+
+  it("maps HTTP 4xx JSON envelope to FileOpsError", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: { code: "POLICY_DENIED", message: "/etc/passwd is in dangerous_paths" },
+        }),
+        { status: 403, headers: { "content-type": "application/json" } },
+      ),
+    );
+    await expect(listFiles(deviceId, { path: "/etc" })).rejects.toMatchObject({
+      code: "POLICY_DENIED",
+      message: expect.stringContaining("dangerous_paths"),
+      httpStatus: 403,
+    });
+  });
+
+  it("maps FileResponse.error (200 OK with proto error) to FileOpsError", async () => {
+    respondWith(
+      FileResponse.fromPartial({
+        requestId: "req-1",
+        error: {
+          code: 12, // FILE_ERROR_CODE_POLICY_DENIED
+          message: "blocked by policy",
+          path: "/etc/shadow",
+        },
+      }),
+    );
+    await expect(readText(deviceId, { path: "/etc/shadow" })).rejects.toMatchObject({
+      code: "FILE_ERROR_CODE_POLICY_DENIED",
+      message: expect.stringContaining("blocked"),
+      httpStatus: 200,
+    });
+  });
+
+  it("mkdir succeeds and decodes result", async () => {
+    respondWith(
+      FileResponse.fromPartial({
+        requestId: "req-1",
+        mkdir: { path: "/tmp/new", alreadyExisted: false },
+      }),
+    );
+    const r = await mkdir(deviceId, { path: "/tmp/new", recursive: true });
+    expect(r.path).toBe("/tmp/new");
+    expect(r.alreadyExisted).toBe(false);
+  });
+
+  it("writeFile rejects payloads > 1 MiB with content_too_large", async () => {
+    const big = new Uint8Array(1_048_577);
+    await expect(
+      writeFile(deviceId, { path: "/tmp/big.bin", content: big }),
+    ).rejects.toMatchObject({
+      code: "content_too_large",
+      message: expect.stringContaining("S3"),
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("FileOpsError is an Error subclass", () => {
+    const e = new FileOpsError("X", "y", 400);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.code).toBe("X");
+    expect(e.httpStatus).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+```bash
+pnpm --filter @ahand/hub-dashboard test -- file-ops-client
+```
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement `file-ops-client.ts`**
+
+Create `apps/hub-dashboard/src/lib/file-ops-client.ts`:
+
+```ts
+import { Buffer } from "buffer";
+import {
+  FileRequest,
+  FileResponse,
+  FileListResult,
+  FileMkdirResult,
+  FileDeleteResult,
+  FileReadTextResult,
+  FileReadImageResult,
+  FileReadBinaryResult,
+  FileWriteResult,
+  fileErrorCodeToJSON,
+} from "@ahandai/proto";
+
+if (typeof globalThis.Buffer === "undefined") {
+  (globalThis as { Buffer: typeof Buffer }).Buffer = Buffer;
+}
+
+const MAX_INLINE_WRITE_BYTES = 1_048_576;
+
+export class FileOpsError extends Error {
+  readonly code: string;
+  readonly httpStatus: number;
+  constructor(code: string, message: string, httpStatus: number) {
+    super(message);
+    this.name = "FileOpsError";
+    this.code = code;
+    this.httpStatus = httpStatus;
+  }
+}
+
+function proxyUrl(deviceId: string): string {
+  return `/api/proxy/api/devices/${encodeURIComponent(deviceId)}/files`;
+}
+
+function newRequestId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `req-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+}
+
+async function sendRequest(deviceId: string, req: FileRequest): Promise<FileResponse> {
+  const body = FileRequest.encode(req).finish();
+  const res = await fetch(proxyUrl(deviceId), {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-protobuf",
+      accept: "application/x-protobuf",
+    },
+    body,
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    let code = `http_${res.status}`;
+    let message = `Hub returned HTTP ${res.status}`;
+    try {
+      const envelope = (await res.clone().json()) as {
+        error?: { code?: string; message?: string };
+      };
+      if (envelope?.error) {
+        code = envelope.error.code ?? code;
+        message = envelope.error.message ?? message;
+      }
+    } catch {
+      try {
+        message = (await res.text()) || message;
+      } catch {
+        // swallow — keep default
+      }
+    }
+    throw new FileOpsError(code, message, res.status);
+  }
+  const raw = new Uint8Array(await res.arrayBuffer());
+  const resp = FileResponse.decode(raw);
+  if (resp.error) {
+    throw new FileOpsError(
+      fileErrorCodeToJSON(resp.error.code),
+      resp.error.message || "file operation failed",
+      200,
+    );
+  }
+  return resp;
+}
+
+export interface ListFilesArgs {
+  path: string;
+  includeHidden?: boolean;
+  maxResults?: number;
+  offset?: number;
+}
+
+export async function listFiles(deviceId: string, args: ListFilesArgs): Promise<FileListResult> {
+  const req = FileRequest.fromPartial({
+    requestId: newRequestId(),
+    list: {
+      path: args.path,
+      includeHidden: args.includeHidden ?? false,
+      maxResults: args.maxResults,
+      offset: args.offset,
+    },
+  });
+  const resp = await sendRequest(deviceId, req);
+  if (!resp.list) {
+    throw new FileOpsError("malformed_response", "list response missing", 200);
+  }
+  return resp.list;
+}
+
+export interface ReadTextArgs {
+  path: string;
+  maxLines?: number;
+  maxBytes?: number;
+}
+
+export async function readText(
+  deviceId: string,
+  args: ReadTextArgs,
+): Promise<FileReadTextResult> {
+  const req = FileRequest.fromPartial({
+    requestId: newRequestId(),
+    readText: {
+      path: args.path,
+      maxLines: args.maxLines ?? 2000,
+      maxBytes: args.maxBytes ?? 65_536,
+      lineNumbers: false,
+      noFollowSymlink: false,
+    },
+  });
+  const resp = await sendRequest(deviceId, req);
+  if (!resp.readText) {
+    throw new FileOpsError("malformed_response", "read_text response missing", 200);
+  }
+  return resp.readText;
+}
+
+export interface ReadImageArgs {
+  path: string;
+  maxBytes?: number;
+}
+
+export async function readImage(
+  deviceId: string,
+  args: ReadImageArgs,
+): Promise<FileReadImageResult> {
+  const req = FileRequest.fromPartial({
+    requestId: newRequestId(),
+    readImage: {
+      path: args.path,
+      maxBytes: args.maxBytes ?? 1_048_576,
+      noFollowSymlink: false,
+    },
+  });
+  const resp = await sendRequest(deviceId, req);
+  if (!resp.readImage) {
+    throw new FileOpsError("malformed_response", "read_image response missing", 200);
+  }
+  return resp.readImage;
+}
+
+export interface ReadBinaryArgs {
+  path: string;
+  maxBytes?: number;
+}
+
+export async function readBinary(
+  deviceId: string,
+  args: ReadBinaryArgs,
+): Promise<FileReadBinaryResult> {
+  const req = FileRequest.fromPartial({
+    requestId: newRequestId(),
+    readBinary: {
+      path: args.path,
+      byteOffset: 0,
+      byteLength: 0,
+      maxBytes: args.maxBytes ?? MAX_INLINE_WRITE_BYTES,
+      noFollowSymlink: false,
+    },
+  });
+  const resp = await sendRequest(deviceId, req);
+  if (!resp.readBinary) {
+    throw new FileOpsError("malformed_response", "read_binary response missing", 200);
+  }
+  return resp.readBinary;
+}
+
+export interface MkdirArgs {
+  path: string;
+  recursive?: boolean;
+}
+
+export async function mkdir(deviceId: string, args: MkdirArgs): Promise<FileMkdirResult> {
+  const req = FileRequest.fromPartial({
+    requestId: newRequestId(),
+    mkdir: { path: args.path, recursive: args.recursive ?? true },
+  });
+  const resp = await sendRequest(deviceId, req);
+  if (!resp.mkdir) {
+    throw new FileOpsError("malformed_response", "mkdir response missing", 200);
+  }
+  return resp.mkdir;
+}
+
+export interface DeleteArgs {
+  path: string;
+  recursive?: boolean;
+}
+
+export async function deleteFile(
+  deviceId: string,
+  args: DeleteArgs,
+): Promise<FileDeleteResult> {
+  const req = FileRequest.fromPartial({
+    requestId: newRequestId(),
+    delete: {
+      path: args.path,
+      recursive: args.recursive ?? false,
+      mode: 0, // DELETE_MODE_UNSPECIFIED — daemon picks safe default
+      noFollowSymlink: false,
+    },
+  });
+  const resp = await sendRequest(deviceId, req);
+  if (!resp.delete) {
+    throw new FileOpsError("malformed_response", "delete response missing", 200);
+  }
+  return resp.delete;
+}
+
+export interface WriteArgs {
+  path: string;
+  content: Uint8Array;
+  createParents?: boolean;
+}
+
+export async function writeFile(
+  deviceId: string,
+  args: WriteArgs,
+): Promise<FileWriteResult> {
+  if (args.content.byteLength > MAX_INLINE_WRITE_BYTES) {
+    throw new FileOpsError(
+      "content_too_large",
+      `Uploads larger than ${MAX_INLINE_WRITE_BYTES} bytes require the S3 path, which is not implemented yet.`,
+      0,
+    );
+  }
+  const req = FileRequest.fromPartial({
+    requestId: newRequestId(),
+    write: {
+      path: args.path,
+      createParents: args.createParents ?? true,
+      fullWrite: { content: Buffer.from(args.content) },
+      noFollowSymlink: false,
+    },
+  });
+  const resp = await sendRequest(deviceId, req);
+  if (!resp.write) {
+    throw new FileOpsError("malformed_response", "write response missing", 200);
+  }
+  return resp.write;
+}
+```
+
+- [ ] **Step 4: Run tests, expect pass**
+
+```bash
+pnpm --filter @ahand/hub-dashboard test -- file-ops-client
+```
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/hub-dashboard/src/lib/file-ops-client.ts apps/hub-dashboard/tests/file-ops-client.test.ts
+git commit -m "feat(dashboard): add file-ops-client (encode/decode + error envelope)"
+```
+
+---
+
+### Task 3: `DeviceFiles` component — list, navigate, view (text/image/binary)
+
+**Goal:** Render a Files panel that lets the operator type a path, list a directory, click into subfolders via breadcrumbs, and preview text/image files. Error envelope messages display inline.
+
+**Files:**
+- Create: `apps/hub-dashboard/src/components/device-files.tsx`
+- Create: `apps/hub-dashboard/tests/device-files.test.tsx`
+
+**Acceptance Criteria:**
+- [ ] Path input + "Open" button → calls `listFiles`, renders entries sorted dirs-first then alphabetically
+- [ ] Breadcrumb for path segments, clicking a segment re-lists that parent
+- [ ] Each entry shows name, file-type badge (DIR / FILE / LNK), size (human-readable for files), and modified time
+- [ ] Clicking a directory navigates into it; clicking a regular file opens a viewer (text or image or "binary — use Download")
+- [ ] Viewer supports Close; error envelope code+message renders inline with `role="alert"`
+- [ ] Component is keyboard-accessible: path input has label, list items are `<button>`s, viewer Close button is focusable; all interactive elements have `aria-label` where text is ambiguous
+
+**Verify:** `pnpm --filter @ahand/hub-dashboard test -- device-files` → tests listed below pass
+
+**Steps:**
+
+- [ ] **Step 1: Write failing tests (list happy + 4xx error envelope)**
+
+Create `apps/hub-dashboard/tests/device-files.test.tsx`:
+
+```tsx
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FileResponse, FileType } from "@ahandai/proto";
+
+import { DeviceFiles } from "@/components/device-files";
+
+function stubProto(resp: FileResponse) {
+  const bytes = FileResponse.encode(resp).finish();
+  (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+    new Response(bytes, {
+      status: 200,
+      headers: { "content-type": "application/x-protobuf" },
+    }),
+  );
+}
+
+function stubErrorEnvelope(code: string, message: string, status = 403) {
+  (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+    new Response(JSON.stringify({ error: { code, message } }), {
+      status,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+}
+
+describe("DeviceFiles", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("lists directory entries and shows dirs before files", async () => {
+    stubProto(
+      FileResponse.fromPartial({
+        requestId: "r",
+        list: {
+          entries: [
+            { name: "readme.txt", fileType: FileType.FILE_TYPE_REGULAR, size: 12, modifiedMs: 0 },
+            { name: "src", fileType: FileType.FILE_TYPE_DIRECTORY, size: 0, modifiedMs: 0 },
+          ],
+          totalCount: 2,
+          hasMore: false,
+        },
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<DeviceFiles deviceId="dev-1" />);
+
+    await user.clear(screen.getByLabelText(/path/i));
+    await user.type(screen.getByLabelText(/path/i), "/home/user");
+    await user.click(screen.getByRole("button", { name: /open/i }));
+
+    const entries = await screen.findAllByRole("listitem");
+    // src (dir) must come first.
+    expect(entries[0]).toHaveTextContent("src");
+    expect(entries[1]).toHaveTextContent("readme.txt");
+  });
+
+  it("displays 4xx error envelope from hub", async () => {
+    stubErrorEnvelope("POLICY_DENIED", "/etc/passwd is in dangerous_paths", 403);
+
+    const user = userEvent.setup();
+    render(<DeviceFiles deviceId="dev-1" />);
+
+    await user.clear(screen.getByLabelText(/path/i));
+    await user.type(screen.getByLabelText(/path/i), "/etc");
+    await user.click(screen.getByRole("button", { name: /open/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/POLICY_DENIED/);
+    expect(alert).toHaveTextContent(/dangerous_paths/);
+  });
+});
+```
+
+Add `@testing-library/user-event` to devDependencies if not present. Check first:
+
+```bash
+grep "@testing-library/user-event" apps/hub-dashboard/package.json
+```
+
+If missing, add it:
+
+```bash
+pnpm --filter @ahand/hub-dashboard add -D @testing-library/user-event@^14
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+```bash
+pnpm --filter @ahand/hub-dashboard test -- device-files
+```
+Expected: FAIL — component does not exist.
+
+- [ ] **Step 3: Implement `DeviceFiles` (list + navigate + view)**
+
+Create `apps/hub-dashboard/src/components/device-files.tsx`:
+
+```tsx
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { FileType, type FileEntry } from "@ahandai/proto";
+import {
+  FileOpsError,
+  listFiles,
+  readImage,
+  readText,
+} from "@/lib/file-ops-client";
+
+interface ViewerState {
+  kind: "text" | "image" | "binary";
+  path: string;
+  text?: string;
+  imageSrc?: string;
+  imageMime?: string;
+}
+
+interface ErrorState {
+  code: string;
+  message: string;
+}
+
+export function DeviceFiles({ deviceId }: { deviceId: string }) {
+  const [path, setPath] = useState("/tmp");
+  const [entries, setEntries] = useState<FileEntry[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<ErrorState | null>(null);
+  const [viewer, setViewer] = useState<ViewerState | null>(null);
+
+  const openDirectory = useCallback(
+    async (target: string) => {
+      setLoading(true);
+      setError(null);
+      setViewer(null);
+      try {
+        const result = await listFiles(deviceId, { path: target });
+        const sorted = [...result.entries].sort((a, b) => {
+          const aDir = a.fileType === FileType.FILE_TYPE_DIRECTORY ? 0 : 1;
+          const bDir = b.fileType === FileType.FILE_TYPE_DIRECTORY ? 0 : 1;
+          if (aDir !== bDir) return aDir - bDir;
+          return a.name.localeCompare(b.name);
+        });
+        setEntries(sorted);
+        setPath(target);
+      } catch (e) {
+        setEntries(null);
+        setError(toErrorState(e));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [deviceId],
+  );
+
+  const openFile = useCallback(
+    async (entryPath: string, entryName: string) => {
+      setError(null);
+      setViewer({ kind: "text", path: entryPath, text: "Loading..." });
+      // Heuristic: image extensions → read_image, everything else → try read_text.
+      if (isImage(entryName)) {
+        try {
+          const r = await readImage(deviceId, { path: entryPath });
+          const mime = imageMimeFor(r.format);
+          const src = `data:${mime};base64,${uint8ToBase64(r.content)}`;
+          setViewer({ kind: "image", path: entryPath, imageSrc: src, imageMime: mime });
+        } catch (e) {
+          if (e instanceof FileOpsError && e.code === "FILE_ERROR_CODE_ENCODING") {
+            setViewer({ kind: "binary", path: entryPath });
+            return;
+          }
+          setViewer(null);
+          setError(toErrorState(e));
+        }
+        return;
+      }
+      try {
+        const r = await readText(deviceId, { path: entryPath });
+        const joined = r.lines.map((l) => l.content).join("\n");
+        setViewer({ kind: "text", path: entryPath, text: joined });
+      } catch (e) {
+        // Heuristic: encoding failure → binary placeholder.
+        if (e instanceof FileOpsError && e.code === "FILE_ERROR_CODE_ENCODING") {
+          setViewer({ kind: "binary", path: entryPath });
+          return;
+        }
+        setViewer(null);
+        setError(toErrorState(e));
+      }
+    },
+    [deviceId],
+  );
+
+  const crumbs = useMemo(() => buildBreadcrumbs(path), [path]);
+
+  return (
+    <div className="files-panel">
+      <div className="files-section">
+        <div className="files-form-row">
+          <label className="files-label" htmlFor="files-path-input">
+            Path
+          </label>
+          <input
+            id="files-path-input"
+            className="files-input"
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+            placeholder="/home/user"
+            onKeyDown={(e) => e.key === "Enter" && openDirectory(path)}
+          />
+          <button
+            type="button"
+            className="files-btn files-btn-primary"
+            onClick={() => openDirectory(path)}
+            disabled={loading}
+          >
+            {loading ? "Loading..." : "Open"}
+          </button>
+        </div>
+        <nav aria-label="Path breadcrumbs" className="files-breadcrumbs">
+          {crumbs.map((c, i) => (
+            <button
+              key={`${c.path}-${i}`}
+              type="button"
+              className="files-breadcrumb"
+              onClick={() => openDirectory(c.path)}
+            >
+              {c.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {error && (
+        <div className="files-error" role="alert">
+          <strong>{error.code}</strong>: {error.message}
+        </div>
+      )}
+
+      {entries && (
+        <ul className="files-list" aria-label="Directory entries">
+          {entries.length === 0 && (
+            <li className="files-empty">(empty directory)</li>
+          )}
+          {entries.map((e) => (
+            <li key={e.name} className="files-entry">
+              <button
+                type="button"
+                className="files-entry-btn"
+                onClick={() =>
+                  e.fileType === FileType.FILE_TYPE_DIRECTORY
+                    ? openDirectory(joinPath(path, e.name))
+                    : openFile(joinPath(path, e.name), e.name)
+                }
+                aria-label={`${typeLabel(e.fileType)} ${e.name}`}
+              >
+                <span className={`files-badge files-badge-${typeLabel(e.fileType).toLowerCase()}`}>
+                  {typeLabel(e.fileType)}
+                </span>
+                <span className="files-entry-name">{e.name}</span>
+                <span className="files-entry-size">
+                  {e.fileType === FileType.FILE_TYPE_REGULAR ? humanSize(e.size) : ""}
+                </span>
+                <span className="files-entry-time">{formatMtime(e.modifiedMs)}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {viewer && (
+        <div className="files-viewer" role="region" aria-label={`Viewer for ${viewer.path}`}>
+          <div className="files-viewer-header">
+            <span className="files-viewer-path">{viewer.path}</span>
+            <button
+              type="button"
+              className="files-btn files-btn-sm"
+              onClick={() => setViewer(null)}
+            >
+              Close
+            </button>
+          </div>
+          {viewer.kind === "text" && (
+            <pre className="files-viewer-text">{viewer.text}</pre>
+          )}
+          {viewer.kind === "image" && (
+            <img
+              className="files-viewer-image"
+              src={viewer.imageSrc}
+              alt={viewer.path}
+            />
+          )}
+          {viewer.kind === "binary" && (
+            <p className="files-viewer-binary">
+              Binary file — use Download to save it locally.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function toErrorState(e: unknown): ErrorState {
+  if (e instanceof FileOpsError) return { code: e.code, message: e.message };
+  if (e instanceof Error) return { code: "ClientError", message: e.message };
+  return { code: "ClientError", message: String(e) };
+}
+
+function typeLabel(t: FileType): "DIR" | "FILE" | "LNK" | "OTHER" {
+  switch (t) {
+    case FileType.FILE_TYPE_DIRECTORY:
+      return "DIR";
+    case FileType.FILE_TYPE_REGULAR:
+      return "FILE";
+    case FileType.FILE_TYPE_SYMLINK:
+      return "LNK";
+    default:
+      return "OTHER";
+  }
+}
+
+function humanSize(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MiB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(1)} GiB`;
+}
+
+function formatMtime(ms: number): string {
+  if (!ms) return "";
+  return new Date(ms).toLocaleString();
+}
+
+function joinPath(base: string, name: string): string {
+  if (base === "/") return `/${name}`;
+  if (base.endsWith("/")) return `${base}${name}`;
+  return `${base}/${name}`;
+}
+
+function buildBreadcrumbs(p: string): { label: string; path: string }[] {
+  const trimmed = p.replace(/\/+$/, "");
+  if (!trimmed || trimmed === "") {
+    return [{ label: "/", path: "/" }];
+  }
+  const isAbs = trimmed.startsWith("/");
+  const parts = trimmed.split("/").filter(Boolean);
+  const crumbs: { label: string; path: string }[] = [];
+  if (isAbs) crumbs.push({ label: "/", path: "/" });
+  let cursor = isAbs ? "" : "";
+  for (const part of parts) {
+    cursor = isAbs ? `${cursor}/${part}` : cursor ? `${cursor}/${part}` : part;
+    crumbs.push({ label: part, path: cursor || "/" });
+  }
+  return crumbs;
+}
+
+function isImage(name: string): boolean {
+  return /\.(png|jpe?g|gif|webp|bmp|ico|svg)$/i.test(name);
+}
+
+function imageMimeFor(fmt: number): string {
+  // ImageFormat enum: 0=original, 1=jpeg, 2=png, 3=webp
+  switch (fmt) {
+    case 1: return "image/jpeg";
+    case 2: return "image/png";
+    case 3: return "image/webp";
+    default: return "image/png";
+  }
+}
+
+function uint8ToBase64(bytes: Uint8Array): string {
+  let s = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    s += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK) as unknown as number[]);
+  }
+  return btoa(s);
+}
+```
+
+- [ ] **Step 4: Rerun tests**
+
+```bash
+pnpm --filter @ahand/hub-dashboard test -- device-files
+```
+Expected: both cases pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/hub-dashboard/src/components/device-files.tsx apps/hub-dashboard/tests/device-files.test.tsx apps/hub-dashboard/package.json
+git commit -m "feat(dashboard): add DeviceFiles list/navigate/view"
+```
+
+---
+
+### Task 4: Mkdir / delete / download / upload
+
+**Goal:** Round out the action set: create a subdirectory, delete an entry (confirm dialog + recursive toggle), download any file, upload a file (<= 1 MiB inline; larger shows the S3-not-implemented message).
+
+**Files:**
+- Modify: `apps/hub-dashboard/src/components/device-files.tsx`
+- Modify: `apps/hub-dashboard/tests/device-files.test.tsx`
+
+**Acceptance Criteria:**
+- [ ] "New folder" action → inline input → calls `mkdir` → re-lists current directory
+- [ ] Delete action on a listed entry → confirm dialog (`role="dialog"`, `aria-modal`) with "Recursive" checkbox → calls `deleteFile` → re-lists
+- [ ] Download action on a listed file → calls `readBinary` → creates Blob URL → triggers `<a download>` click → URL revoked after download
+- [ ] Upload: `<input type="file">` → if `file.size > 1_048_576` show "S3 path not implemented yet" error; else `writeFile` → re-list
+- [ ] All new tests pass: mkdir happy, delete confirm-dialog, upload size guard
+
+**Verify:** `pnpm --filter @ahand/hub-dashboard test -- device-files` → all tests pass
+
+**Steps:**
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `apps/hub-dashboard/tests/device-files.test.tsx` inside the same `describe("DeviceFiles", ...)`:
+
+```tsx
+it("creates a new directory via mkdir", async () => {
+  // First list is the initial state.
+  stubProto(
+    FileResponse.fromPartial({
+      requestId: "r",
+      list: { entries: [], totalCount: 0, hasMore: false },
+    }),
+  );
+  // Mkdir response.
+  stubProto(
+    FileResponse.fromPartial({
+      requestId: "r",
+      mkdir: { path: "/tmp/newfolder", alreadyExisted: false },
+    }),
+  );
+  // Re-list after mkdir.
+  stubProto(
+    FileResponse.fromPartial({
+      requestId: "r",
+      list: {
+        entries: [{ name: "newfolder", fileType: FileType.FILE_TYPE_DIRECTORY, size: 0, modifiedMs: 0 }],
+        totalCount: 1,
+        hasMore: false,
+      },
+    }),
+  );
+
+  const user = userEvent.setup();
+  render(<DeviceFiles deviceId="dev-1" />);
+  await user.click(screen.getByRole("button", { name: /open/i }));
+  await screen.findByText(/empty directory/i);
+
+  await user.click(screen.getByRole("button", { name: /new folder/i }));
+  const nameInput = await screen.findByLabelText(/folder name/i);
+  await user.type(nameInput, "newfolder");
+  await user.click(screen.getByRole("button", { name: /create/i }));
+
+  expect(await screen.findByText("newfolder")).toBeInTheDocument();
+});
+
+it("shows a confirm dialog before delete and respects Cancel", async () => {
+  stubProto(
+    FileResponse.fromPartial({
+      requestId: "r",
+      list: {
+        entries: [
+          { name: "old.txt", fileType: FileType.FILE_TYPE_REGULAR, size: 3, modifiedMs: 0 },
+        ],
+        totalCount: 1,
+        hasMore: false,
+      },
+    }),
+  );
+  const user = userEvent.setup();
+  render(<DeviceFiles deviceId="dev-1" />);
+  await user.click(screen.getByRole("button", { name: /open/i }));
+  await screen.findByText("old.txt");
+
+  await user.click(screen.getByRole("button", { name: /delete old.txt/i }));
+  const dialog = await screen.findByRole("dialog");
+  expect(dialog).toHaveTextContent(/delete/i);
+  expect(screen.getByLabelText(/recursive/i)).toBeInTheDocument();
+
+  await user.click(screen.getByRole("button", { name: /cancel/i }));
+  expect(screen.queryByRole("dialog")).toBeNull();
+  // fetch was only called once (the initial list) — no delete was issued.
+  expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+});
+
+it("rejects uploads larger than 1 MiB without calling the network", async () => {
+  stubProto(
+    FileResponse.fromPartial({
+      requestId: "r",
+      list: { entries: [], totalCount: 0, hasMore: false },
+    }),
+  );
+  const user = userEvent.setup();
+  render(<DeviceFiles deviceId="dev-1" />);
+  await user.click(screen.getByRole("button", { name: /open/i }));
+  await screen.findByText(/empty directory/i);
+
+  const big = new File([new Uint8Array(1_048_577)], "big.bin", { type: "application/octet-stream" });
+  const uploadInput = screen.getByLabelText(/upload file/i) as HTMLInputElement;
+  await user.upload(uploadInput, big);
+
+  const alert = await screen.findByRole("alert");
+  expect(alert).toHaveTextContent(/S3/i);
+  // One fetch from the initial list, none from the upload.
+  expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+});
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+```bash
+pnpm --filter @ahand/hub-dashboard test -- device-files
+```
+Expected: new tests FAIL.
+
+- [ ] **Step 3: Extend `DeviceFiles` with actions**
+
+Edit `apps/hub-dashboard/src/components/device-files.tsx`:
+
+a) Add the new imports at the top:
+
+```tsx
+import { deleteFile, mkdir, readBinary, writeFile } from "@/lib/file-ops-client";
+```
+
+(Merge with existing imports from `@/lib/file-ops-client`.)
+
+b) Inside the `DeviceFiles` function, add state and handlers before the `return`:
+
+```tsx
+const [mkdirName, setMkdirName] = useState<string | null>(null);
+const [pendingDelete, setPendingDelete] = useState<{ name: string; recursive: boolean } | null>(null);
+const [busy, setBusy] = useState<string | null>(null);
+
+const handleMkdir = useCallback(async () => {
+  if (mkdirName === null) return;
+  const name = mkdirName.trim();
+  if (!name) return;
+  setBusy("mkdir");
+  setError(null);
+  try {
+    await mkdir(deviceId, { path: joinPath(path, name), recursive: true });
+    setMkdirName(null);
+    await openDirectory(path);
+  } catch (e) {
+    setError(toErrorState(e));
+  } finally {
+    setBusy(null);
+  }
+}, [mkdirName, deviceId, path, openDirectory]);
+
+const handleDelete = useCallback(async () => {
+  if (!pendingDelete) return;
+  const { name, recursive } = pendingDelete;
+  setBusy("delete");
+  setError(null);
+  try {
+    await deleteFile(deviceId, { path: joinPath(path, name), recursive });
+    setPendingDelete(null);
+    await openDirectory(path);
+  } catch (e) {
+    setError(toErrorState(e));
+  } finally {
+    setBusy(null);
+  }
+}, [pendingDelete, deviceId, path, openDirectory]);
+
+const handleDownload = useCallback(
+  async (name: string) => {
+    setBusy(`download:${name}`);
+    setError(null);
+    try {
+      const r = await readBinary(deviceId, { path: joinPath(path, name) });
+      const blob = new Blob([r.content as unknown as Uint8Array], {
+        type: "application/octet-stream",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = name;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setError(toErrorState(e));
+    } finally {
+      setBusy(null);
+    }
+  },
+  [deviceId, path],
+);
+
+const handleUpload = useCallback(
+  async (file: File | null | undefined) => {
+    if (!file) return;
+    setBusy("upload");
+    setError(null);
+    try {
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      await writeFile(deviceId, { path: joinPath(path, file.name), content: bytes });
+      await openDirectory(path);
+    } catch (e) {
+      setError(toErrorState(e));
+    } finally {
+      setBusy(null);
+    }
+  },
+  [deviceId, path, openDirectory],
+);
+```
+
+c) In the top action row (inside the `files-section` div that holds the path input), add a new sibling row under the existing form-row:
+
+```tsx
+<div className="files-actions-row">
+  <button
+    type="button"
+    className="files-btn"
+    onClick={() => setMkdirName("")}
+    disabled={busy !== null}
+  >
+    New folder
+  </button>
+  <label className="files-btn files-upload-label">
+    Upload file
+    <input
+      type="file"
+      className="files-upload-input"
+      aria-label="Upload file"
+      onChange={(e) => handleUpload(e.target.files?.[0])}
+    />
+  </label>
+</div>
+{mkdirName !== null && (
+  <div className="files-form-row">
+    <label className="files-label" htmlFor="files-mkdir-input">
+      Folder name
+    </label>
+    <input
+      id="files-mkdir-input"
+      className="files-input"
+      value={mkdirName}
+      onChange={(e) => setMkdirName(e.target.value)}
+      onKeyDown={(e) => e.key === "Enter" && handleMkdir()}
+    />
+    <button
+      type="button"
+      className="files-btn files-btn-primary"
+      onClick={handleMkdir}
+      disabled={busy === "mkdir"}
+    >
+      Create
+    </button>
+    <button
+      type="button"
+      className="files-btn"
+      onClick={() => setMkdirName(null)}
+    >
+      Cancel
+    </button>
+  </div>
+)}
+```
+
+d) Inside the entry list, replace the entry `<button>` with a row that includes Download / Delete affordances for files:
+
+```tsx
+<li key={e.name} className="files-entry">
+  <button
+    type="button"
+    className="files-entry-btn"
+    onClick={() =>
+      e.fileType === FileType.FILE_TYPE_DIRECTORY
+        ? openDirectory(joinPath(path, e.name))
+        : openFile(joinPath(path, e.name), e.name)
+    }
+    aria-label={`${typeLabel(e.fileType)} ${e.name}`}
+  >
+    <span className={`files-badge files-badge-${typeLabel(e.fileType).toLowerCase()}`}>
+      {typeLabel(e.fileType)}
+    </span>
+    <span className="files-entry-name">{e.name}</span>
+    <span className="files-entry-size">
+      {e.fileType === FileType.FILE_TYPE_REGULAR ? humanSize(e.size) : ""}
+    </span>
+    <span className="files-entry-time">{formatMtime(e.modifiedMs)}</span>
+  </button>
+  <div className="files-entry-actions">
+    {e.fileType === FileType.FILE_TYPE_REGULAR && (
+      <button
+        type="button"
+        className="files-btn files-btn-sm"
+        onClick={() => handleDownload(e.name)}
+        disabled={busy === `download:${e.name}`}
+        aria-label={`Download ${e.name}`}
+      >
+        Download
+      </button>
+    )}
+    <button
+      type="button"
+      className="files-btn files-btn-sm files-btn-danger"
+      onClick={() => setPendingDelete({ name: e.name, recursive: false })}
+      disabled={busy === "delete"}
+      aria-label={`Delete ${e.name}`}
+    >
+      Delete
+    </button>
+  </div>
+</li>
+```
+
+e) Above the closing `</div>` of `.files-panel`, add the confirm dialog:
+
+```tsx
+{pendingDelete && (
+  <div className="files-dialog-backdrop">
+    <div
+      className="files-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Delete ${pendingDelete.name}`}
+    >
+      <h3 className="files-dialog-title">Delete {pendingDelete.name}?</h3>
+      <label className="files-dialog-option">
+        <input
+          type="checkbox"
+          checked={pendingDelete.recursive}
+          onChange={(e) =>
+            setPendingDelete({
+              name: pendingDelete.name,
+              recursive: e.target.checked,
+            })
+          }
+        />
+        Recursive (delete contents)
+      </label>
+      <div className="files-dialog-actions">
+        <button
+          type="button"
+          className="files-btn"
+          onClick={() => setPendingDelete(null)}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="files-btn files-btn-danger"
+          onClick={handleDelete}
+          disabled={busy === "delete"}
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  </div>
+)}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm --filter @ahand/hub-dashboard test -- device-files
+```
+Expected: all 5 cases pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/hub-dashboard/src/components/device-files.tsx apps/hub-dashboard/tests/device-files.test.tsx
+git commit -m "feat(dashboard): add mkdir/delete/download/upload to DeviceFiles"
+```
+
+---
+
+### Task 5: Wire "Files" tab + CSS styles + final build/test verification
+
+**Goal:** Expose `DeviceFiles` in the tabbed UI, add matching CSS, and confirm the whole Files tab works end-to-end in the Next.js production build.
+
+**Files:**
+- Modify: `apps/hub-dashboard/src/components/device-tabs.tsx`
+- Modify: `apps/hub-dashboard/src/app/globals.css`
+
+**Acceptance Criteria:**
+- [ ] Device detail page shows a "Files" tab whenever `online === true` (same gate as Terminal)
+- [ ] Clicking "Files" mounts `DeviceFiles` with the correct `deviceId`
+- [ ] CSS classes `.files-panel`, `.files-section`, `.files-form-row`, `.files-input`, `.files-btn`, `.files-btn-primary`, `.files-btn-sm`, `.files-btn-danger`, `.files-list`, `.files-entry`, `.files-entry-btn`, `.files-entry-actions`, `.files-breadcrumbs`, `.files-breadcrumb`, `.files-error`, `.files-viewer`, `.files-viewer-text`, `.files-viewer-image`, `.files-dialog-backdrop`, `.files-dialog`, `.files-dialog-actions`, `.files-upload-label`, `.files-upload-input` are defined
+- [ ] `pnpm --filter @ahand/hub-dashboard test` clean
+- [ ] `pnpm --filter @ahand/hub-dashboard build` clean (Next.js production build)
+- [ ] Coverage threshold (`vitest.config.ts`) not breached
+
+**Verify:** `pnpm --filter @ahand/hub-dashboard test && pnpm --filter @ahand/hub-dashboard build`
+
+**Steps:**
+
+- [ ] **Step 1: Add Files tab to `device-tabs.tsx`**
+
+Edit `apps/hub-dashboard/src/components/device-tabs.tsx`. Replace the component to add the Files branch:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { DeviceJobsPanel } from "./device-jobs-panel";
+import { DeviceTerminal } from "./device-terminal";
+import { DeviceBrowser } from "./device-browser";
+import { DeviceFiles } from "./device-files";
+
+export function DeviceTabs({
+  deviceId,
+  online,
+  capabilities,
+}: {
+  deviceId: string;
+  online: boolean;
+  capabilities: string[];
+}) {
+  const hasBrowser = online && capabilities.includes("browser");
+  const [tab, setTab] = useState<"jobs" | "terminal" | "browser" | "files">(
+    hasBrowser ? "browser" : online ? "terminal" : "jobs",
+  );
+
+  return (
+    <article className="surface-panel device-tabs-panel">
+      <div className="device-tabs-header">
+        <button
+          className={`device-tab ${tab === "jobs" ? "device-tab-active" : ""}`}
+          onClick={() => setTab("jobs")}
+        >
+          Jobs
+        </button>
+        {online && (
+          <button
+            className={`device-tab ${tab === "terminal" ? "device-tab-active" : ""}`}
+            onClick={() => setTab("terminal")}
+          >
+            Terminal
+          </button>
+        )}
+        {hasBrowser && (
+          <button
+            className={`device-tab ${tab === "browser" ? "device-tab-active" : ""}`}
+            onClick={() => setTab("browser")}
+          >
+            Browser
+          </button>
+        )}
+        {online && (
+          <button
+            className={`device-tab ${tab === "files" ? "device-tab-active" : ""}`}
+            onClick={() => setTab("files")}
+          >
+            Files
+          </button>
+        )}
+      </div>
+
+      {tab === "jobs" && (
+        <div className="device-tab-content">
+          <DeviceJobsPanel deviceId={deviceId} />
+        </div>
+      )}
+
+      {tab === "terminal" && online && (
+        <DeviceTerminal deviceId={deviceId} />
+      )}
+
+      {tab === "browser" && hasBrowser && (
+        <DeviceBrowser deviceId={deviceId} />
+      )}
+
+      {tab === "files" && online && (
+        <div className="device-tab-content">
+          <DeviceFiles deviceId={deviceId} />
+        </div>
+      )}
+    </article>
+  );
+}
+```
+
+- [ ] **Step 2: Add CSS styles**
+
+Append to `apps/hub-dashboard/src/app/globals.css`:
+
+```css
+/* ---- Files tab ---- */
+.files-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 16px;
+}
+.files-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.files-form-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.files-label {
+  min-width: 96px;
+  color: var(--muted);
+  font-size: 13px;
+}
+.files-input {
+  flex: 1 1 320px;
+  min-width: 0;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface-soft);
+  color: var(--text);
+}
+.files-actions-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.files-breadcrumbs {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  font-size: 13px;
+  color: var(--muted);
+}
+.files-breadcrumb {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 6px;
+}
+.files-breadcrumb:hover,
+.files-breadcrumb:focus-visible {
+  background: var(--surface-soft);
+  outline: none;
+}
+.files-btn {
+  padding: 6px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--surface-soft);
+  color: var(--text);
+  font-size: 13px;
+  cursor: pointer;
+}
+.files-btn:hover:not(:disabled) {
+  background: rgba(148, 163, 184, 0.16);
+}
+.files-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.files-btn-primary {
+  background: var(--accent-strong);
+  color: #0b111b;
+  border-color: var(--accent-strong);
+}
+.files-btn-sm {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+.files-btn-danger {
+  color: #fca5a5;
+  border-color: rgba(252, 165, 165, 0.4);
+}
+.files-upload-label {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+.files-upload-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+.files-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.files-empty {
+  padding: 16px;
+  color: var(--muted);
+  text-align: center;
+}
+.files-entry {
+  display: flex;
+  gap: 8px;
+  padding: 6px 12px;
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+}
+.files-entry:last-child {
+  border-bottom: none;
+}
+.files-entry-btn {
+  flex: 1 1 auto;
+  display: grid;
+  grid-template-columns: 52px 1fr auto auto;
+  gap: 12px;
+  align-items: center;
+  background: none;
+  border: none;
+  color: var(--text);
+  cursor: pointer;
+  padding: 4px 0;
+  text-align: left;
+}
+.files-entry-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  border-radius: 6px;
+}
+.files-badge {
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: var(--surface-soft);
+  color: var(--muted);
+  text-align: center;
+}
+.files-badge-dir {
+  color: var(--accent);
+}
+.files-entry-size,
+.files-entry-time {
+  color: var(--muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+.files-entry-actions {
+  display: flex;
+  gap: 4px;
+}
+.files-error {
+  border: 1px solid rgba(252, 165, 165, 0.4);
+  background: rgba(252, 165, 165, 0.08);
+  color: #fecaca;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 13px;
+}
+.files-viewer {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  background: var(--surface-soft);
+}
+.files-viewer-header {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.files-viewer-path {
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  color: var(--muted);
+  word-break: break-all;
+}
+.files-viewer-text {
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  max-height: 60vh;
+  overflow: auto;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.files-viewer-image {
+  max-width: 100%;
+  max-height: 60vh;
+  display: block;
+  margin: 0 auto;
+}
+.files-viewer-binary {
+  color: var(--muted);
+  font-size: 13px;
+}
+.files-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 15, 29, 0.6);
+  display: grid;
+  place-items: center;
+  z-index: 50;
+}
+.files-dialog {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  width: min(420px, 90vw);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.files-dialog-title {
+  margin: 0;
+  font-size: 16px;
+}
+.files-dialog-option {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 13px;
+  color: var(--muted);
+}
+.files-dialog-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+```
+
+- [ ] **Step 3: Run full dashboard test suite**
+
+```bash
+pnpm --filter @ahand/hub-dashboard test
+```
+Expected: all tests pass.
+
+- [ ] **Step 4: Run production build**
+
+```bash
+pnpm --filter @ahand/hub-dashboard build
+```
+Expected: build completes with no errors. Warnings about static generation are acceptable; a *build error* is not.
+
+- [ ] **Step 5: Manual UI smoke check (dev server)**
+
+```bash
+pnpm --filter @ahand/hub-dashboard dev
+# Open http://localhost:1516/devices/<some-online-device-id>
+# Confirm: Files tab appears → click → path input visible → open /tmp → list shows → click a text file → viewer opens
+```
+This is a manual verification step. If no online device is available in the local env, note that in the PR description ("manual smoke deferred — no dev device available") and rely on the component tests.
+
+- [ ] **Step 6: Commit & push**
+
+```bash
+git add apps/hub-dashboard/src/components/device-tabs.tsx apps/hub-dashboard/src/app/globals.css
+git commit -m "feat(dashboard): wire Files tab + styles"
+git push -u origin feat/dashboard-files-tab
+```
+
+- [ ] **Step 7: Open PR**
+
+```bash
+gh pr create --base dev --title "feat(dashboard): Files tab on device detail page" --body "$(cat <<'EOF'
+## Summary
+- New **Files** tab on the device detail page (`/devices/{id}`), visible whenever the device is online.
+- Operators can list directories, navigate via breadcrumbs, view text and image files, create folders, delete entries (with recursive toggle confirm dialog), download files, and upload files up to 1 MiB.
+- Uploads >1 MiB show "S3 path not implemented yet" (tracking PR #22 per `docs/superpowers/specs/2026-04-12-device-file-operations-design.md`).
+- Thin client helper `file-ops-client.ts` wraps protobuf encode/decode + fetch + the two error-envelope paths (HTTP 4xx JSON and `FileResponse.error`).
+- New pass-through `POST` in `/api/proxy/[...path]/route.ts` forwards protobuf bodies to the hub unchanged.
+
+## Flow checklist
+- [x] list → navigate into folder
+- [x] read text (`read_text`) → viewer renders
+- [x] read image (`read_image`) → viewer renders
+- [x] mkdir
+- [x] delete (confirm dialog + recursive)
+- [x] download (read_binary → Blob → `<a download>`)
+- [x] upload (FullWrite inline ≤ 1 MiB; >1 MiB shows S3-not-implemented message)
+
+## v1 boundaries
+- No S3 large-file path — blocked on PR #22 (per spec "Large File S3 Transfer")
+- No edit / chmod / copy / move / create_symlink UI (backend supports them — deliberately out of scope)
+- No client-side path validation — hub `file_policy` is authoritative and its error message (e.g. `PolicyDenied: /etc/passwd is in dangerous_paths`) is surfaced inline
+
+## Test coverage
+- `tests/auth-server.test.ts` — POST proxy: protobuf body passthrough, 401 no-session, 503 no-base-url
+- `tests/file-ops-client.test.ts` — encode/decode roundtrip, 4xx JSON envelope, proto-level `FileResponse.error`, >1 MiB guard
+- `tests/device-files.test.tsx` — list happy, 4xx error envelope rendering, mkdir happy, delete confirm dialog (Cancel path), upload size guard
+
+## Accessibility
+- Path input has label
+- List items are native `<button>`s with `aria-label`
+- Delete dialog is `role="dialog"` with `aria-modal="true"`
+- Error box is `role="alert"`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Checklist
+
+- [x] Every task has explicit file paths and exact code
+- [x] Every test has the expected assertion codepath
+- [x] Every `Verify:` is an executable command
+- [x] No TODOs, no "similar to earlier task", no unexplained placeholders
+- [x] Types, method names, CSS class names used in later tasks match earlier definitions (`listFiles`, `mkdir`, `deleteFile`, `readBinary`, `writeFile`, `FileOpsError`, `.files-*`)
+- [x] Spec coverage: list/view/mkdir/delete/download/upload all mapped to Task 3 and Task 4; error envelope in Task 2 helper + Task 3 UI; accessibility in Task 3/4/5; build verification in Task 5

--- a/docs/superpowers/plans/2026-04-30-dashboard-files-tab.md.tasks.json
+++ b/docs/superpowers/plans/2026-04-30-dashboard-files-tab.md.tasks.json
@@ -1,0 +1,47 @@
+{
+  "planPath": "docs/superpowers/plans/2026-04-30-dashboard-files-tab.md",
+  "tasks": [
+    {
+      "id": 0,
+      "subject": "Task 0: Workspace wiring — add proto dep + re-export file_ops types + Buffer polyfill",
+      "status": "completed",
+      "description": "**Goal:** Make `FileRequest` / `FileResponse` and related types importable from `@ahandai/proto` inside `apps/hub-dashboard`, and ensure `Buffer` works in the browser bundle.\n\n**Files:**\n- Modify: `apps/hub-dashboard/package.json`\n- Modify: `packages/proto-ts/src/index.ts`\n\n**Acceptance Criteria:**\n- `@ahandai/proto` types import cleanly in hub-dashboard\n- `pnpm install` succeeds\n- `pnpm --filter @ahandai/proto build` succeeds\n- `tsc --noEmit` passes\n\n**Verify:** `pnpm --filter @ahand/hub-dashboard exec tsc --noEmit`\n\n```json:metadata\n{\"files\": [\"apps/hub-dashboard/package.json\", \"packages/proto-ts/src/index.ts\"], \"verifyCommand\": \"pnpm --filter @ahand/hub-dashboard exec tsc --noEmit\", \"acceptanceCriteria\": [\"@ahandai/proto types import cleanly in hub-dashboard\", \"pnpm install succeeds\", \"pnpm --filter @ahandai/proto build succeeds\", \"tsc --noEmit passes\"]}\n```"
+    },
+    {
+      "id": 1,
+      "subject": "Task 1: Dashboard proxy POST handler for protobuf",
+      "status": "completed",
+      "blockedBy": [0],
+      "description": "**Goal:** Teach the dashboard proxy route to forward POST requests (protobuf or JSON) through to the hub with body + `content-type` preserved.\n\n**Files:**\n- Modify: `apps/hub-dashboard/src/app/api/proxy/[...path]/route.ts`\n- Modify: `apps/hub-dashboard/tests/auth-server.test.ts`\n\n**Acceptance Criteria:**\n- POST forwards raw ArrayBuffer body\n- content-type header preserved\n- 401 when session missing\n- 503 when base url missing or fetch error\n- auth-server tests pass\n\n**Verify:** `pnpm --filter @ahand/hub-dashboard test -- auth-server`\n\n```json:metadata\n{\"files\": [\"apps/hub-dashboard/src/app/api/proxy/[...path]/route.ts\", \"apps/hub-dashboard/tests/auth-server.test.ts\"], \"verifyCommand\": \"pnpm --filter @ahand/hub-dashboard test -- auth-server\", \"acceptanceCriteria\": [\"POST forwards raw ArrayBuffer body\", \"content-type header preserved\", \"401 when session missing\", \"503 when base url missing or fetch error\"]}\n```"
+    },
+    {
+      "id": 2,
+      "subject": "Task 2: file-ops-client.ts — typed request builders + encode/decode + error handling",
+      "status": "completed",
+      "blockedBy": [1],
+      "description": "**Goal:** Provide one small, well-tested module the React component can call. It hides protobuf serialization, the Buffer polyfill, and the two error-envelope paths.\n\n**Files:**\n- Create: `apps/hub-dashboard/src/lib/file-ops-client.ts`\n- Create: `apps/hub-dashboard/tests/file-ops-client.test.ts`\n\n**Acceptance Criteria:**\n- Exports listFiles/readText/readImage/readBinary/mkdir/deleteFile/writeFile\n- FileOpsError class with code/message/httpStatus\n- HTTP 4xx JSON envelope → FileOpsError\n- FileResponse.error → FileOpsError\n- writeFile guards against >1 MiB payloads\n- Buffer polyfill idempotent\n\n**Verify:** `pnpm --filter @ahand/hub-dashboard test -- file-ops-client`\n\n```json:metadata\n{\"files\": [\"apps/hub-dashboard/src/lib/file-ops-client.ts\", \"apps/hub-dashboard/tests/file-ops-client.test.ts\"], \"verifyCommand\": \"pnpm --filter @ahand/hub-dashboard test -- file-ops-client\", \"acceptanceCriteria\": [\"Exports typed request builders\", \"FileOpsError handles both error paths\", \"writeFile >1MiB rejects without fetch\", \"Buffer polyfill works in jsdom\"]}\n```"
+    },
+    {
+      "id": 3,
+      "subject": "Task 3: DeviceFiles component — list, navigate, view",
+      "status": "completed",
+      "blockedBy": [2],
+      "description": "**Goal:** Render a Files panel that lets the operator type a path, list a directory, click into subfolders via breadcrumbs, and preview text/image files.\n\n**Files:**\n- Create: `apps/hub-dashboard/src/components/device-files.tsx`\n- Create: `apps/hub-dashboard/tests/device-files.test.tsx`\n\n**Acceptance Criteria:**\n- Path input + Open button → list entries\n- Breadcrumb navigation\n- Dirs-first sort, then alphabetical\n- Click dir → navigate; click file → viewer (text/image/binary)\n- 4xx error envelope renders in role=alert\n- Keyboard accessible\n\n**Verify:** `pnpm --filter @ahand/hub-dashboard test -- device-files`\n\n```json:metadata\n{\"files\": [\"apps/hub-dashboard/src/components/device-files.tsx\", \"apps/hub-dashboard/tests/device-files.test.tsx\"], \"verifyCommand\": \"pnpm --filter @ahand/hub-dashboard test -- device-files\", \"acceptanceCriteria\": [\"List happy path works\", \"4xx error envelope renders\", \"breadcrumbs navigate\", \"text/image/binary viewer states\"]}\n```"
+    },
+    {
+      "id": 4,
+      "subject": "Task 4: mkdir / delete / download / upload",
+      "status": "completed",
+      "blockedBy": [3],
+      "description": "**Goal:** Round out the action set: mkdir inline input, delete confirm dialog with recursive toggle, download via Blob, upload <= 1 MiB inline.\n\n**Files:**\n- Modify: `apps/hub-dashboard/src/components/device-files.tsx`\n- Modify: `apps/hub-dashboard/tests/device-files.test.tsx`\n\n**Acceptance Criteria:**\n- New folder action → inline input → mkdir → re-list\n- Delete → role=dialog aria-modal with recursive checkbox → deleteFile → re-list\n- Download → readBinary → Blob → anchor download → revokeObjectURL\n- Upload <=1 MiB → writeFile; >1 MiB → S3-not-implemented alert, no fetch\n\n**Verify:** `pnpm --filter @ahand/hub-dashboard test -- device-files`\n\n```json:metadata\n{\"files\": [\"apps/hub-dashboard/src/components/device-files.tsx\", \"apps/hub-dashboard/tests/device-files.test.tsx\"], \"verifyCommand\": \"pnpm --filter @ahand/hub-dashboard test -- device-files\", \"acceptanceCriteria\": [\"mkdir happy\", \"delete confirm dialog Cancel\", \"upload >1MiB guard without fetch\", \"download triggers anchor click\"]}\n```"
+    },
+    {
+      "id": 5,
+      "subject": "Task 5: Wire Files tab + CSS styles + final build/test verification",
+      "status": "completed",
+      "blockedBy": [4],
+      "description": "**Goal:** Expose DeviceFiles in the tabbed UI, add matching CSS, confirm Next.js production build is clean.\n\n**Files:**\n- Modify: `apps/hub-dashboard/src/components/device-tabs.tsx`\n- Modify: `apps/hub-dashboard/src/app/globals.css`\n\n**Acceptance Criteria:**\n- Files tab appears when online\n- DeviceFiles renders with deviceId\n- .files-* CSS classes defined\n- All tests pass\n- Next.js production build clean\n- Coverage threshold not breached\n\n**Verify:** `pnpm --filter @ahand/hub-dashboard test && pnpm --filter @ahand/hub-dashboard build`\n\n```json:metadata\n{\"files\": [\"apps/hub-dashboard/src/components/device-tabs.tsx\", \"apps/hub-dashboard/src/app/globals.css\"], \"verifyCommand\": \"pnpm --filter @ahand/hub-dashboard test && pnpm --filter @ahand/hub-dashboard build\", \"acceptanceCriteria\": [\"Files tab wired\", \"CSS classes defined\", \"vitest clean\", \"next build clean\"]}\n```"
+    }
+  ],
+  "lastUpdated": "2026-04-30T00:00:00Z"
+}

--- a/packages/proto-ts/src/index.ts
+++ b/packages/proto-ts/src/index.ts
@@ -53,5 +53,6 @@ export {
   FileMkdirResult,
   ImageFormat,
   WriteAction,
+  DeleteMode,
   fileErrorCodeToJSON,
 } from "./generated/ahand/v1/file_ops.ts";

--- a/packages/proto-ts/src/index.ts
+++ b/packages/proto-ts/src/index.ts
@@ -43,6 +43,7 @@ export {
   FileReadImage,
   FileReadImageResult,
   FileWrite,
+  FileWriteResult,
   FullWrite,
   FileDelete,
   FileDeleteResult,

--- a/packages/proto-ts/src/index.ts
+++ b/packages/proto-ts/src/index.ts
@@ -51,13 +51,6 @@ export {
   FileMkdir,
   FileMkdirResult,
   ImageFormat,
-  DeleteMode,
   WriteAction,
   fileErrorCodeToJSON,
-  fileTypeToJSON,
-} from "./generated/ahand/v1/file_ops.ts";
-
-export type {
-  FileRequest as FileRequestMsg,
-  FileResponse as FileResponseMsg,
 } from "./generated/ahand/v1/file_ops.ts";

--- a/packages/proto-ts/src/index.ts
+++ b/packages/proto-ts/src/index.ts
@@ -28,3 +28,36 @@ export type {
   DeepPartial,
   MessageFns,
 } from "./generated/ahand/v1/envelope.ts";
+
+export {
+  FileRequest,
+  FileResponse,
+  FileError,
+  FileEntry,
+  FileType,
+  FileErrorCode,
+  FileReadText,
+  FileReadTextResult,
+  FileReadBinary,
+  FileReadBinaryResult,
+  FileReadImage,
+  FileReadImageResult,
+  FileWrite,
+  FullWrite,
+  FileDelete,
+  FileDeleteResult,
+  FileList,
+  FileListResult,
+  FileMkdir,
+  FileMkdirResult,
+  ImageFormat,
+  DeleteMode,
+  WriteAction,
+  fileErrorCodeToJSON,
+  fileTypeToJSON,
+} from "./generated/ahand/v1/file_ops.ts";
+
+export type {
+  FileRequest as FileRequestMsg,
+  FileResponse as FileResponseMsg,
+} from "./generated/ahand/v1/file_ops.ts";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,7 +106,7 @@ importers:
         version: 6.2.2
       next:
         specifier: 16.1.6
-        version: 16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -123,6 +123,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.0.1
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^20.19.17
         version: 20.19.32
@@ -156,6 +159,8 @@ importers:
       vitest:
         specifier: 4.0.18
         version: 4.0.18(@types/node@20.19.32)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.12.14(@types/node@20.19.32)(typescript@5.9.3))(tsx@4.21.0)
+
+  crates/ahand-hub: {}
 
   crates/ahand-protocol: {}
 
@@ -738,6 +743,7 @@ packages:
   '@hono/node-ws@1.3.0':
     resolution: {integrity: sha512-ju25YbbvLuXdqBCmLZLqnNYu1nbHIQjoyUqA8ApZOeL1k4skuiTcw5SW77/5SUYo2Xi2NVBJoVlfQurnKEp03Q==}
     engines: {node: '>=18.14.1'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       '@hono/node-server': ^1.19.2
       hono: ^4.6.0
@@ -1202,6 +1208,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -4020,6 +4032,10 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -4788,8 +4804,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -4811,7 +4827,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4822,22 +4838,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4848,7 +4864,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -5535,7 +5551,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@16.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -5544,7 +5560,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.6
       '@next/swc-darwin-x64': 16.1.6
@@ -6022,10 +6038,12 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-jsx@5.1.6(react@19.2.3):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.3):
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
+    optionalDependencies:
+      '@babel/core': 7.29.0
 
   supports-color@7.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
 
   apps/hub-dashboard:
     dependencies:
+      '@ahandai/proto':
+        specifier: workspace:*
+        version: link:../../packages/proto-ts
       '@tanstack/react-query':
         specifier: ^5.90.0
         version: 5.96.1(react@19.2.3)
@@ -95,6 +98,9 @@ importers:
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
+      buffer:
+        specifier: ^6.0.3
+        version: 6.0.3
       jose:
         specifier: ^6.1.3
         version: 6.2.2
@@ -1566,6 +1572,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
@@ -1585,6 +1594,9 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2111,6 +2123,9 @@ packages:
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -4423,6 +4438,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.9.19: {}
 
   brace-expansion@1.1.13:
@@ -4445,6 +4462,11 @@ snapshots:
       electron-to-chromium: 1.5.286
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -5146,6 +5168,8 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 


### PR DESCRIPTION
## Summary

Adds a **Files** tab to the hub-dashboard device detail page (`/devices/{id}`), visible whenever the device is online. Operators can now:

- **List** directory contents, sorted dirs-first then alphabetical
- **Navigate** via path input + Enter, or by clicking breadcrumb segments
- **View** text files (UTF-8 decoded, NUL-byte heuristic falls back to "Binary file" placeholder), PNG/JPG/WEBP images inline, other files as "binary — use Download"
- **Create folders** via an inline "New folder" form
- **Delete** entries via a confirm dialog with a "Recursive" checkbox and Esc-to-close; sends `DELETE_MODE_PERMANENT` on the wire (matches the UI label)
- **Download** any file via a `Blob` + `<a download>` — `a.download` is basename-sanitized so a name like `../etc/passwd` can't suggest a traversal path
- **Upload** any file ≤ 1 MiB inline; larger uploads show "S3 path not implemented yet" per v1 spec (PR #22 tracks the S3 e2e flow)

The Files tab also ships a built-in **debug panel** (collapsed by default) that records the last 20 operations with op / path / latency / status / detail — per the project's standing rule that every hub-dashboard feature must ship with a stats/debug surface.

## What changed

| Area | File | Change |
|------|------|--------|
| proto | `packages/proto-ts/src/index.ts` | Re-export file_ops types so `@ahandai/proto` exposes `FileRequest`, `FileResponse`, `FileEntry`, `FileType`, etc. |
| proxy | `apps/hub-dashboard/src/app/api/proxy/[...path]/route.ts` | New POST handler that forwards body bytes verbatim with `content-type` preserved; upstream response headers are allowlisted (`content-type` / `content-length` / `cache-control` / `etag`) to prevent `set-cookie` or `content-encoding` leakage on mutation responses. GET is untouched — it needs full passthrough for SSE. |
| client | `apps/hub-dashboard/src/lib/file-ops-client.ts` | Typed protobuf helper: `listFiles` / `readText` / `readImage` / `readBinary` / `mkdir` / `deleteFile` / `writeFile` + `FileOpsError`. Handles both error paths (HTTP 4xx JSON envelope + proto-level `FileResponse.error`). Buffer polyfill, content-type guard, explicit 1 MiB write ceiling. |
| UI | `apps/hub-dashboard/src/components/device-files.tsx` | The whole Files tab. ~700 lines, no UI library, uses existing dark-theme CSS tokens. |
| wiring | `apps/hub-dashboard/src/components/device-tabs.tsx` | "Files" tab gated by `online` (no capability check — every daemon supports file ops). All four tab buttons now carry `type="button"`. |
| styles | `apps/hub-dashboard/src/app/globals.css` | `.files-*` classes + debug panel styles. Reuses existing tokens (`--surface`, `--border`, `--accent`). |
| plan | `docs/superpowers/plans/2026-04-30-dashboard-files-tab.md` | Implementation plan. |

## Quality Checklist

- [x] Spec/Quality check — per-task spec review + code quality review after each commit
- [x] Review loop (Claude) — 2 rounds, convergence trajectory 8 → 4 → 0 Important+ issues
- [x] Test completeness — 97/97 pass; every public client function, every UI action (including error path for list), and the debug panel are covered
- [ ] Copilot review — skipped per fast-track (per-task reviews already done)
- [ ] Codex review — skipped per fast-track
- [ ] Documentation consistency — plan doc shipped; no README/CHANGELOG changes needed (feature is user-visible only through the UI)
- [x] No merge conflicts — verified via `git merge --no-commit --no-ff origin/dev`
- [ ] CI passing — will run on push

## Test Plan

```
pnpm --filter @ahand/hub-dashboard test    # 97/97 pass
pnpm --filter @ahand/hub-dashboard build   # clean next build
```

6 core flow checklist (verified through component tests):

- [x] **list** → navigate into folder via breadcrumb
- [x] **read text** → viewer renders
- [x] **read image** → viewer renders as data: URL
- [x] **mkdir** → re-list shows new folder
- [x] **delete** → confirm dialog, recursive checkbox, Cancel/Esc both close without fetch, Delete sends PERMANENT mode then re-lists
- [x] **download** → `readBinary` → Blob → anchor click → `URL.revokeObjectURL` (deferred via `setTimeout(0)` for Safari)
- [x] **upload** ≤ 1 MiB → `writeFile`; > 1 MiB → "S3 path not implemented yet" alert, no fetch

## v1 boundaries (explicitly out of scope)

- **Large-file S3 transfer** — blocked on PR #22; > 1 MiB surfaces a clear "not implemented" error rather than silently truncating.
- **edit / chmod / copy / move / create_symlink** — backend supports them, but no UI in v1.
- **Client-side path validation** — the daemon's `file_policy` is authoritative; the UI surfaces 4xx envelope messages (e.g. "POLICY_DENIED: /etc/passwd is in dangerous_paths") inline in a `role="alert"` box.
- **Dialog focus trap** — `role="dialog"` + `aria-modal="true"` + `aria-labelledby` + Esc-to-close are shipped; automatic focus trap is deferred (requires a library or non-trivial manual wiring; reviewers agreed this is MVP-acceptable).

## Known follow-ups

- GET `/api/proxy/[...path]` still uses full upstream header passthrough because SSE resume needs it. The POST path's header allowlist is a pattern to carry over to GET, but GET would require a narrower allowlist that includes `text/event-stream` + `last-event-id` + `cache-control: no-cache` + `x-accel-buffering` — out of scope here, worth a follow-up.

## Security notes

- **Path traversal via upload filename:** `file.name` is basename-sanitized before composing the target path. The daemon's `file_policy` catches anything that slips through, but the displayed target path now matches what actually happens.
- **Filename injection via `a.download`:** entry `name` is basename-sanitized so a listing entry with slashes can't construct a cross-folder suggested filename.
- **Upstream header leakage on POST proxy:** mutation responses are no longer a silent cookie-injection primitive; tested explicitly for `set-cookie` stripping.
- **Content-type sniffing:** `sendRequest` rejects 200 responses whose content-type is not `application/x-protobuf`, so a proxy redirect to an HTML login page cannot decode into garbage `FileResponse` fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)