### PR TITLE
feat(hub-store): log when outbox reconcile takes the bootstrap branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,7 @@ dependencies = [
  "sqlx",
  "testcontainers",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/ahand-hub-store/Cargo.toml
+++ b/crates/ahand-hub-store/Cargo.toml
@@ -25,6 +25,7 @@ serde_json.workspace = true
 sqlx.workspace = true
 testcontainers = { workspace = true, optional = true }
 tokio.workspace = true
+tracing = { workspace = true }
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/ahand-hub-store/src/outbox_lua.rs
+++ b/crates/ahand-hub-store/src/outbox_lua.rs
@@ -47,6 +47,9 @@ pub const RECONCILE_ON_HELLO: &str = r#"
 -- ARGV[1] = session_id
 -- ARGV[2] = last_ack (decimal)
 -- ARGV[3] = retention_secs
+-- Returns {branch, seq} where branch=1 ⇒ bootstrap path fired
+-- (server lost state; trusted device's last_ack as the seq floor),
+-- branch=0 ⇒ normal path (trim or no-op).
 if redis.call('GET', KEYS[1]) ~= ARGV[1] then
   return redis.error_reply('NOT_OWNER stale session')
 end
@@ -56,12 +59,12 @@ if last_ack > current then
   redis.call('SET', KEYS[2], last_ack)
   redis.call('DEL', KEYS[3])
   redis.call('EXPIRE', KEYS[2], ARGV[3])
-  return last_ack
+  return {1, last_ack}
 end
 if last_ack > 0 then
   redis.call('XTRIM', KEYS[3], 'MINID', '0-' .. (last_ack + 1))
 end
-return current
+return {0, current}
 "#;
 
 pub const FENCED_INCR_SEQ: &str = r#"

--- a/crates/ahand-hub-store/src/outbox_store.rs
+++ b/crates/ahand-hub-store/src/outbox_store.rs
@@ -165,7 +165,7 @@ impl OutboxStore for RedisOutboxStore {
         last_ack: u64,
     ) -> Result<u64> {
         let mut conn = self.conn.lock().await;
-        let returned: u64 = self
+        let result: (i64, u64) = self
             .scripts
             .reconcile_on_hello
             .key(Self::lock_key(device_id))
@@ -177,7 +177,16 @@ impl OutboxStore for RedisOutboxStore {
             .invoke_async(&mut *conn)
             .await
             .map_err(map_redis_err)?;
-        Ok(returned)
+        let (branch, seq) = result;
+        if branch == 1 {
+            tracing::warn!(
+                device_id = %device_id,
+                last_ack = last_ack,
+                seq_floor = seq,
+                "outbox bootstrap: device's last_ack exceeded server's max issued seq; trusted device's value as the new seq floor (any in-flight server-issued frames before this point have been dropped)",
+            );
+        }
+        Ok(seq)
     }
 
     async fn unacked_frames(&self, device_id: &str, last_ack: u64) -> Result<Vec<Vec<u8>>> {

--- a/crates/ahand-hub/src/ws/in_memory_outbox.rs
+++ b/crates/ahand-hub/src/ws/in_memory_outbox.rs
@@ -110,7 +110,16 @@ impl OutboxStore for InMemoryOutboxStore {
             return Err(HubError::Unauthorized);
         }
         if last_ack > entry.seq {
-            // Bootstrap path
+            // Bootstrap path: server lost state, trust the device's
+            // last_ack as the new seq floor. Logged at WARN so operators
+            // can see post-deploy how many devices fell into this branch
+            // (matches the RedisOutboxStore log line for symmetry).
+            tracing::warn!(
+                device_id = %device_id,
+                last_ack = last_ack,
+                seq_floor = last_ack,
+                "outbox bootstrap: device's last_ack exceeded server's max issued seq; trusted device's value as the new seq floor (any in-flight server-issued frames before this point have been dropped)",
+            );
             entry.seq = last_ack;
             entry.buffer.clear();
             return Ok(last_ack);


### PR DESCRIPTION
## Summary

Small follow-up to PR #33 / #15 (hub outbox persistence). Adds runtime observability to the bootstrap recovery branch — until now you couldn't tell from CloudWatch whether N devices recovered via this branch after a deploy.

## Change

- `RECONCILE_ON_HELLO` Lua now returns \`{branch, seq}\` instead of \`seq\` (branch=1 ⇒ bootstrap path fired, 0 ⇒ normal trim or no-op).
- \`RedisOutboxStore::reconcile_on_hello\` decodes the tuple and emits \`tracing::warn!\` when branch=1; trait API unchanged (still returns \`Result<u64>\`).
- \`InMemoryOutboxStore::reconcile_on_hello\` mirrors the same warn for symmetry.
- Adds \`tracing\` as a runtime dep on \`ahand-hub-store\`.

Log line:
\`\`\`
WARN outbox bootstrap: device's last_ack exceeded server's max issued seq;
trusted device's value as the new seq floor (any in-flight server-issued
frames before this point have been dropped) device_id=... last_ack=... seq_floor=...
\`\`\`

## Why this matters

After a hub deploy (or any in-memory state loss), devices that were connected before the rollover hit this branch on first reconnect. With this log, operators can:

- Count how many devices fell into the bootstrap branch post-deploy (proxy for "how disruptive was this deploy")
- Spot devices that hit it repeatedly (might indicate other state-loss scenarios)
- Confirm the fix is actually triggering when expected, not just hoping the absence of \`invalid peer ack\` lines is sufficient

## Test plan

- [x] \`cargo build --tests -p ahand-hub -p ahand-hub-store\` clean
- [x] \`cargo clippy -p ahand-hub-core -p ahand-hub-store -p ahand-hub --tests --features test-support -- -D warnings\` clean
- [x] \`cargo test -p ahand-hub --lib ws::in_memory_outbox\` 14/14 pass
- [ ] CI green (testcontainer integration tests against Redis 7-alpine; existing reconcile tests assert returned u64 — unchanged)
- [ ] Post-deploy: \`/ecs/ahand-hub\` shows the new log line for any device that recovers via bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)