### PR TITLE
chore(release): CI publish workflow + bump sdk/proto to 0.2.0

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -1,0 +1,105 @@
+name: Release @ahandai/sdk + @ahandai/proto
+
+# Publishes both npm packages in lockstep.
+#
+# Two trigger modes:
+#  - push of a `release-v<semver>` tag (normal release path)
+#  - manual workflow_dispatch (for dry-runs or ad-hoc re-publishes)
+#
+# The tag version MUST match the `version` field in BOTH packages'
+# package.json. This prevents accidental releases from a mis-tagged
+# commit. When triggered manually from workflow_dispatch, the job
+# skips the tag check; dry_run=true then verifies the publish-time
+# contents without touching the npm registry.
+#
+# Auth uses npm trusted publishers via OIDC — no NPM_TOKEN secret.
+# Each package MUST be configured on npmjs.com:
+#   Package settings → Publishing access → Trusted publisher
+#     Organization / user: team9ai
+#     Repository:          aHand
+#     Workflow filename:   release-sdk.yml
+#     Environment:         (empty)
+#
+# Publish order is proto → sdk because sdk depends on @ahandai/proto
+# via `workspace:*`; pnpm rewrites the dependency to the concrete
+# version at publish time, so proto must already exist on the registry
+# when sdk is published.
+
+on:
+  push:
+    tags:
+      - 'release-v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (skip actual npm publish)'
+        type: boolean
+        default: false
+
+permissions:
+  id-token: write   # Required for npm trusted-publisher OIDC + --provenance
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify tag version matches package.json versions
+        if: startsWith(github.ref, 'refs/tags/release-v')
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${GITHUB_REF_NAME#release-v}"
+          PROTO_VERSION=$(node -p "require('./packages/proto-ts/package.json').version")
+          SDK_VERSION=$(node -p "require('./packages/sdk/package.json').version")
+          echo "tag=$TAG_VERSION proto=$PROTO_VERSION sdk=$SDK_VERSION"
+          if [ "$TAG_VERSION" != "$PROTO_VERSION" ]; then
+            echo "::error::Tag $TAG_VERSION does not match @ahandai/proto version $PROTO_VERSION"
+            exit 1
+          fi
+          if [ "$TAG_VERSION" != "$SDK_VERSION" ]; then
+            echo "::error::Tag $TAG_VERSION does not match @ahandai/sdk version $SDK_VERSION"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build @ahandai/proto
+        run: pnpm -F @ahandai/proto build
+
+      - name: Build @ahandai/sdk
+        run: pnpm -F @ahandai/sdk build
+
+      - name: Test @ahandai/sdk
+        run: pnpm -F @ahandai/sdk test
+
+      # ── Dry-run path (workflow_dispatch with dry_run=true) ─────────────
+      - name: Dry-run publish @ahandai/proto
+        if: ${{ inputs.dry_run == true }}
+        run: pnpm -F @ahandai/proto publish --access public --no-git-checks --dry-run
+
+      - name: Dry-run publish @ahandai/sdk
+        if: ${{ inputs.dry_run == true }}
+        run: pnpm -F @ahandai/sdk publish --access public --no-git-checks --dry-run
+
+      # ── Real publish path (tag push, or manual with dry_run=false) ─────
+      - name: Publish @ahandai/proto
+        if: ${{ inputs.dry_run != true }}
+        run: pnpm -F @ahandai/proto publish --access public --no-git-checks --provenance
+        env:
+          NPM_CONFIG_PROVENANCE: 'true'
+
+      - name: Publish @ahandai/sdk
+        if: ${{ inputs.dry_run != true }}
+        run: pnpm -F @ahandai/sdk publish --access public --no-git-checks --provenance
+        env:
+          NPM_CONFIG_PROVENANCE: 'true'

--- a/packages/proto-ts/CHANGELOG.md
+++ b/packages/proto-ts/CHANGELOG.md
@@ -1,0 +1,32 @@
+# @ahandai/proto Changelog
+
+## 0.2.0 — 2026-04-30
+
+Released alongside `@ahandai/sdk@0.2.0`. Both packages are now published
+via CI (`.github/workflows/release-sdk.yml`) on a `release-v<semver>` tag
+push, using npm trusted-publisher OIDC (no long-lived token).
+
+### Added
+
+- **`FileRequest` / `FileResponse`** wire types for the 14 file operations
+  defined in `proto/ahand/v1/file_ops.proto`: `stat`, `list`, `glob`,
+  `read_text`, `read_binary`, `read_image`, `write`, `edit`, `delete`,
+  `chmod`, `mkdir`, `copy`, `move`, `create_symlink`. Consumed by the hub
+  for dashboard / control-plane file operations and by the daemon's
+  `file_manager`. Generated via `ts-proto` from the upstream proto source;
+  no hand-written code.
+
+### Notes
+
+- `@ahandai/sdk@0.2.0`'s `CloudClient.files()` does **not** depend on
+  these types directly — it uses the JSON control-plane endpoint
+  (`POST /api/control/files`). These generated types are provided for
+  consumers that interact with the raw protobuf envelope (e.g. in-process
+  hub integrations).
+
+## 0.1.4 — 2026-04-24
+
+Last manually-published version. See git history for earlier changes:
+- `chore(sdk): rename npm scope @ahand/{sdk,proto} → @ahandai/{sdk,proto}` (#5)
+- `fix(proto,sdk): emit .js suffix in generated imports` (#6)
+- `fix(sdk,proto): add "type": "module"` (#7)

--- a/packages/proto-ts/package.json
+++ b/packages/proto-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahandai/proto",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "ts-proto generated types for ahand protocol",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,6 +1,10 @@
 # @ahandai/sdk Changelog
 
-## Unreleased
+## 0.2.0 — 2026-04-30
+
+Released alongside `@ahandai/proto@0.2.0`. Both packages are now published
+via CI (`.github/workflows/release-sdk.yml`) on a `release-v<semver>` tag
+push, using npm trusted-publisher OIDC (no long-lived token).
 
 ### Breaking
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ahandai/sdk",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "AHand cloud control plane SDK",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release-sdk.yml` — publishes both `@ahandai/proto` and `@ahandai/sdk` in lockstep on `release-v<semver>` tag push, via npm trusted-publisher OIDC (no `NPM_TOKEN` secret).
- Bumps `@ahandai/proto` **0.1.4 → 0.2.0** (`file_ops.ts` wire types have been present since 0.1.4 shipped; this is the first release that includes them on npm).
- Bumps `@ahandai/sdk` **0.1.6 → 0.2.0** (`CloudClient.files()` + `CloudClient.browser()` + breaking rename `BrowserResult` → `DeviceBrowserResult` on the WS side).
- CHANGELOGs promoted from `Unreleased` → `0.2.0 — 2026-04-30`; new `CHANGELOG.md` added for proto-ts.

Why minor (not patch): both packages are pre-1.0, and the sdk ships a breaking rename. Both bumps keep the minor aligned so downstream consumers only see one version to track.

Why proto before sdk in the workflow: sdk depends on `@ahandai/proto` via `workspace:*`; pnpm rewrites this to the concrete version at publish time, so proto must already exist on the registry when sdk is published.

## How the release flow works after merge

1. Merge this PR to `dev`.
2. Push tag `release-v0.2.0` from the merge commit.
3. CI verifies the tag version matches **both** `package.json` versions, builds both packages, runs the sdk test suite, then publishes proto → sdk via OIDC with provenance.

Manual fallback: `workflow_dispatch` with `dry_run=true` runs the same steps but skips the final `pnpm publish`, so the workflow itself can be exercised without touching the registry.

## npm trusted-publisher setup (already done)

Both packages have GitHub Actions trusted-publisher configured on npmjs.com:
- Organization/user: `team9ai`
- Repository: `aHand`
- Workflow filename: `release-sdk.yml`
- Environment: (empty)

## Test plan

- [x] `pnpm install --frozen-lockfile` in worktree
- [x] `pnpm -F @ahandai/proto build`
- [x] `pnpm -F @ahandai/sdk build`
- [x] `pnpm -F @ahandai/sdk test` — 156/156 passing
- [x] `pnpm -F @ahandai/proto publish --dry-run` — tarball contains `file_ops.{d.ts,js}`
- [x] `pnpm -F @ahandai/sdk publish --dry-run` — tarball contains `CloudClient.files()`
- [ ] After merge: push tag `release-v0.2.0` and verify CI publishes both packages successfully
- [ ] After publish: `npm view @ahandai/sdk@0.2.0 version` and `npm view @ahandai/proto@0.2.0 version` return `0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)