### PR TITLE
fix(release): bump Node to 24 + use npm CLI for actual publish

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -50,8 +50,18 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          # 22.14+ + npm CLI 11.5.1+ are required by npm trusted-publisher
+          # OIDC. Earlier setups produced misleading PUT 404s after a
+          # successful sigstore provenance signing — npm rejects the
+          # registry auth and returns 404 instead of 401 for security.
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify tool versions
+        run: |
+          node --version
+          npm --version
+          # Trusted-publisher OIDC requires npm CLI >= 11.5.1.
 
       - name: Verify tag version matches package.json versions
         if: startsWith(github.ref, 'refs/tags/release-v')
@@ -92,14 +102,32 @@ jobs:
         run: pnpm -F @ahandai/sdk publish --access public --no-git-checks --dry-run
 
       # ── Real publish path (tag push, or manual with dry_run=false) ─────
-      - name: Publish @ahandai/proto
+      #
+      # Final publish goes through the npm CLI (not pnpm) because npm is
+      # the official OIDC trusted-publisher exchange implementation. pnpm's
+      # publish wrapper does not perform the npm/registry token exchange
+      # needed by trusted publishers — it only signs sigstore provenance,
+      # which is necessary but not sufficient. (See npm/cli#8678.)
+      #
+      # We still use `pnpm pack` to produce the tarball, because it
+      # rewrites `workspace:*` dependencies into concrete versions
+      # (verified locally: sdk's @ahandai/proto: workspace:* becomes
+      # @ahandai/proto: 0.2.0 in the tarball's package.json). `npm publish`
+      # alone would fail because npm does not recognize `workspace:*`.
+      - name: Pack + publish @ahandai/proto
         if: ${{ inputs.dry_run != true }}
-        run: pnpm -F @ahandai/proto publish --access public --no-git-checks --provenance
+        working-directory: packages/proto-ts
+        run: |
+          pnpm pack
+          npm publish ./ahandai-proto-*.tgz --access public --provenance
         env:
           NPM_CONFIG_PROVENANCE: 'true'
 
-      - name: Publish @ahandai/sdk
+      - name: Pack + publish @ahandai/sdk
         if: ${{ inputs.dry_run != true }}
-        run: pnpm -F @ahandai/sdk publish --access public --no-git-checks --provenance
+        working-directory: packages/sdk
+        run: |
+          pnpm pack
+          npm publish ./ahandai-sdk-*.tgz --access public --provenance
         env:
           NPM_CONFIG_PROVENANCE: 'true'


### PR DESCRIPTION
## Summary

Follow-up to #31 — the first \`release-v0.2.0\` tag run failed three times with a misleading \`PUT 404 Not Found\` from npm immediately AFTER the sigstore provenance statement was successfully signed. Root causes (per Codex investigation + [npm/cli#8678](https://github.com/npm/cli/issues/8678)):

1. **Node 20 ships an npm CLI < 11.5.1**, which is the version that performs the npm registry's trusted-publisher token exchange. Older clients sign sigstore provenance fine (that path uses GitHub's OIDC) but silently fail the npm-side OIDC handshake — npm returns \`404\` instead of \`401\` for security reasons.
2. **pnpm's publish wrapper does not perform the npm trusted-publisher token exchange.** It only signs sigstore provenance.

## Fix

- **Node 20 → Node 24** in the workflow.
- **Add a 'Verify tool versions' step** that prints \`node --version\` and \`npm --version\` so any future CLI regression is loud.
- **Final publish goes through npm CLI directly** (not pnpm):
  - \`pnpm pack\` first — this is still required because npm publish does not understand \`workspace:*\`. \`pnpm pack\` rewrites \`workspace:*\` dependencies to concrete versions in the tarball's package.json (verified: sdk's \`@ahandai/proto: workspace:*\` becomes \`@ahandai/proto: 0.2.0\`).
  - \`npm publish ./*.tgz --access public --provenance\` — performs the npm trusted-publisher OIDC exchange.

## Local verification

Full simulated CI run:

- \`pnpm install --frozen-lockfile\` ✅
- \`pnpm -F @ahandai/{proto,sdk} build\` ✅
- \`pnpm -F @ahandai/sdk test\` — **156/156 passing** ✅
- \`pnpm pack\` for both packages ✅ — sdk's \`workspace:*\` correctly rewritten to \`0.2.0\`
- \`npm publish *.tgz --dry-run\` for both ✅

Local npm is 10.9.2 (still < 11.5.1) so this PR does not change local pre-publish behavior; only CI uses the new path.

## Test plan

- [x] Local install + build + test + pack + dry-run publish
- [ ] After merge: re-run the \`release-v0.2.0\` workflow (or retag); confirm both packages publish successfully and provenance shows on npm UI
- [ ] \`npm view @ahandai/sdk@0.2.0 version\` and \`npm view @ahandai/proto@0.2.0 version\` both return \`0.2.0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)