### PR TITLE
docs(sdk): @deprecated CloudClient.browser() — caller removed in agent-pi#104

### DIFF
--- a/packages/sdk/src/cloud-client.ts
+++ b/packages/sdk/src/cloud-client.ts
@@ -491,6 +491,18 @@ export class CloudClient {
    * response into camelCase + `Uint8Array` for binary payloads, and
    * resolves with a `BrowserResult`. Errors map to the same taxonomy
    * as `spawn()` (401→`unauthorized`, 504→`timeout`, etc).
+   *
+   * @deprecated As of 2026-04-30 this method has no live callers. It
+   * was used by team9-agent-pi's `AhandBackend.browser()`, which was
+   * deleted (team9ai/agent-pi#104) when browser automation migrated
+   * to the SKILL model — agents now drive `playwright-cli` via
+   * `run_command` against the device's installed binary instead of
+   * routing through the hub. The underlying hub endpoint
+   * `/api/control/browser` is retained behind a deprecation banner;
+   * see `crates/ahand-hub/src/http/browser.rs`. Do NOT add new
+   * callers without revisiting that decision; if a future non-
+   * playwright backend needs browser dispatch, design the new
+   * pathway end-to-end rather than reviving this one.
    */
   async browser(params: BrowserParams): Promise<BrowserResult> {
     if (params.signal?.aborted) {


### PR DESCRIPTION
## Summary

Doc-only follow-up to the browser-tool → SKILL migration (Phase B).

The SDK method \`CloudClient.browser()\` had exactly one consumer: team9-agent-pi's \`AhandBackend.browser()\`. That caller was deleted in [team9ai/agent-pi#104](https://github.com/team9ai/agent-pi/pull/104) (merged \`efbc56cf\`) when browser automation moved to the SKILL model — agents now drive \`playwright-cli\` via \`run_command\` against the device's installed binary, not through the hub's \`/api/control/browser\` endpoint.

Per the Phase A + Phase B design (see [team9 docs/superpowers/specs/2026-04-29-ahand-browser-runtime-install-design.md](https://github.com/team9ai/team9/blob/dev/docs/superpowers/specs/2026-04-29-ahand-browser-runtime-install-design.md) Task 9 Step 6), we picked **Option A — retain the SDK method with a \`@deprecated\` JSDoc** rather than deleting it, so the entry point stays available for the rare future case where a non-playwright backend might want hub-routed browser dispatch. Reviving it should be a deliberate design decision, not an accident — the JSDoc says so.

## Changes

- Add \`@deprecated\` JSDoc paragraph to \`CloudClient.browser()\` at \`packages/sdk/src/cloud-client.ts\`.

No code changes, no behavior changes, no API changes.

## Test Plan

- [x] \`pnpm lint\` (\`tsc --noEmit\`) clean in \`packages/sdk\`
- [x] \`pnpm test\` green: 78/78 SDK tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)