### PR TITLE
[codex] Add plugin runtime stage 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,7 @@ name = "ahandctl"
 version = "0.1.2"
 dependencies = [
  "ahand-protocol",
+ "ahandd",
  "anyhow",
  "clap",
  "dirs 5.0.1",

--- a/apps/admin/src/lib/api.ts
+++ b/apps/admin/src/lib/api.ts
@@ -89,6 +89,9 @@ export type PluginStatus =
   | "failed"
   | "blocked";
 
+export type HostPlatform = "darwin" | "linux" | "windows";
+export type HostArch = "arm64" | "x64";
+
 export type HostResourceValue =
   | { kind: "executable"; name: string; path: string; version?: string }
   | { kind: "directory"; name: string; path: string }
@@ -107,8 +110,8 @@ export interface InstalledPluginResource {
 
 export interface HostResourceSnapshot {
   runtimeVersion: string;
-  platform: string;
-  arch: string;
+  platform: HostPlatform;
+  arch: HostArch;
   plugins: InstalledPluginResource[];
 }
 

--- a/apps/admin/src/lib/api.ts
+++ b/apps/admin/src/lib/api.ts
@@ -82,6 +82,36 @@ export interface StatusResponse {
   data_dir_size: number;
 }
 
+export type PluginStatus =
+  | "installed"
+  | "missing"
+  | "outdated"
+  | "failed"
+  | "blocked";
+
+export type HostResourceValue =
+  | { kind: "executable"; name: string; path: string; version?: string }
+  | { kind: "directory"; name: string; path: string }
+  | { kind: "env"; name: string; value: string }
+  | { kind: "config"; name: string; value: unknown };
+
+export interface InstalledPluginResource {
+  id: string;
+  version: string;
+  status: PluginStatus;
+  dependencies: string[];
+  capabilities: string[];
+  resources: Record<string, HostResourceValue>;
+  helpPrompt?: string;
+}
+
+export interface HostResourceSnapshot {
+  runtimeVersion: string;
+  platform: string;
+  arch: string;
+  plugins: InstalledPluginResource[];
+}
+
 export interface LogEntry {
   ts_ms: number;
   direction: string;
@@ -117,6 +147,10 @@ export interface RunDetail {
 export const api = {
   async getStatus(): Promise<StatusResponse> {
     return fetchAPI("/status");
+  },
+
+  async getHostResource(): Promise<HostResourceSnapshot> {
+    return fetchAPI("/host-resource");
   },
 
   async getConfig(): Promise<any> {

--- a/crates/ahandctl/Cargo.toml
+++ b/crates/ahandctl/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 ahand-protocol = { path = "../ahand-protocol" }
+ahandd = { path = "../ahandd" }
 tokio.workspace = true
 prost.workspace = true
 anyhow.workspace = true

--- a/crates/ahandctl/src/admin.rs
+++ b/crates/ahandctl/src/admin.rs
@@ -91,6 +91,7 @@ pub async fn serve(port: u16, config_path: Option<String>, no_open: bool) -> Res
 
     let api = warp::path("api").and(
         status_route(token_arc.clone(), config_arc.clone())
+            .or(host_resource_route(token_arc.clone()))
             .or(config_get_route(token_arc.clone(), config_arc.clone()))
             .or(config_put_route(token_arc.clone(), config_arc.clone()))
             .or(logs_route(token_arc.clone()))
@@ -195,6 +196,23 @@ fn status_route(
                         eprintln!("Status error: {}", e);
                         Err(reject::reject())
                     }
+                }
+            }
+        })
+}
+
+fn host_resource_route(
+    token: Arc<String>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    warp::path!("host-resource")
+        .and(warp::get())
+        .and(with_auth(token))
+        .and_then(|| async move {
+            match ahandd::plugin_runtime::get_host_resource().await {
+                Ok(snapshot) => Ok::<_, Rejection>(warp::reply::json(&snapshot)),
+                Err(e) => {
+                    eprintln!("Host resource error: {}", e);
+                    Err(reject::reject())
                 }
             }
         })

--- a/crates/ahandd/src/browser.rs
+++ b/crates/ahandd/src/browser.rs
@@ -414,23 +414,20 @@ impl BrowserManager {
     }
 
     fn binary_path(&self) -> PathBuf {
-        match &self.config.binary_path {
-            Some(p) => PathBuf::from(p),
-            None => {
-                // Prefer the aHand-managed Node.js installation
-                let ahand_path = dirs::home_dir()
-                    .unwrap_or_else(|| PathBuf::from("/tmp"))
-                    .join(".ahand")
-                    .join("node")
-                    .join("bin")
-                    .join("playwright-cli");
-                if ahand_path.exists() {
-                    ahand_path
-                } else {
-                    PathBuf::from("playwright-cli") // fallback to PATH
-                }
-            }
+        let managed = crate::plugin_runtime::RuntimeDirs::new()
+            .ok()
+            .map(|dirs| dirs.playwright_cli_bin());
+        Self::resolve_binary_path(self.config.binary_path.as_deref(), managed)
+    }
+
+    fn resolve_binary_path(configured: Option<&str>, managed: Option<PathBuf>) -> PathBuf {
+        if let Some(path) = configured {
+            return PathBuf::from(path);
         }
+
+        managed
+            .filter(|path| path.exists())
+            .unwrap_or_else(|| PathBuf::from("playwright-cli"))
     }
 
     fn build_cli_args(
@@ -460,10 +457,9 @@ impl BrowserManager {
     fn build_env_vars(&self) -> Vec<(String, String)> {
         let mut envs = Vec::new();
 
-        // Prepend our locally-installed Node.js to PATH so playwright-cli
-        // can find dependencies.
-        if let Some(home) = dirs::home_dir() {
-            let node_bin_dir = home.join(".ahand").join("node").join("bin");
+        // Prepend the managed Node.js runtime to PATH so playwright-cli can find node.
+        if let Ok(runtime) = crate::plugin_runtime::RuntimeDirs::new() {
+            let node_bin_dir = runtime.node_dir().join("bin");
             if node_bin_dir.is_dir() {
                 let system_path = std::env::var("PATH").unwrap_or_default();
                 envs.push((
@@ -863,5 +859,35 @@ mod tests {
         assert!(!is_download_complete(Path::new("/tmp/file.crdownload")));
         assert!(!is_download_complete(Path::new("/tmp/file.part")));
         assert!(!is_download_complete(Path::new("/tmp/file.tmp")));
+    }
+
+    #[test]
+    fn binary_path_uses_explicit_config() {
+        let managed = PathBuf::from("/tmp/managed/playwright-cli");
+        let resolved =
+            BrowserManager::resolve_binary_path(Some("/custom/playwright-cli"), Some(managed));
+
+        assert_eq!(resolved, PathBuf::from("/custom/playwright-cli"));
+    }
+
+    #[test]
+    fn binary_path_uses_existing_managed_runtime_cli() {
+        let dir = tempfile::tempdir().unwrap();
+        let managed = dir.path().join("playwright-cli");
+        std::fs::write(&managed, "").unwrap();
+
+        let resolved = BrowserManager::resolve_binary_path(None, Some(managed.clone()));
+
+        assert_eq!(resolved, managed);
+    }
+
+    #[test]
+    fn binary_path_falls_back_to_path_when_managed_cli_is_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let managed = dir.path().join("missing-playwright-cli");
+
+        let resolved = BrowserManager::resolve_binary_path(None, Some(managed));
+
+        assert_eq!(resolved, PathBuf::from("playwright-cli"));
     }
 }

--- a/crates/ahandd/src/browser_setup/mod.rs
+++ b/crates/ahandd/src/browser_setup/mod.rs
@@ -85,7 +85,7 @@ pub async fn inspect_all() -> Vec<CheckReport> {
 pub async fn inspect(name: &str) -> Option<CheckReport> {
     match name {
         "node" => Some(node::inspect().await),
-        "playwright" => Some(playwright::inspect().await),
+        "playwright" | "browser-playwright-cli" => Some(playwright::inspect().await),
         "browser" => Some(inspect_browser()),
         _ => None,
     }
@@ -123,8 +123,10 @@ pub async fn run_all(
     Ok(vec![node_report, playwright_report, browser_report])
 }
 
-/// Run a single install step. Valid names: `node`, `playwright`.
-/// Returns an error for `playwright` if Node is not already installed.
+/// Run a single install step. Valid names: `node`, `playwright`,
+/// `browser-playwright-cli`, plus non-installable plugin ids for diagnostics.
+/// Returns an error for `playwright`/`browser-playwright-cli` if Node is not
+/// already installed.
 ///
 /// **Progress-callback note:** `Phase::Done` is emitted even on failure
 /// (see `wrap_failure`); use the `Result` return value, not the callback,
@@ -140,26 +142,31 @@ pub async fn run_step(
             Ok(r) => Ok(r),
             Err(e) => Err(wrap_failure(e, "node", "Node.js", progress_ref)),
         },
-        "playwright" => {
+        "playwright" | "browser-playwright-cli" => {
             let node_status = node::inspect().await;
             if !matches!(node_status.status, CheckStatus::Ok { .. }) {
                 bail!(
-                    "playwright step requires node to be installed first. \
+                    "browser-playwright-cli requires node to be installed first. \
                      Run `ahandd browser-init --step node` first, or \
-                     `ahandd browser-init` for all steps."
+                     `ahandd plugin install browser-playwright-cli`."
                 );
             }
             match playwright::ensure(force, progress_ref).await {
                 Ok(r) => Ok(r),
                 Err(e) => Err(wrap_failure(
                     e,
-                    "playwright",
+                    "browser-playwright-cli",
                     "playwright-cli",
                     progress_ref,
                 )),
             }
         }
-        other => bail!("unknown step `{other}`. Valid steps: node, playwright"),
+        "shell" | "file" | "python" => {
+            bail!("plugin `{name}` does not have an install step in this release")
+        }
+        other => bail!(
+            "unknown step `{other}`. Valid install steps: node, playwright, browser-playwright-cli"
+        ),
     }
 }
 
@@ -268,6 +275,23 @@ mod tests {
         assert!(inspect("playwright").await.is_some());
         assert!(inspect("browser").await.is_some());
         assert!(inspect("nothing").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn inspect_accepts_plugin_id_aliases() {
+        assert!(inspect("node").await.is_some());
+        assert!(inspect("playwright").await.is_some());
+        assert!(inspect("browser-playwright-cli").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn run_step_rejects_file_plugin_because_it_has_no_installer() {
+        let progress = |_: ProgressEvent| {};
+        let err = run_step("file", false, progress)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("does not have an install step"));
     }
 
     #[test]

--- a/crates/ahandd/src/browser_setup/node.rs
+++ b/crates/ahandd/src/browser_setup/node.rs
@@ -10,22 +10,46 @@ pub const NODE_LTS_VERSION: &str = "24.13.0";
 pub struct Dirs {
     pub ahand: PathBuf,
     pub node: PathBuf,
+    runtime: crate::plugin_runtime::RuntimeDirs,
 }
 
 impl Dirs {
     pub fn new() -> Result<Self> {
-        let home = dirs::home_dir().context("cannot determine home directory")?;
-        let ahand = home.join(".ahand");
-        Ok(Self {
-            node: ahand.join("node"),
+        let runtime = crate::plugin_runtime::RuntimeDirs::new()?;
+        Ok(Self::from_runtime(runtime))
+    }
+
+    pub fn from_runtime_root(root: PathBuf) -> Self {
+        Self::from_runtime(crate::plugin_runtime::RuntimeDirs::from_root(root))
+    }
+
+    fn from_runtime(runtime: crate::plugin_runtime::RuntimeDirs) -> Self {
+        let ahand = dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".ahand");
+        let node = runtime.node_dir();
+        Self {
             ahand,
-        })
+            node,
+            runtime,
+        }
+    }
+
+    pub fn local_node_bin(&self) -> PathBuf {
+        self.runtime.node_bin()
+    }
+
+    pub fn npm_bin(&self) -> PathBuf {
+        self.runtime.npm_bin()
+    }
+
+    pub fn playwright_cli_bin(&self) -> PathBuf {
+        self.runtime.playwright_cli_bin()
     }
 }
 
 fn local_node_bin() -> Result<PathBuf> {
-    let dirs = Dirs::new()?;
-    Ok(dirs.node.join("bin").join("node"))
+    Ok(Dirs::new()?.local_node_bin())
 }
 
 /// Read-only check: report current Node.js status.
@@ -93,7 +117,7 @@ pub async fn ensure(
     progress: &(dyn Fn(ProgressEvent) + Send + Sync),
 ) -> Result<CheckReport> {
     let dirs = Dirs::new()?;
-    let local_node = dirs.node.join("bin").join("node");
+    let local_node = dirs.local_node_bin();
 
     if !force && local_node.exists() {
         if let Some(ver) = read_node_major_version(&local_node).await {
@@ -282,6 +306,21 @@ mod tests {
     use super::*;
     use std::sync::{Arc, Mutex};
 
+    #[test]
+    fn dirs_use_plugin_runtime_node_directory() {
+        let root = PathBuf::from("/tmp/ahand-primary-runtime");
+        let dirs = Dirs::from_runtime_root(root);
+
+        assert_eq!(
+            dirs.node,
+            PathBuf::from("/tmp/ahand-primary-runtime/dependencies/node")
+        );
+        assert_eq!(
+            dirs.local_node_bin(),
+            PathBuf::from("/tmp/ahand-primary-runtime/dependencies/node/bin/node")
+        );
+    }
+
     // ---------------------------------------------------------------------------
     // Task 4 verification: node.rs has NO subprocess install calls — the entire
     // install path is pure-Rust (reqwest HTTP download + xz2/tar extraction).
@@ -351,10 +390,7 @@ mod tests {
         );
 
         // Verify the phase sequence matches install_node()'s order
-        let phases: Vec<String> = events
-            .iter()
-            .map(|e| format!("{:?}", e.phase))
-            .collect();
+        let phases: Vec<String> = events.iter().map(|e| format!("{:?}", e.phase)).collect();
         assert_eq!(
             phases,
             vec!["Starting", "Downloading", "Extracting", "Verifying", "Done"]
@@ -373,28 +409,25 @@ mod tests {
         let bin_dir = dir.path().join("bin");
         std::fs::create_dir_all(&bin_dir).unwrap();
         let node_bin = bin_dir.join("node");
-        std::fs::write(
-            &node_bin,
-            "#!/bin/sh\necho 'v24.13.0'\n",
-        )
-        .unwrap();
+        std::fs::write(&node_bin, "#!/bin/sh\necho 'v24.13.0'\n").unwrap();
         let mut perms = std::fs::metadata(&node_bin).unwrap().permissions();
         perms.set_mode(0o755);
         std::fs::set_permissions(&node_bin, perms).unwrap();
 
         // read_node_major_version reads the binary directly, so test it in isolation
         let version = read_node_major_version(&node_bin).await;
-        assert_eq!(version, Some(24), "fake node binary should report major version 24");
+        assert_eq!(
+            version,
+            Some(24),
+            "fake node binary should report major version 24"
+        );
     }
 
     /// Confirms read_node_major_version returns None for a binary that fails to run.
     #[tokio::test]
     async fn read_node_major_version_returns_none_for_nonexistent_bin() {
         let version = read_node_major_version(std::path::Path::new("/nonexistent/node")).await;
-        assert_eq!(
-            version, None,
-            "nonexistent binary should return None"
-        );
+        assert_eq!(version, None, "nonexistent binary should return None");
     }
 
     /// Confirms read_node_major_version returns None when output is unparseable.
@@ -411,10 +444,7 @@ mod tests {
         std::fs::set_permissions(&bin, perms).unwrap();
 
         let version = read_node_major_version(&bin).await;
-        assert_eq!(
-            version, None,
-            "garbage version output should return None"
-        );
+        assert_eq!(version, None, "garbage version output should return None");
     }
 
     /// Confirms read_node_major_version parses the standard `vMAJOR.MINOR.PATCH` format.
@@ -443,9 +473,6 @@ mod tests {
             ["darwin", "linux", "win"].contains(&os),
             "unexpected os: {os}"
         );
-        assert!(
-            ["arm64", "x64"].contains(&arch),
-            "unexpected arch: {arch}"
-        );
+        assert!(["arm64", "x64"].contains(&arch), "unexpected arch: {arch}");
     }
 }

--- a/crates/ahandd/src/browser_setup/playwright.rs
+++ b/crates/ahandd/src/browser_setup/playwright.rs
@@ -11,9 +11,9 @@ use super::types::{
 
 pub const PLAYWRIGHT_CLI_VERSION: &str = "0.1.1";
 
-fn cli_path() -> Result<PathBuf> {
+pub fn cli_path() -> Result<PathBuf> {
     let dirs = Dirs::new()?;
-    Ok(dirs.node.join("bin").join("playwright-cli"))
+    Ok(dirs.playwright_cli_bin())
 }
 
 /// Read-only check: report current playwright-cli status.
@@ -171,7 +171,7 @@ pub async fn ensure(
     progress: &(dyn Fn(ProgressEvent) + Send + Sync),
 ) -> Result<CheckReport> {
     let dirs = Dirs::new()?;
-    let npm = dirs.node.join("bin").join("npm");
+    let npm = dirs.npm_bin();
     if !npm.exists() {
         anyhow::bail!(
             "npm not found at {} — install Node.js first (`ahandd browser-init --step node`)",

--- a/crates/ahandd/src/cli/browser_init.rs
+++ b/crates/ahandd/src/cli/browser_init.rs
@@ -10,7 +10,7 @@ pub async fn run(force: bool, step: Option<String>) -> Result<()> {
         Some(name) => {
             let report = browser_setup::run_step(name, force, progress).await?;
             println!();
-            println!("Step `{name}` complete.");
+            println!("Plugin step `{name}` complete.");
             print_summary(&[report]);
         }
         None => {

--- a/crates/ahandd/src/lib.rs
+++ b/crates/ahandd/src/lib.rs
@@ -7,6 +7,7 @@ pub mod device_identity;
 pub mod executor;
 pub mod file_manager;
 pub mod outbox;
+pub mod plugin_runtime;
 pub mod registry;
 pub mod session;
 pub mod store;

--- a/crates/ahandd/src/main.rs
+++ b/crates/ahandd/src/main.rs
@@ -17,6 +17,7 @@ mod session;
 mod store;
 pub mod updater;
 
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -104,6 +105,29 @@ enum Cmd {
     },
     /// Diagnose browser automation setup and report missing components
     BrowserDoctor,
+    Plugin {
+        #[command(subcommand)]
+        command: PluginCmd,
+    },
+}
+
+#[derive(Subcommand)]
+enum PluginCmd {
+    /// Inspect all plugins or a single plugin
+    Doctor { plugin: Option<String> },
+    /// Install a plugin and required dependencies
+    Install {
+        plugin: String,
+        #[arg(long)]
+        force: bool,
+    },
+    /// Reinstall or repair a plugin
+    Repair { plugin: String },
+    /// Print getHostResource JSON
+    HostResource {
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[tokio::main]
@@ -120,6 +144,9 @@ async fn main() -> anyhow::Result<()> {
             }
             Cmd::BrowserDoctor => {
                 return cli::browser_doctor::run().await;
+            }
+            Cmd::Plugin { command } => {
+                return run_plugin_command(command).await;
             }
         }
     }
@@ -437,6 +464,85 @@ async fn main() -> anyhow::Result<()> {
     result
 }
 
+async fn run_plugin_command(command: &PluginCmd) -> anyhow::Result<()> {
+    match command {
+        PluginCmd::Doctor { plugin } => {
+            let snapshot = plugin_runtime::get_host_resource().await?;
+            let mut matched = false;
+            for item in snapshot.plugins {
+                if plugin.as_deref().is_some_and(|id| id != item.id) {
+                    continue;
+                }
+                matched = true;
+                println!("{}: {:?}", item.id, item.status);
+            }
+            if let Some(plugin) = plugin
+                && !matched
+            {
+                anyhow::bail!("unknown plugin `{plugin}`");
+            }
+            Ok(())
+        }
+        PluginCmd::Install { plugin, force } => run_plugin_install(plugin, *force).await,
+        PluginCmd::Repair { plugin } => run_plugin_install(plugin, true).await,
+        PluginCmd::HostResource { json } => {
+            let snapshot = plugin_runtime::get_host_resource().await?;
+            if *json {
+                println!("{}", serde_json::to_string_pretty(&snapshot)?);
+            } else {
+                for plugin in snapshot.plugins {
+                    println!("{}: {:?}", plugin.id, plugin.status);
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+async fn run_plugin_install(plugin: &str, force: bool) -> anyhow::Result<()> {
+    for step in install_steps_for(plugin)? {
+        cli::browser_init::run(force, Some(step)).await?;
+    }
+    Ok(())
+}
+
+fn install_steps_for(plugin: &str) -> anyhow::Result<Vec<String>> {
+    let registry = plugin_runtime::builtin::builtin_registry()?;
+    let activation_order = registry.activation_order()?;
+    let mut required = BTreeSet::new();
+    collect_plugin_and_dependencies(plugin, &registry, &mut required)?;
+
+    let steps = activation_order
+        .into_iter()
+        .filter(|id| required.contains(id) && has_install_step(id))
+        .collect::<Vec<_>>();
+
+    if steps.is_empty() {
+        anyhow::bail!("plugin `{plugin}` does not have an install step in this release");
+    }
+
+    Ok(steps)
+}
+
+fn collect_plugin_and_dependencies(
+    plugin: &str,
+    registry: &plugin_runtime::PluginRegistry,
+    required: &mut BTreeSet<String>,
+) -> anyhow::Result<()> {
+    let manifest = registry
+        .get(plugin)
+        .ok_or_else(|| anyhow::anyhow!("unknown plugin `{plugin}`"))?;
+    for dependency in &manifest.dependencies {
+        collect_plugin_and_dependencies(dependency, registry, required)?;
+    }
+    required.insert(plugin.to_string());
+    Ok(())
+}
+
+fn has_install_step(plugin: &str) -> bool {
+    matches!(plugin, "node" | "browser-playwright-cli")
+}
+
 fn write_pid_file(data_dir: &Option<PathBuf>) -> Option<PathBuf> {
     let dir = data_dir.as_ref()?;
     if let Err(e) = std::fs::create_dir_all(dir) {
@@ -458,5 +564,40 @@ fn cleanup_pid_file(pid_path: &Option<PathBuf>) {
         } else {
             tracing::info!(path = %path.display(), "removed PID file");
         }
+    }
+}
+
+#[cfg(test)]
+mod plugin_cli_tests {
+    use super::*;
+
+    #[test]
+    fn browser_plugin_install_steps_include_node_dependency_first() {
+        assert_eq!(
+            install_steps_for("browser-playwright-cli").unwrap(),
+            vec!["node".to_string(), "browser-playwright-cli".to_string()]
+        );
+    }
+
+    #[test]
+    fn node_plugin_install_steps_include_only_node() {
+        assert_eq!(install_steps_for("node").unwrap(), vec!["node".to_string()]);
+    }
+
+    #[test]
+    fn non_installable_plugin_reports_no_install_step() {
+        let err = install_steps_for("file").unwrap_err().to_string();
+        assert!(err.contains("does not have an install step"));
+    }
+
+    #[tokio::test]
+    async fn plugin_doctor_rejects_unknown_plugin() {
+        let err = run_plugin_command(&PluginCmd::Doctor {
+            plugin: Some("does-not-exist".to_string()),
+        })
+        .await
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("unknown plugin `does-not-exist`"));
     }
 }

--- a/crates/ahandd/src/main.rs
+++ b/crates/ahandd/src/main.rs
@@ -10,6 +10,7 @@ mod file_manager;
 mod ipc;
 mod openclaw;
 mod outbox;
+mod plugin_runtime;
 mod policy;
 mod registry;
 mod session;

--- a/crates/ahandd/src/plugin_runtime/builtin.rs
+++ b/crates/ahandd/src/plugin_runtime/builtin.rs
@@ -1,0 +1,110 @@
+use super::manifest::PluginManifest;
+use super::registry::PluginRegistry;
+
+const SHELL: &str = r#"
+id = "shell"
+version = "0.1.0"
+display_name = "Shell"
+dependencies = []
+capabilities = ["shell"]
+
+[resources.executables.shell]
+name = "shell"
+path = "$SHELL"
+
+[help]
+prompt = "Provides local command execution, PTY sessions, stdin forwarding, terminal resize, cwd/env propagation, and stdout/stderr streaming."
+"#;
+
+const NODE: &str = r#"
+id = "node"
+version = "0.1.0"
+display_name = "Node.js Runtime"
+dependencies = []
+capabilities = []
+
+[resources.executables.node]
+name = "node"
+path = "dependencies/node/bin/node"
+
+[resources.executables.npm]
+name = "npm"
+path = "dependencies/node/bin/npm"
+
+[help]
+prompt = "Use the managed Node.js runtime for JavaScript-based local tools. Prefer this path over system node when a plugin depends on node."
+"#;
+
+const PYTHON: &str = r#"
+id = "python"
+version = "0.1.0"
+display_name = "Python Runtime"
+dependencies = []
+capabilities = []
+
+[resources.executables.python]
+name = "python"
+path = "dependencies/python/bin/python3"
+
+[help]
+prompt = "Use the managed Python runtime for Python-based local tools and scripts."
+"#;
+
+const FILE: &str = r#"
+id = "file"
+version = "0.1.0"
+display_name = "File Operations"
+dependencies = []
+capabilities = ["file"]
+
+[help]
+prompt = "Provides file list, read, write, edit, delete, stat, glob, mkdir, copy, move, symlink, and chmod operations under daemon file policy."
+"#;
+
+const BROWSER_PLAYWRIGHT_CLI: &str = r#"
+id = "browser-playwright-cli"
+version = "0.1.0"
+display_name = "Browser Playwright CLI"
+dependencies = ["shell", "node"]
+capabilities = ["browser"]
+
+[resources.executables.playwrightCli]
+name = "playwright-cli"
+path = "dependencies/node/bin/playwright-cli"
+
+[help]
+prompt = "Provides browser automation through playwright-cli. Use for browser open, click, fill, snapshot, screenshot, PDF, download, and close actions."
+"#;
+
+pub fn builtin_registry() -> anyhow::Result<PluginRegistry> {
+    let manifests = [SHELL, NODE, PYTHON, FILE, BROWSER_PLAYWRIGHT_CLI]
+        .into_iter()
+        .map(PluginManifest::parse)
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    PluginRegistry::new(manifests)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_manifests_parse_and_include_expected_ids() {
+        let registry = builtin_registry().unwrap();
+        let ids: Vec<_> = registry.manifests().map(|m| m.id.as_str()).collect();
+
+        assert_eq!(
+            ids,
+            vec!["browser-playwright-cli", "file", "node", "python", "shell"]
+        );
+    }
+
+    #[test]
+    fn browser_playwright_declares_shell_and_node_dependencies() {
+        let registry = builtin_registry().unwrap();
+        let manifest = registry.get("browser-playwright-cli").unwrap();
+
+        assert_eq!(manifest.dependencies, vec!["shell", "node"]);
+        assert_eq!(manifest.capabilities, vec!["browser"]);
+    }
+}

--- a/crates/ahandd/src/plugin_runtime/host_resource.rs
+++ b/crates/ahandd/src/plugin_runtime/host_resource.rs
@@ -13,30 +13,62 @@ pub async fn get_host_resource() -> anyhow::Result<HostResourceSnapshot> {
     let registry = builtin_registry()?;
     let runtime = RuntimeDirs::new()?;
     let node_report = crate::browser_setup::node::inspect().await;
-    let node_is_ok = matches!(node_report.status, CheckStatus::Ok { .. });
+    let shell_candidate = shell_path();
+    let mut dependency_statuses = BTreeMap::new();
+    dependency_statuses.insert(
+        "shell".to_string(),
+        shell_status_from_path(&shell_candidate),
+    );
+    if let Some(manifest) = registry.get("node") {
+        dependency_statuses.insert(
+            "node".to_string(),
+            node_resource(manifest, &runtime, &node_report).status,
+        );
+    }
 
     let mut plugins = Vec::new();
     for manifest in registry.manifests() {
         plugins.push(match manifest.id.as_str() {
-            "shell" => shell_resource(manifest),
+            "shell" => shell_resource_from_path(manifest, shell_candidate.clone()),
             "file" => file_resource(manifest),
             "node" => node_resource(manifest, &runtime, &node_report),
             "python" => python_resource(manifest, &runtime).await,
-            "browser-playwright-cli" => browser_playwright_resource(manifest, node_is_ok).await,
+            "browser-playwright-cli" => {
+                browser_playwright_resource(manifest, &dependency_statuses).await
+            }
             _ => manifest_resource(manifest, PluginStatus::Missing, BTreeMap::new()),
         });
     }
 
     Ok(HostResourceSnapshot {
         runtime_version: env!("CARGO_PKG_VERSION").to_string(),
-        platform: std::env::consts::OS.to_string(),
-        arch: std::env::consts::ARCH.to_string(),
+        platform: host_platform(),
+        arch: host_arch(),
         plugins,
     })
 }
 
-fn shell_resource(manifest: &PluginManifest) -> InstalledPluginResource {
-    shell_resource_from_path(manifest, shell_path())
+fn host_platform() -> String {
+    normalize_platform(std::env::consts::OS).to_string()
+}
+
+fn normalize_platform(platform: &str) -> &str {
+    match platform {
+        "macos" => "darwin",
+        other => other,
+    }
+}
+
+fn host_arch() -> String {
+    normalize_arch(std::env::consts::ARCH).to_string()
+}
+
+fn normalize_arch(arch: &str) -> &str {
+    match arch {
+        "aarch64" => "arm64",
+        "x86_64" => "x64",
+        other => other,
+    }
 }
 
 fn shell_path() -> String {
@@ -62,7 +94,7 @@ fn shell_path() -> String {
 }
 
 fn shell_resource_from_path(manifest: &PluginManifest, shell: String) -> InstalledPluginResource {
-    if !Path::new(&shell).is_file() {
+    if shell_status_from_path(&shell) != PluginStatus::Installed {
         return manifest_resource(manifest, PluginStatus::Missing, BTreeMap::new());
     }
 
@@ -77,6 +109,34 @@ fn shell_resource_from_path(manifest: &PluginManifest, shell: String) -> Install
     );
 
     manifest_resource(manifest, PluginStatus::Installed, resources)
+}
+
+fn shell_status_from_path(shell: &str) -> PluginStatus {
+    if is_executable_file(Path::new(shell)) {
+        PluginStatus::Installed
+    } else {
+        PluginStatus::Missing
+    }
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        path.metadata()
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+
+    #[cfg(not(unix))]
+    {
+        true
+    }
 }
 
 fn file_resource(manifest: &PluginManifest) -> InstalledPluginResource {
@@ -148,9 +208,9 @@ async fn python_resource(
 
 async fn browser_playwright_resource(
     manifest: &PluginManifest,
-    node_is_ok: bool,
+    dependency_statuses: &BTreeMap<String, PluginStatus>,
 ) -> InstalledPluginResource {
-    if !node_is_ok {
+    if !dependencies_installed(manifest, dependency_statuses) {
         return manifest_resource(manifest, PluginStatus::Blocked, BTreeMap::new());
     }
 
@@ -172,6 +232,16 @@ async fn browser_playwright_resource(
     };
 
     manifest_resource(manifest, status, resources)
+}
+
+fn dependencies_installed(
+    manifest: &PluginManifest,
+    dependency_statuses: &BTreeMap<String, PluginStatus>,
+) -> bool {
+    manifest
+        .dependencies
+        .iter()
+        .all(|dependency| dependency_statuses.get(dependency) == Some(&PluginStatus::Installed))
 }
 
 fn manifest_resource(
@@ -242,6 +312,15 @@ mod tests {
         }
     }
 
+    fn manifest_with_dependencies(id: &str, dependencies: &[&str]) -> PluginManifest {
+        let mut manifest = manifest(id);
+        manifest.dependencies = dependencies
+            .iter()
+            .map(|dependency| dependency.to_string())
+            .collect();
+        manifest
+    }
+
     #[tokio::test]
     async fn snapshot_contains_first_party_plugins() {
         let snapshot = get_host_resource().await.unwrap();
@@ -274,6 +353,15 @@ mod tests {
                 .as_ref()
                 .is_some_and(|prompt| prompt.contains("browser automation"))
         );
+    }
+
+    #[test]
+    fn platform_and_arch_use_public_host_resource_vocabulary() {
+        assert_eq!(normalize_platform("macos"), "darwin");
+        assert_eq!(normalize_platform("linux"), "linux");
+        assert_eq!(normalize_platform("windows"), "windows");
+        assert_eq!(normalize_arch("aarch64"), "arm64");
+        assert_eq!(normalize_arch("x86_64"), "x64");
     }
 
     #[test]
@@ -310,6 +398,22 @@ mod tests {
         assert!(plugin.resources.is_empty());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn shell_resource_missing_when_candidate_is_not_executable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let shell = dir.path().join("shell");
+        std::fs::write(&shell, "#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&shell, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let plugin = shell_resource_from_path(&manifest("shell"), path_to_string(shell));
+
+        assert_eq!(plugin.status, PluginStatus::Missing);
+        assert!(plugin.resources.is_empty());
+    }
+
     #[test]
     fn shell_resource_missing_when_candidate_is_absent() {
         let dir = tempfile::tempdir().unwrap();
@@ -318,6 +422,20 @@ mod tests {
         let plugin = shell_resource_from_path(&manifest("shell"), path_to_string(missing));
 
         assert_eq!(plugin.status, PluginStatus::Missing);
+        assert!(plugin.resources.is_empty());
+    }
+
+    #[tokio::test]
+    async fn browser_plugin_blocks_when_shell_dependency_is_missing() {
+        let manifest = manifest_with_dependencies("browser-playwright-cli", &["shell", "node"]);
+        let dependency_statuses = BTreeMap::from([
+            ("shell".to_string(), PluginStatus::Missing),
+            ("node".to_string(), PluginStatus::Installed),
+        ]);
+
+        let plugin = browser_playwright_resource(&manifest, &dependency_statuses).await;
+
+        assert_eq!(plugin.status, PluginStatus::Blocked);
         assert!(plugin.resources.is_empty());
     }
 }

--- a/crates/ahandd/src/plugin_runtime/host_resource.rs
+++ b/crates/ahandd/src/plugin_runtime/host_resource.rs
@@ -1,0 +1,323 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use crate::browser_setup::CheckStatus;
+
+use super::builtin::builtin_registry;
+use super::{
+    HostResourceSnapshot, HostResourceValue, InstalledPluginResource, PluginManifest, PluginStatus,
+    RuntimeDirs,
+};
+
+pub async fn get_host_resource() -> anyhow::Result<HostResourceSnapshot> {
+    let registry = builtin_registry()?;
+    let runtime = RuntimeDirs::new()?;
+    let node_report = crate::browser_setup::node::inspect().await;
+    let node_is_ok = matches!(node_report.status, CheckStatus::Ok { .. });
+
+    let mut plugins = Vec::new();
+    for manifest in registry.manifests() {
+        plugins.push(match manifest.id.as_str() {
+            "shell" => shell_resource(manifest),
+            "file" => file_resource(manifest),
+            "node" => node_resource(manifest, &runtime, &node_report),
+            "python" => python_resource(manifest, &runtime).await,
+            "browser-playwright-cli" => browser_playwright_resource(manifest, node_is_ok).await,
+            _ => manifest_resource(manifest, PluginStatus::Missing, BTreeMap::new()),
+        });
+    }
+
+    Ok(HostResourceSnapshot {
+        runtime_version: env!("CARGO_PKG_VERSION").to_string(),
+        platform: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        plugins,
+    })
+}
+
+fn shell_resource(manifest: &PluginManifest) -> InstalledPluginResource {
+    shell_resource_from_path(manifest, shell_path())
+}
+
+fn shell_path() -> String {
+    std::env::var("SHELL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            if cfg!(windows) {
+                std::env::var("COMSPEC")
+                    .ok()
+                    .filter(|value| !value.trim().is_empty())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| {
+            if cfg!(windows) {
+                "cmd.exe".to_string()
+            } else {
+                "/bin/sh".to_string()
+            }
+        })
+}
+
+fn shell_resource_from_path(manifest: &PluginManifest, shell: String) -> InstalledPluginResource {
+    if !Path::new(&shell).is_file() {
+        return manifest_resource(manifest, PluginStatus::Missing, BTreeMap::new());
+    }
+
+    let mut resources = BTreeMap::new();
+    resources.insert(
+        "shell".to_string(),
+        HostResourceValue::Executable {
+            name: "shell".to_string(),
+            path: shell,
+            version: None,
+        },
+    );
+
+    manifest_resource(manifest, PluginStatus::Installed, resources)
+}
+
+fn file_resource(manifest: &PluginManifest) -> InstalledPluginResource {
+    manifest_resource(manifest, PluginStatus::Installed, BTreeMap::new())
+}
+
+fn node_resource(
+    manifest: &PluginManifest,
+    runtime: &RuntimeDirs,
+    report: &crate::browser_setup::CheckReport,
+) -> InstalledPluginResource {
+    let mut resources = BTreeMap::new();
+    let status = match &report.status {
+        CheckStatus::Ok { version, path, .. } => {
+            let npm = runtime.npm_bin();
+            resources.insert(
+                "node".to_string(),
+                HostResourceValue::Executable {
+                    name: "node".to_string(),
+                    path: path_to_string(path),
+                    version: Some(version.clone()),
+                },
+            );
+            if npm.is_file() {
+                resources.insert(
+                    "npm".to_string(),
+                    HostResourceValue::Executable {
+                        name: "npm".to_string(),
+                        path: path_to_string(npm),
+                        version: None,
+                    },
+                );
+                PluginStatus::Installed
+            } else {
+                PluginStatus::Failed
+            }
+        }
+        other => plugin_status_from_check(other),
+    };
+
+    manifest_resource(manifest, status, resources)
+}
+
+async fn python_resource(
+    manifest: &PluginManifest,
+    runtime: &RuntimeDirs,
+) -> InstalledPluginResource {
+    let python = runtime.python_bin();
+    if !python.exists() {
+        return manifest_resource(manifest, PluginStatus::Missing, BTreeMap::new());
+    }
+
+    let Ok(version) = executable_version(&python).await else {
+        return manifest_resource(manifest, PluginStatus::Failed, BTreeMap::new());
+    };
+
+    let mut resources = BTreeMap::new();
+    resources.insert(
+        "python".to_string(),
+        HostResourceValue::Executable {
+            name: "python".to_string(),
+            path: path_to_string(python),
+            version,
+        },
+    );
+
+    manifest_resource(manifest, PluginStatus::Installed, resources)
+}
+
+async fn browser_playwright_resource(
+    manifest: &PluginManifest,
+    node_is_ok: bool,
+) -> InstalledPluginResource {
+    if !node_is_ok {
+        return manifest_resource(manifest, PluginStatus::Blocked, BTreeMap::new());
+    }
+
+    let report = crate::browser_setup::playwright::inspect().await;
+    let mut resources = BTreeMap::new();
+    let status = match &report.status {
+        CheckStatus::Ok { version, path, .. } => {
+            resources.insert(
+                "playwrightCli".to_string(),
+                HostResourceValue::Executable {
+                    name: "playwright-cli".to_string(),
+                    path: path_to_string(path),
+                    version: Some(version.clone()),
+                },
+            );
+            PluginStatus::Installed
+        }
+        other => plugin_status_from_check(other),
+    };
+
+    manifest_resource(manifest, status, resources)
+}
+
+fn manifest_resource(
+    manifest: &PluginManifest,
+    status: PluginStatus,
+    resources: BTreeMap<String, HostResourceValue>,
+) -> InstalledPluginResource {
+    InstalledPluginResource {
+        id: manifest.id.clone(),
+        version: manifest.version.clone(),
+        status,
+        dependencies: manifest.dependencies.clone(),
+        capabilities: manifest.capabilities.clone(),
+        resources,
+        help_prompt: manifest.help.as_ref().map(|help| help.prompt.clone()),
+    }
+}
+
+fn plugin_status_from_check(status: &CheckStatus) -> PluginStatus {
+    match status {
+        CheckStatus::Ok { .. } => PluginStatus::Installed,
+        CheckStatus::Missing | CheckStatus::NoneDetected { .. } => PluginStatus::Missing,
+        CheckStatus::Outdated { .. } => PluginStatus::Outdated,
+        CheckStatus::Failed { .. } => PluginStatus::Failed,
+    }
+}
+
+async fn executable_version(path: &Path) -> anyhow::Result<Option<String>> {
+    let output = tokio::process::Command::new(path)
+        .arg("--version")
+        .output()
+        .await?;
+    if !output.status.success() {
+        anyhow::bail!("{} --version exited with {}", path.display(), output.status);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !stdout.is_empty() {
+        return Ok(Some(stdout));
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if stderr.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(stderr))
+    }
+}
+
+fn path_to_string(path: impl AsRef<Path>) -> String {
+    path.as_ref().to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::browser_setup::{CheckReport, CheckSource, CheckStatus};
+    use std::path::PathBuf;
+
+    fn manifest(id: &str) -> PluginManifest {
+        PluginManifest {
+            id: id.to_string(),
+            version: "0.1.0".to_string(),
+            display_name: id.to_string(),
+            dependencies: Vec::new(),
+            capabilities: Vec::new(),
+            resources: Default::default(),
+            help: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn snapshot_contains_first_party_plugins() {
+        let snapshot = get_host_resource().await.unwrap();
+        let ids: Vec<_> = snapshot
+            .plugins
+            .iter()
+            .map(|plugin| plugin.id.as_str())
+            .collect();
+
+        assert_eq!(
+            ids,
+            vec!["browser-playwright-cli", "file", "node", "python", "shell"]
+        );
+    }
+
+    #[tokio::test]
+    async fn browser_plugin_reports_shell_and_node_dependencies() {
+        let snapshot = get_host_resource().await.unwrap();
+        let plugin = snapshot
+            .plugins
+            .iter()
+            .find(|plugin| plugin.id == "browser-playwright-cli")
+            .unwrap();
+
+        assert_eq!(plugin.dependencies, vec!["shell", "node"]);
+        assert_eq!(plugin.capabilities, vec!["browser"]);
+        assert!(
+            plugin
+                .help_prompt
+                .as_ref()
+                .is_some_and(|prompt| prompt.contains("browser automation"))
+        );
+    }
+
+    #[test]
+    fn node_resource_does_not_report_missing_npm_executable() {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = RuntimeDirs::from_root(dir.path().to_path_buf());
+        let report = CheckReport {
+            name: "node",
+            label: "Node.js",
+            status: CheckStatus::Ok {
+                version: "24.13.0".to_string(),
+                path: PathBuf::from("/tmp/node"),
+                source: CheckSource::Managed,
+            },
+            fix_hint: None,
+        };
+
+        let plugin = node_resource(&manifest("node"), &runtime, &report);
+
+        assert_eq!(plugin.status, PluginStatus::Failed);
+        assert!(plugin.resources.contains_key("node"));
+        assert!(!plugin.resources.contains_key("npm"));
+    }
+
+    #[tokio::test]
+    async fn python_resource_fails_when_path_is_not_executable() {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = RuntimeDirs::from_root(dir.path().to_path_buf());
+        std::fs::create_dir_all(runtime.python_bin()).unwrap();
+
+        let plugin = python_resource(&manifest("python"), &runtime).await;
+
+        assert_eq!(plugin.status, PluginStatus::Failed);
+        assert!(plugin.resources.is_empty());
+    }
+
+    #[test]
+    fn shell_resource_missing_when_candidate_is_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing-shell");
+
+        let plugin = shell_resource_from_path(&manifest("shell"), path_to_string(missing));
+
+        assert_eq!(plugin.status, PluginStatus::Missing);
+        assert!(plugin.resources.is_empty());
+    }
+}

--- a/crates/ahandd/src/plugin_runtime/manifest.rs
+++ b/crates/ahandd/src/plugin_runtime/manifest.rs
@@ -1,0 +1,117 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PluginManifest {
+    pub id: String,
+    pub version: String,
+    pub display_name: String,
+    #[serde(default)]
+    pub dependencies: Vec<String>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    #[serde(default)]
+    pub resources: ResourceManifest,
+    #[serde(default)]
+    pub help: Option<HelpManifest>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceManifest {
+    #[serde(default)]
+    pub executables: BTreeMap<String, ExecutableResourceManifest>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutableResourceManifest {
+    pub name: String,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HelpManifest {
+    pub prompt: String,
+}
+
+impl PluginManifest {
+    pub fn parse(input: &str) -> anyhow::Result<Self> {
+        let manifest: Self = toml::from_str(input)?;
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.id.trim().is_empty() {
+            anyhow::bail!("plugin id cannot be empty");
+        }
+        if self.version.trim().is_empty() {
+            anyhow::bail!("plugin `{}` version cannot be empty", self.id);
+        }
+        if self.display_name.trim().is_empty() {
+            anyhow::bail!("plugin `{}` display_name cannot be empty", self.id);
+        }
+        for dep in &self.dependencies {
+            if dep.trim().is_empty() {
+                anyhow::bail!("plugin `{}` has an empty dependency id", self.id);
+            }
+            if dep == &self.id {
+                anyhow::bail!("plugin `{}` cannot depend on itself", self.id);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_browser_playwright_manifest() {
+        let manifest = PluginManifest::parse(
+            r#"
+id = "browser-playwright-cli"
+version = "0.1.0"
+display_name = "Browser Playwright CLI"
+dependencies = ["shell", "node"]
+capabilities = ["browser"]
+
+[resources.executables.playwrightCli]
+name = "playwright-cli"
+path = "plugins/browser-playwright-cli/bin/playwright-cli"
+
+[help]
+prompt = "Provides browser automation through playwright-cli."
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(manifest.id, "browser-playwright-cli");
+        assert_eq!(manifest.dependencies, vec!["shell", "node"]);
+        assert_eq!(manifest.capabilities, vec!["browser"]);
+        assert_eq!(
+            manifest.help.as_ref().unwrap().prompt,
+            "Provides browser automation through playwright-cli."
+        );
+        assert_eq!(
+            manifest.resources.executables["playwrightCli"].path,
+            "plugins/browser-playwright-cli/bin/playwright-cli"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_plugin_id() {
+        let err = PluginManifest::parse(
+            r#"
+id = ""
+version = "0.1.0"
+display_name = "Invalid"
+"#,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("plugin id cannot be empty"));
+    }
+}

--- a/crates/ahandd/src/plugin_runtime/mod.rs
+++ b/crates/ahandd/src/plugin_runtime/mod.rs
@@ -1,7 +1,12 @@
+pub mod builtin;
 pub mod manifest;
+pub mod registry;
 pub mod resource;
+pub mod runtime_dir;
 
 pub use manifest::{ExecutableResourceManifest, HelpManifest, PluginManifest, ResourceManifest};
+pub use registry::PluginRegistry;
 pub use resource::{
     HostResourceSnapshot, HostResourceValue, InstalledPluginResource, PluginStatus,
 };
+pub use runtime_dir::RuntimeDirs;

--- a/crates/ahandd/src/plugin_runtime/mod.rs
+++ b/crates/ahandd/src/plugin_runtime/mod.rs
@@ -1,0 +1,7 @@
+pub mod manifest;
+pub mod resource;
+
+pub use manifest::{ExecutableResourceManifest, HelpManifest, PluginManifest, ResourceManifest};
+pub use resource::{
+    HostResourceSnapshot, HostResourceValue, InstalledPluginResource, PluginStatus,
+};

--- a/crates/ahandd/src/plugin_runtime/mod.rs
+++ b/crates/ahandd/src/plugin_runtime/mod.rs
@@ -1,9 +1,11 @@
 pub mod builtin;
+pub mod host_resource;
 pub mod manifest;
 pub mod registry;
 pub mod resource;
 pub mod runtime_dir;
 
+pub use host_resource::get_host_resource;
 pub use manifest::{ExecutableResourceManifest, HelpManifest, PluginManifest, ResourceManifest};
 pub use registry::PluginRegistry;
 pub use resource::{

--- a/crates/ahandd/src/plugin_runtime/registry.rs
+++ b/crates/ahandd/src/plugin_runtime/registry.rs
@@ -26,4 +26,103 @@ impl PluginRegistry {
     pub fn manifests(&self) -> impl Iterator<Item = &PluginManifest> {
         self.manifests.values()
     }
+
+    pub fn activation_order(&self) -> anyhow::Result<Vec<String>> {
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        enum Mark {
+            Visiting,
+            Done,
+        }
+
+        fn visit(
+            id: &str,
+            registry: &PluginRegistry,
+            marks: &mut BTreeMap<String, Mark>,
+            order: &mut Vec<String>,
+        ) -> anyhow::Result<()> {
+            match marks.get(id).copied() {
+                Some(Mark::Done) => return Ok(()),
+                Some(Mark::Visiting) => anyhow::bail!("plugin dependency cycle includes `{id}`"),
+                None => {}
+            }
+
+            let manifest = registry
+                .get(id)
+                .ok_or_else(|| anyhow::anyhow!("plugin `{id}` is not registered"))?;
+
+            marks.insert(id.to_string(), Mark::Visiting);
+            for dep in &manifest.dependencies {
+                if registry.get(dep).is_none() {
+                    anyhow::bail!("plugin `{}` depends on missing plugin `{dep}`", manifest.id);
+                }
+                visit(dep, registry, marks, order)?;
+            }
+            marks.insert(id.to_string(), Mark::Done);
+            order.push(id.to_string());
+            Ok(())
+        }
+
+        let mut marks = BTreeMap::new();
+        let mut order = Vec::new();
+        for id in self.manifests.keys() {
+            visit(id, self, &mut marks, &mut order)?;
+        }
+        Ok(order)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest(id: &str, deps: &[&str]) -> PluginManifest {
+        PluginManifest {
+            id: id.to_string(),
+            version: "0.1.0".to_string(),
+            display_name: id.to_string(),
+            dependencies: deps.iter().map(|d| d.to_string()).collect(),
+            capabilities: vec![],
+            resources: Default::default(),
+            help: None,
+        }
+    }
+
+    #[test]
+    fn activation_order_places_dependencies_first() {
+        let registry = PluginRegistry::new(vec![
+            manifest("browser-playwright-cli", &["shell", "node"]),
+            manifest("node", &[]),
+            manifest("shell", &[]),
+        ])
+        .unwrap();
+
+        let order = registry.activation_order().unwrap();
+        let browser = order
+            .iter()
+            .position(|id| id == "browser-playwright-cli")
+            .unwrap();
+        let shell = order.iter().position(|id| id == "shell").unwrap();
+        let node = order.iter().position(|id| id == "node").unwrap();
+
+        assert!(shell < browser);
+        assert!(node < browser);
+    }
+
+    #[test]
+    fn activation_order_rejects_missing_dependency() {
+        let registry =
+            PluginRegistry::new(vec![manifest("browser-playwright-cli", &["node"])]).unwrap();
+
+        let err = registry.activation_order().unwrap_err().to_string();
+        assert!(err.contains("depends on missing plugin `node`"));
+    }
+
+    #[test]
+    fn activation_order_rejects_cycles() {
+        let registry =
+            PluginRegistry::new(vec![manifest("a", &["b"]), manifest("b", &["a"])]).unwrap();
+
+        let err = registry.activation_order().unwrap_err().to_string();
+        assert!(err.contains("cycle"));
+    }
 }

--- a/crates/ahandd/src/plugin_runtime/registry.rs
+++ b/crates/ahandd/src/plugin_runtime/registry.rs
@@ -1,0 +1,29 @@
+use std::collections::BTreeMap;
+
+use super::manifest::PluginManifest;
+
+#[derive(Debug, Clone)]
+pub struct PluginRegistry {
+    manifests: BTreeMap<String, PluginManifest>,
+}
+
+impl PluginRegistry {
+    pub fn new(manifests: Vec<PluginManifest>) -> anyhow::Result<Self> {
+        let mut by_id = BTreeMap::new();
+        for manifest in manifests {
+            manifest.validate()?;
+            if by_id.insert(manifest.id.clone(), manifest).is_some() {
+                anyhow::bail!("duplicate plugin id in registry");
+            }
+        }
+        Ok(Self { manifests: by_id })
+    }
+
+    pub fn get(&self, id: &str) -> Option<&PluginManifest> {
+        self.manifests.get(id)
+    }
+
+    pub fn manifests(&self) -> impl Iterator<Item = &PluginManifest> {
+        self.manifests.values()
+    }
+}

--- a/crates/ahandd/src/plugin_runtime/resource.rs
+++ b/crates/ahandd/src/plugin_runtime/resource.rs
@@ -1,0 +1,119 @@
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PluginStatus {
+    Installed,
+    Missing,
+    Outdated,
+    Failed,
+    Blocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostResourceSnapshot {
+    pub runtime_version: String,
+    pub platform: String,
+    pub arch: String,
+    pub plugins: Vec<InstalledPluginResource>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstalledPluginResource {
+    pub id: String,
+    pub version: String,
+    pub status: PluginStatus,
+    pub dependencies: Vec<String>,
+    pub capabilities: Vec<String>,
+    pub resources: BTreeMap<String, HostResourceValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help_prompt: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum HostResourceValue {
+    Executable {
+        name: String,
+        path: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        version: Option<String>,
+    },
+    Directory {
+        name: String,
+        path: String,
+    },
+    Env {
+        name: String,
+        value: String,
+    },
+    Config {
+        name: String,
+        value: serde_json::Value,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn host_resource_snapshot_serializes_camel_case() {
+        let mut resources = BTreeMap::new();
+        resources.insert(
+            "node".to_string(),
+            HostResourceValue::Executable {
+                name: "node".to_string(),
+                path: "/tmp/node/bin/node".to_string(),
+                version: Some("v24.14.0".to_string()),
+            },
+        );
+
+        let snapshot = HostResourceSnapshot {
+            runtime_version: "0.1.0".to_string(),
+            platform: "darwin".to_string(),
+            arch: "arm64".to_string(),
+            plugins: vec![InstalledPluginResource {
+                id: "node".to_string(),
+                version: "0.1.0".to_string(),
+                status: PluginStatus::Installed,
+                dependencies: vec![],
+                capabilities: vec![],
+                resources,
+                help_prompt: Some("Use managed Node.js.".to_string()),
+            }],
+        };
+
+        let actual = serde_json::to_value(snapshot).unwrap();
+        assert_eq!(
+            actual,
+            json!({
+                "runtimeVersion": "0.1.0",
+                "platform": "darwin",
+                "arch": "arm64",
+                "plugins": [{
+                    "id": "node",
+                    "version": "0.1.0",
+                    "status": "installed",
+                    "dependencies": [],
+                    "capabilities": [],
+                    "resources": {
+                        "node": {
+                            "kind": "executable",
+                            "name": "node",
+                            "path": "/tmp/node/bin/node",
+                            "version": "v24.14.0"
+                        }
+                    },
+                    "helpPrompt": "Use managed Node.js."
+                }]
+            })
+        );
+    }
+}

--- a/crates/ahandd/src/plugin_runtime/runtime_dir.rs
+++ b/crates/ahandd/src/plugin_runtime/runtime_dir.rs
@@ -7,10 +7,12 @@ pub struct RuntimeDirs {
 
 impl RuntimeDirs {
     pub fn new() -> anyhow::Result<Self> {
-        let cache = dirs::cache_dir()
-            .ok_or_else(|| anyhow::anyhow!("cannot determine user cache directory"))?;
+        let home =
+            dirs::home_dir().ok_or_else(|| anyhow::anyhow!("cannot determine home directory"))?;
         Ok(Self::from_root(
-            cache.join("ahand-runtimes").join("ahand-primary-runtime"),
+            home.join(".cache")
+                .join("ahand-runtimes")
+                .join("ahand-primary-runtime"),
         ))
     }
 
@@ -82,6 +84,19 @@ mod tests {
             std::path::PathBuf::from(
                 "/tmp/cache/ahand-primary-runtime/dependencies/node/bin/playwright-cli"
             )
+        );
+    }
+
+    #[test]
+    fn runtime_dirs_new_uses_dot_cache_runtime_root() {
+        let home = dirs::home_dir().unwrap();
+        let dirs = RuntimeDirs::new().unwrap();
+
+        assert_eq!(
+            dirs.root,
+            home.join(".cache")
+                .join("ahand-runtimes")
+                .join("ahand-primary-runtime")
         );
     }
 }

--- a/crates/ahandd/src/plugin_runtime/runtime_dir.rs
+++ b/crates/ahandd/src/plugin_runtime/runtime_dir.rs
@@ -1,0 +1,87 @@
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeDirs {
+    pub root: PathBuf,
+}
+
+impl RuntimeDirs {
+    pub fn new() -> anyhow::Result<Self> {
+        let cache = dirs::cache_dir()
+            .ok_or_else(|| anyhow::anyhow!("cannot determine user cache directory"))?;
+        Ok(Self::from_root(
+            cache.join("ahand-runtimes").join("ahand-primary-runtime"),
+        ))
+    }
+
+    pub fn from_root(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    pub fn runtime_json(&self) -> PathBuf {
+        self.root.join("runtime.json")
+    }
+
+    pub fn plugins_dir(&self) -> PathBuf {
+        self.root.join("plugins")
+    }
+
+    pub fn dependencies_dir(&self) -> PathBuf {
+        self.root.join("dependencies")
+    }
+
+    pub fn node_dir(&self) -> PathBuf {
+        self.dependencies_dir().join("node")
+    }
+
+    pub fn node_bin(&self) -> PathBuf {
+        self.node_dir().join("bin").join(exe_name("node"))
+    }
+
+    pub fn npm_bin(&self) -> PathBuf {
+        self.node_dir().join("bin").join(exe_name("npm"))
+    }
+
+    pub fn playwright_cli_bin(&self) -> PathBuf {
+        self.node_dir().join("bin").join(exe_name("playwright-cli"))
+    }
+
+    pub fn python_dir(&self) -> PathBuf {
+        self.dependencies_dir().join("python")
+    }
+
+    pub fn python_bin(&self) -> PathBuf {
+        self.python_dir().join("bin").join(exe_name("python3"))
+    }
+}
+
+fn exe_name(name: &str) -> String {
+    if cfg!(target_os = "windows") {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_dirs_use_cache_root() {
+        let root = std::path::PathBuf::from("/tmp/cache/ahand-primary-runtime");
+        let dirs = RuntimeDirs::from_root(root.clone());
+
+        assert_eq!(dirs.root, root);
+        assert_eq!(
+            dirs.node_dir(),
+            std::path::PathBuf::from("/tmp/cache/ahand-primary-runtime/dependencies/node")
+        );
+        assert_eq!(
+            dirs.playwright_cli_bin(),
+            std::path::PathBuf::from(
+                "/tmp/cache/ahand-primary-runtime/dependencies/node/bin/playwright-cli"
+            )
+        );
+    }
+}

--- a/docs/superpowers/plans/2026-05-13-ahand-plugin-runtime-stage1.md
+++ b/docs/superpowers/plans/2026-05-13-ahand-plugin-runtime-stage1.md
@@ -1,0 +1,1605 @@
+# AHand Plugin Runtime Stage 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first plugin runtime foundation for aHand, expose `getHostResource`, and migrate Node/playwright setup behind first-party plugin metadata while preserving existing browser setup commands.
+
+**Architecture:** Add a static first-party plugin registry under `crates/ahandd/src/plugin_runtime/` with TOML manifest parsing, dependency ordering, runtime directory helpers, and host resource serialization. Reuse the existing `browser_setup` installer code as plugin lifecycle adapters, moving managed Node/playwright paths into `~/.cache/ahand-runtimes/ahand-primary-runtime`. Expose host resources through `ahandd plugin host-resource --json` and the local admin API without changing the protobuf wire protocol.
+
+**Tech Stack:** Rust 2024, tokio, clap, serde, serde_json, toml, existing `browser_setup` modules, ahandctl warp admin server, Solid admin API client.
+
+**Spec:** `docs/superpowers/specs/2026-05-12-ahand-plugin-runtime-design.md`
+
+---
+
+## Scope Check
+
+This plan covers Stage 1 from the spec only:
+
+- plugin manifest types.
+- static first-party plugin registry.
+- dependency graph ordering and cycle rejection.
+- host resource snapshot model.
+- `node` and `browser-playwright-cli` inspection/install paths.
+- compatibility wrappers for `browser-init` and `browser-doctor`.
+- local/admin JSON `getHostResource` surface.
+
+The Stage 2 capability activation work is intentionally excluded from this plan. `JobRequest`, `BrowserRequest`, and `FileRequest` continue through their current handlers.
+
+## File Structure
+
+### Created
+
+| File | Responsibility |
+|------|----------------|
+| `crates/ahandd/src/plugin_runtime/mod.rs` | Public module entry point and re-exports for plugin runtime types and helpers. |
+| `crates/ahandd/src/plugin_runtime/manifest.rs` | TOML manifest data structures and parsing/validation. |
+| `crates/ahandd/src/plugin_runtime/resource.rs` | Plugin status, resource values, host resource snapshot structs, and serialization tests. |
+| `crates/ahandd/src/plugin_runtime/runtime_dir.rs` | `~/.cache/ahand-runtimes/ahand-primary-runtime` path helpers. |
+| `crates/ahandd/src/plugin_runtime/registry.rs` | Static registry, dependency graph ordering, dependency status checks, and cycle detection. |
+| `crates/ahandd/src/plugin_runtime/builtin.rs` | Built-in TOML manifests for `shell`, `node`, `python`, `file`, and `browser-playwright-cli`. |
+| `crates/ahandd/src/plugin_runtime/host_resource.rs` | Async aggregation of installed plugin resources from manifests and existing inspectors. |
+
+### Modified
+
+| File | Change |
+|------|--------|
+| `crates/ahandd/src/lib.rs` | Export `plugin_runtime`. |
+| `crates/ahandd/src/main.rs` | Add `plugin` subcommands for doctor/install/repair/host-resource and route them through `plugin_runtime`. |
+| `crates/ahandd/src/browser_setup/node.rs` | Replace `~/.ahand/node` paths with runtime directory helper paths. |
+| `crates/ahandd/src/browser_setup/playwright.rs` | Resolve `npm` and `playwright-cli` through the node runtime directory helper. |
+| `crates/ahandd/src/browser_setup/mod.rs` | Add plugin-name aliases for inspect/run paths while keeping `node`, `playwright`, and `browser` compatibility. |
+| `crates/ahandd/src/browser.rs` | Default `playwright-cli` path comes from the plugin runtime when `browser.binary_path` is unset. |
+| `crates/ahandd/src/cli/browser_init.rs` | Keep existing command output but call plugin ids internally. |
+| `crates/ahandd/src/cli/browser_doctor.rs` | Keep existing browser-focused doctor behavior using compatibility aliases. |
+| `crates/ahandctl/Cargo.toml` | Add dependency on the `ahandd` library target for host resource JSON. |
+| `crates/ahandctl/src/admin.rs` | Add `GET /api/host-resource` route. |
+| `apps/admin/src/lib/api.ts` | Add host resource TypeScript types and `api.getHostResource()`. |
+
+---
+
+### Task 1: Add Plugin Manifest And Resource Types
+
+**Files:**
+- Create: `crates/ahandd/src/plugin_runtime/mod.rs`
+- Create: `crates/ahandd/src/plugin_runtime/manifest.rs`
+- Create: `crates/ahandd/src/plugin_runtime/resource.rs`
+- Modify: `crates/ahandd/src/lib.rs`
+- Test: module tests inside `manifest.rs` and `resource.rs`
+
+- [ ] **Step 1: Write manifest parsing tests**
+
+Add this test module to the new file `crates/ahandd/src/plugin_runtime/manifest.rs` before writing the implementation:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_browser_playwright_manifest() {
+        let manifest = PluginManifest::parse(
+            r#"
+id = "browser-playwright-cli"
+version = "0.1.0"
+display_name = "Browser Playwright CLI"
+dependencies = ["shell", "node"]
+capabilities = ["browser"]
+
+[resources.executables.playwrightCli]
+name = "playwright-cli"
+path = "plugins/browser-playwright-cli/bin/playwright-cli"
+
+[help]
+prompt = "Provides browser automation through playwright-cli."
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(manifest.id, "browser-playwright-cli");
+        assert_eq!(manifest.dependencies, vec!["shell", "node"]);
+        assert_eq!(manifest.capabilities, vec!["browser"]);
+        assert_eq!(
+            manifest.help.as_ref().unwrap().prompt,
+            "Provides browser automation through playwright-cli."
+        );
+        assert_eq!(
+            manifest.resources.executables["playwrightCli"].path,
+            "plugins/browser-playwright-cli/bin/playwright-cli"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_plugin_id() {
+        let err = PluginManifest::parse(
+            r#"
+id = ""
+version = "0.1.0"
+display_name = "Invalid"
+"#,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("plugin id cannot be empty"));
+    }
+}
+```
+
+- [ ] **Step 2: Run manifest tests to verify they fail**
+
+Run: `cargo test -p ahandd plugin_runtime::manifest`
+
+Expected: compile failure because `PluginManifest` and `plugin_runtime` do not exist yet.
+
+- [ ] **Step 3: Create the plugin runtime module entry point**
+
+Create `crates/ahandd/src/plugin_runtime/mod.rs`:
+
+```rust
+pub mod builtin;
+pub mod host_resource;
+pub mod manifest;
+pub mod registry;
+pub mod resource;
+pub mod runtime_dir;
+
+pub use host_resource::get_host_resource;
+pub use manifest::{ExecutableResourceManifest, HelpManifest, PluginManifest, ResourceManifest};
+pub use registry::PluginRegistry;
+pub use resource::{
+    HostResourceSnapshot, HostResourceValue, InstalledPluginResource, PluginStatus,
+};
+pub use runtime_dir::RuntimeDirs;
+```
+
+Modify `crates/ahandd/src/lib.rs`:
+
+```rust
+pub mod ahand_client;
+pub mod approval;
+pub mod browser;
+pub mod browser_setup;
+pub mod config;
+pub mod device_identity;
+pub mod executor;
+pub mod file_manager;
+pub mod outbox;
+pub mod plugin_runtime;
+pub mod registry;
+pub mod session;
+pub mod store;
+pub mod updater;
+```
+
+Keep the existing `mod public_api;` and public re-exports below this block unchanged.
+
+- [ ] **Step 4: Implement manifest parsing**
+
+Create `crates/ahandd/src/plugin_runtime/manifest.rs` with:
+
+```rust
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PluginManifest {
+    pub id: String,
+    pub version: String,
+    pub display_name: String,
+    #[serde(default)]
+    pub dependencies: Vec<String>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    #[serde(default)]
+    pub resources: ResourceManifest,
+    #[serde(default)]
+    pub help: Option<HelpManifest>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceManifest {
+    #[serde(default)]
+    pub executables: BTreeMap<String, ExecutableResourceManifest>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutableResourceManifest {
+    pub name: String,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HelpManifest {
+    pub prompt: String,
+}
+
+impl PluginManifest {
+    pub fn parse(input: &str) -> anyhow::Result<Self> {
+        let manifest: Self = toml::from_str(input)?;
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.id.trim().is_empty() {
+            anyhow::bail!("plugin id cannot be empty");
+        }
+        if self.version.trim().is_empty() {
+            anyhow::bail!("plugin `{}` version cannot be empty", self.id);
+        }
+        if self.display_name.trim().is_empty() {
+            anyhow::bail!("plugin `{}` display_name cannot be empty", self.id);
+        }
+        for dep in &self.dependencies {
+            if dep.trim().is_empty() {
+                anyhow::bail!("plugin `{}` has an empty dependency id", self.id);
+            }
+            if dep == &self.id {
+                anyhow::bail!("plugin `{}` cannot depend on itself", self.id);
+            }
+        }
+        Ok(())
+    }
+}
+```
+
+Keep the tests from Step 1 at the bottom of the file.
+
+- [ ] **Step 5: Write resource serialization tests**
+
+Create `crates/ahandd/src/plugin_runtime/resource.rs` with only this test module first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn host_resource_snapshot_serializes_camel_case() {
+        let mut resources = BTreeMap::new();
+        resources.insert(
+            "node".to_string(),
+            HostResourceValue::Executable {
+                name: "node".to_string(),
+                path: "/tmp/node/bin/node".to_string(),
+                version: Some("v24.14.0".to_string()),
+            },
+        );
+
+        let snapshot = HostResourceSnapshot {
+            runtime_version: "0.1.0".to_string(),
+            platform: "darwin".to_string(),
+            arch: "arm64".to_string(),
+            plugins: vec![InstalledPluginResource {
+                id: "node".to_string(),
+                version: "0.1.0".to_string(),
+                status: PluginStatus::Installed,
+                dependencies: vec![],
+                capabilities: vec![],
+                resources,
+                help_prompt: Some("Use managed Node.js.".to_string()),
+            }],
+        };
+
+        let actual = serde_json::to_value(snapshot).unwrap();
+        assert_eq!(
+            actual,
+            json!({
+                "runtimeVersion": "0.1.0",
+                "platform": "darwin",
+                "arch": "arm64",
+                "plugins": [{
+                    "id": "node",
+                    "version": "0.1.0",
+                    "status": "installed",
+                    "dependencies": [],
+                    "capabilities": [],
+                    "resources": {
+                        "node": {
+                            "kind": "executable",
+                            "name": "node",
+                            "path": "/tmp/node/bin/node",
+                            "version": "v24.14.0"
+                        }
+                    },
+                    "helpPrompt": "Use managed Node.js."
+                }]
+            })
+        );
+    }
+}
+```
+
+- [ ] **Step 6: Run resource tests to verify they fail**
+
+Run: `cargo test -p ahandd plugin_runtime::resource`
+
+Expected: compile failure because resource structs do not exist yet.
+
+- [ ] **Step 7: Implement resource types**
+
+Put this implementation above the tests in `crates/ahandd/src/plugin_runtime/resource.rs`:
+
+```rust
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PluginStatus {
+    Installed,
+    Missing,
+    Outdated,
+    Failed,
+    Blocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostResourceSnapshot {
+    pub runtime_version: String,
+    pub platform: String,
+    pub arch: String,
+    pub plugins: Vec<InstalledPluginResource>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstalledPluginResource {
+    pub id: String,
+    pub version: String,
+    pub status: PluginStatus,
+    pub dependencies: Vec<String>,
+    pub capabilities: Vec<String>,
+    pub resources: BTreeMap<String, HostResourceValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help_prompt: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum HostResourceValue {
+    Executable {
+        name: String,
+        path: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        version: Option<String>,
+    },
+    Directory {
+        name: String,
+        path: String,
+    },
+    Env {
+        name: String,
+        value: String,
+    },
+    Config {
+        name: String,
+        value: serde_json::Value,
+    },
+}
+```
+
+- [ ] **Step 8: Verify Task 1**
+
+Run: `cargo test -p ahandd plugin_runtime::manifest plugin_runtime::resource`
+
+Expected: all manifest and resource tests pass.
+
+- [ ] **Step 9: Commit Task 1**
+
+```bash
+git add crates/ahandd/src/lib.rs crates/ahandd/src/plugin_runtime
+git commit -m "feat(ahandd): add plugin manifest resource types"
+```
+
+---
+
+### Task 2: Add Runtime Directory Helpers And Built-In Manifests
+
+**Files:**
+- Create: `crates/ahandd/src/plugin_runtime/runtime_dir.rs`
+- Create: `crates/ahandd/src/plugin_runtime/builtin.rs`
+- Test: module tests inside both files
+
+- [ ] **Step 1: Write runtime directory tests**
+
+Create `crates/ahandd/src/plugin_runtime/runtime_dir.rs` with tests first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_dirs_use_cache_root() {
+        let root = std::path::PathBuf::from("/tmp/cache/ahand-primary-runtime");
+        let dirs = RuntimeDirs::from_root(root.clone());
+
+        assert_eq!(dirs.root, root);
+        assert_eq!(
+            dirs.node_dir(),
+            std::path::PathBuf::from("/tmp/cache/ahand-primary-runtime/dependencies/node")
+        );
+        assert_eq!(
+            dirs.playwright_cli_bin(),
+            std::path::PathBuf::from(
+                "/tmp/cache/ahand-primary-runtime/dependencies/node/bin/playwright-cli"
+            )
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run runtime directory test to verify it fails**
+
+Run: `cargo test -p ahandd plugin_runtime::runtime_dir`
+
+Expected: compile failure because `RuntimeDirs` is not implemented.
+
+- [ ] **Step 3: Implement runtime directory helper**
+
+Add this implementation above the tests:
+
+```rust
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeDirs {
+    pub root: PathBuf,
+}
+
+impl RuntimeDirs {
+    pub fn new() -> anyhow::Result<Self> {
+        let cache = dirs::cache_dir()
+            .ok_or_else(|| anyhow::anyhow!("cannot determine user cache directory"))?;
+        Ok(Self::from_root(
+            cache
+                .join("ahand-runtimes")
+                .join("ahand-primary-runtime"),
+        ))
+    }
+
+    pub fn from_root(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    pub fn runtime_json(&self) -> PathBuf {
+        self.root.join("runtime.json")
+    }
+
+    pub fn plugins_dir(&self) -> PathBuf {
+        self.root.join("plugins")
+    }
+
+    pub fn dependencies_dir(&self) -> PathBuf {
+        self.root.join("dependencies")
+    }
+
+    pub fn node_dir(&self) -> PathBuf {
+        self.dependencies_dir().join("node")
+    }
+
+    pub fn node_bin(&self) -> PathBuf {
+        self.node_dir().join("bin").join(exe_name("node"))
+    }
+
+    pub fn npm_bin(&self) -> PathBuf {
+        self.node_dir().join("bin").join(exe_name("npm"))
+    }
+
+    pub fn playwright_cli_bin(&self) -> PathBuf {
+        self.node_dir().join("bin").join(exe_name("playwright-cli"))
+    }
+
+    pub fn python_dir(&self) -> PathBuf {
+        self.dependencies_dir().join("python")
+    }
+
+    pub fn python_bin(&self) -> PathBuf {
+        self.python_dir().join("bin").join(exe_name("python3"))
+    }
+}
+
+fn exe_name(name: &str) -> String {
+    if cfg!(target_os = "windows") {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    }
+}
+```
+
+- [ ] **Step 4: Write built-in manifest tests**
+
+Create `crates/ahandd/src/plugin_runtime/builtin.rs` with tests first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_manifests_parse_and_include_expected_ids() {
+        let registry = builtin_registry().unwrap();
+        let ids: Vec<_> = registry.manifests().map(|m| m.id.as_str()).collect();
+
+        assert_eq!(
+            ids,
+            vec!["browser-playwright-cli", "file", "node", "python", "shell"]
+        );
+    }
+
+    #[test]
+    fn browser_playwright_declares_shell_and_node_dependencies() {
+        let registry = builtin_registry().unwrap();
+        let manifest = registry.get("browser-playwright-cli").unwrap();
+
+        assert_eq!(manifest.dependencies, vec!["shell", "node"]);
+        assert_eq!(manifest.capabilities, vec!["browser"]);
+    }
+}
+```
+
+- [ ] **Step 5: Run built-in tests to verify they fail**
+
+Run: `cargo test -p ahandd plugin_runtime::builtin`
+
+Expected: compile failure because `builtin_registry` and `PluginRegistry` do not exist yet.
+
+- [ ] **Step 6: Add a minimal registry container needed by built-ins**
+
+Create `crates/ahandd/src/plugin_runtime/registry.rs`:
+
+```rust
+use std::collections::BTreeMap;
+
+use super::manifest::PluginManifest;
+
+#[derive(Debug, Clone)]
+pub struct PluginRegistry {
+    manifests: BTreeMap<String, PluginManifest>,
+}
+
+impl PluginRegistry {
+    pub fn new(manifests: Vec<PluginManifest>) -> anyhow::Result<Self> {
+        let mut by_id = BTreeMap::new();
+        for manifest in manifests {
+            manifest.validate()?;
+            if by_id.insert(manifest.id.clone(), manifest).is_some() {
+                anyhow::bail!("duplicate plugin id in registry");
+            }
+        }
+        Ok(Self { manifests: by_id })
+    }
+
+    pub fn get(&self, id: &str) -> Option<&PluginManifest> {
+        self.manifests.get(id)
+    }
+
+    pub fn manifests(&self) -> impl Iterator<Item = &PluginManifest> {
+        self.manifests.values()
+    }
+}
+```
+
+- [ ] **Step 7: Implement built-in manifests**
+
+Add this implementation above the tests in `builtin.rs`:
+
+```rust
+use super::manifest::PluginManifest;
+use super::registry::PluginRegistry;
+
+const SHELL: &str = r#"
+id = "shell"
+version = "0.1.0"
+display_name = "Shell"
+dependencies = []
+capabilities = ["shell"]
+
+[resources.executables.shell]
+name = "shell"
+path = "$SHELL"
+
+[help]
+prompt = "Provides local command execution, PTY sessions, stdin forwarding, terminal resize, cwd/env propagation, and stdout/stderr streaming."
+"#;
+
+const NODE: &str = r#"
+id = "node"
+version = "0.1.0"
+display_name = "Node.js Runtime"
+dependencies = []
+capabilities = []
+
+[resources.executables.node]
+name = "node"
+path = "dependencies/node/bin/node"
+
+[resources.executables.npm]
+name = "npm"
+path = "dependencies/node/bin/npm"
+
+[help]
+prompt = "Use the managed Node.js runtime for JavaScript-based local tools. Prefer this path over system node when a plugin depends on node."
+"#;
+
+const PYTHON: &str = r#"
+id = "python"
+version = "0.1.0"
+display_name = "Python Runtime"
+dependencies = []
+capabilities = []
+
+[resources.executables.python]
+name = "python"
+path = "dependencies/python/bin/python3"
+
+[help]
+prompt = "Use the managed Python runtime for Python-based local tools and scripts."
+"#;
+
+const FILE: &str = r#"
+id = "file"
+version = "0.1.0"
+display_name = "File Operations"
+dependencies = []
+capabilities = ["file"]
+
+[help]
+prompt = "Provides file list, read, write, edit, delete, stat, glob, mkdir, copy, move, symlink, and chmod operations under daemon file policy."
+"#;
+
+const BROWSER_PLAYWRIGHT_CLI: &str = r#"
+id = "browser-playwright-cli"
+version = "0.1.0"
+display_name = "Browser Playwright CLI"
+dependencies = ["shell", "node"]
+capabilities = ["browser"]
+
+[resources.executables.playwrightCli]
+name = "playwright-cli"
+path = "dependencies/node/bin/playwright-cli"
+
+[help]
+prompt = "Provides browser automation through playwright-cli. Use for browser open, click, fill, snapshot, screenshot, PDF, download, and close actions."
+"#;
+
+pub fn builtin_registry() -> anyhow::Result<PluginRegistry> {
+    let manifests = [SHELL, NODE, PYTHON, FILE, BROWSER_PLAYWRIGHT_CLI]
+        .into_iter()
+        .map(PluginManifest::parse)
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    PluginRegistry::new(manifests)
+}
+```
+
+- [ ] **Step 8: Verify Task 2**
+
+Run: `cargo test -p ahandd plugin_runtime::runtime_dir plugin_runtime::builtin`
+
+Expected: all runtime directory and built-in manifest tests pass.
+
+- [ ] **Step 9: Commit Task 2**
+
+```bash
+git add crates/ahandd/src/plugin_runtime
+git commit -m "feat(ahandd): add builtin plugin runtime metadata"
+```
+
+---
+
+### Task 3: Add Dependency Graph Ordering And Blocking Status
+
+**Files:**
+- Modify: `crates/ahandd/src/plugin_runtime/registry.rs`
+- Test: module tests inside `registry.rs`
+
+- [ ] **Step 1: Write dependency graph tests**
+
+Append these tests to `registry.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest(id: &str, deps: &[&str]) -> PluginManifest {
+        PluginManifest {
+            id: id.to_string(),
+            version: "0.1.0".to_string(),
+            display_name: id.to_string(),
+            dependencies: deps.iter().map(|d| d.to_string()).collect(),
+            capabilities: vec![],
+            resources: Default::default(),
+            help: None,
+        }
+    }
+
+    #[test]
+    fn activation_order_places_dependencies_first() {
+        let registry = PluginRegistry::new(vec![
+            manifest("browser-playwright-cli", &["shell", "node"]),
+            manifest("node", &[]),
+            manifest("shell", &[]),
+        ])
+        .unwrap();
+
+        let order = registry.activation_order().unwrap();
+        let browser = order.iter().position(|id| id == "browser-playwright-cli").unwrap();
+        let shell = order.iter().position(|id| id == "shell").unwrap();
+        let node = order.iter().position(|id| id == "node").unwrap();
+
+        assert!(shell < browser);
+        assert!(node < browser);
+    }
+
+    #[test]
+    fn activation_order_rejects_missing_dependency() {
+        let registry = PluginRegistry::new(vec![manifest("browser-playwright-cli", &["node"])])
+            .unwrap();
+
+        let err = registry.activation_order().unwrap_err().to_string();
+        assert!(err.contains("depends on missing plugin `node`"));
+    }
+
+    #[test]
+    fn activation_order_rejects_cycles() {
+        let registry =
+            PluginRegistry::new(vec![manifest("a", &["b"]), manifest("b", &["a"])]).unwrap();
+
+        let err = registry.activation_order().unwrap_err().to_string();
+        assert!(err.contains("cycle"));
+    }
+}
+```
+
+- [ ] **Step 2: Run dependency tests to verify they fail**
+
+Run: `cargo test -p ahandd plugin_runtime::registry`
+
+Expected: compile failure because `activation_order` does not exist.
+
+- [ ] **Step 3: Implement dependency graph ordering**
+
+Add this below the existing `manifests()` method in `registry.rs`:
+
+```rust
+    pub fn activation_order(&self) -> anyhow::Result<Vec<String>> {
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        enum Mark {
+            Visiting,
+            Done,
+        }
+
+        fn visit(
+            id: &str,
+            registry: &PluginRegistry,
+            marks: &mut BTreeMap<String, Mark>,
+            order: &mut Vec<String>,
+        ) -> anyhow::Result<()> {
+            match marks.get(id).copied() {
+                Some(Mark::Done) => return Ok(()),
+                Some(Mark::Visiting) => anyhow::bail!("plugin dependency cycle includes `{id}`"),
+                None => {}
+            }
+
+            let manifest = registry
+                .get(id)
+                .ok_or_else(|| anyhow::anyhow!("plugin `{id}` is not registered"))?;
+
+            marks.insert(id.to_string(), Mark::Visiting);
+            for dep in &manifest.dependencies {
+                if registry.get(dep).is_none() {
+                    anyhow::bail!("plugin `{}` depends on missing plugin `{dep}`", manifest.id);
+                }
+                visit(dep, registry, marks, order)?;
+            }
+            marks.insert(id.to_string(), Mark::Done);
+            order.push(id.to_string());
+            Ok(())
+        }
+
+        let mut marks = BTreeMap::new();
+        let mut order = Vec::new();
+        for id in self.manifests.keys() {
+            visit(id, self, &mut marks, &mut order)?;
+        }
+        Ok(order)
+    }
+```
+
+- [ ] **Step 4: Verify Task 3**
+
+Run: `cargo test -p ahandd plugin_runtime::registry`
+
+Expected: dependency ordering, missing dependency, and cycle tests pass.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add crates/ahandd/src/plugin_runtime/registry.rs
+git commit -m "feat(ahandd): order plugin dependencies"
+```
+
+---
+
+### Task 4: Move Node And Playwright Paths Into Runtime Directory
+
+**Files:**
+- Modify: `crates/ahandd/src/browser_setup/node.rs`
+- Modify: `crates/ahandd/src/browser_setup/playwright.rs`
+- Modify: `crates/ahandd/src/browser.rs`
+- Test: existing module tests plus small path tests
+
+- [ ] **Step 1: Write path expectation tests for Node dirs**
+
+In `crates/ahandd/src/browser_setup/node.rs`, add this test inside the existing test module:
+
+```rust
+#[test]
+fn dirs_use_plugin_runtime_node_directory() {
+    let root = PathBuf::from("/tmp/ahand-primary-runtime");
+    let dirs = Dirs::from_runtime_root(root);
+
+    assert_eq!(
+        dirs.node,
+        PathBuf::from("/tmp/ahand-primary-runtime/dependencies/node")
+    );
+    assert_eq!(
+        dirs.local_node_bin(),
+        PathBuf::from("/tmp/ahand-primary-runtime/dependencies/node/bin/node")
+    );
+}
+```
+
+- [ ] **Step 2: Run Node path test to verify it fails**
+
+Run: `cargo test -p ahandd browser_setup::node::tests::dirs_use_plugin_runtime_node_directory`
+
+Expected: compile failure because `Dirs::from_runtime_root` and `local_node_bin` do not exist.
+
+- [ ] **Step 3: Refactor Node dirs to use `RuntimeDirs`**
+
+Replace the `Dirs` struct and `local_node_bin()` helper in `node.rs` with:
+
+```rust
+pub struct Dirs {
+    pub ahand: PathBuf,
+    pub node: PathBuf,
+    runtime: crate::plugin_runtime::RuntimeDirs,
+}
+
+impl Dirs {
+    pub fn new() -> Result<Self> {
+        let runtime = crate::plugin_runtime::RuntimeDirs::new()?;
+        Ok(Self::from_runtime(runtime))
+    }
+
+    pub fn from_runtime_root(root: PathBuf) -> Self {
+        Self::from_runtime(crate::plugin_runtime::RuntimeDirs::from_root(root))
+    }
+
+    fn from_runtime(runtime: crate::plugin_runtime::RuntimeDirs) -> Self {
+        let ahand = dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".ahand");
+        let node = runtime.node_dir();
+        Self {
+            ahand,
+            node,
+            runtime,
+        }
+    }
+
+    pub fn local_node_bin(&self) -> PathBuf {
+        self.runtime.node_bin()
+    }
+
+    pub fn npm_bin(&self) -> PathBuf {
+        self.runtime.npm_bin()
+    }
+
+    pub fn playwright_cli_bin(&self) -> PathBuf {
+        self.runtime.playwright_cli_bin()
+    }
+}
+
+fn local_node_bin() -> Result<PathBuf> {
+    Ok(Dirs::new()?.local_node_bin())
+}
+```
+
+In `ensure()`, replace:
+
+```rust
+let local_node = dirs.node.join("bin").join("node");
+```
+
+with:
+
+```rust
+let local_node = dirs.local_node_bin();
+```
+
+- [ ] **Step 4: Refactor playwright paths to use Node dirs methods**
+
+In `crates/ahandd/src/browser_setup/playwright.rs`, replace `cli_path()` with:
+
+```rust
+pub fn cli_path() -> Result<PathBuf> {
+    let dirs = Dirs::new()?;
+    Ok(dirs.playwright_cli_bin())
+}
+```
+
+In `ensure()`, replace:
+
+```rust
+let npm = dirs.node.join("bin").join("npm");
+```
+
+with:
+
+```rust
+let npm = dirs.npm_bin();
+```
+
+Keep `let prefix = dirs.node.to_string_lossy().to_string();` because npm still installs into the managed Node prefix.
+
+- [ ] **Step 5: Make BrowserManager default to plugin runtime path**
+
+In `crates/ahandd/src/browser.rs`, replace the default branch of `binary_path()` with:
+
+```rust
+None => crate::plugin_runtime::RuntimeDirs::new()
+    .map(|dirs| dirs.playwright_cli_bin())
+    .unwrap_or_else(|_| PathBuf::from("playwright-cli")),
+```
+
+Leave `Some(path) => PathBuf::from(path)` unchanged so explicit config still wins.
+
+- [ ] **Step 6: Verify Task 4**
+
+Run:
+
+```bash
+cargo test -p ahandd browser_setup::node browser_setup::playwright browser_setup::types
+cargo test -p ahandd --test browser_doctor
+```
+
+Expected: all listed tests pass. The browser doctor test may exit 0 or 1, but the test itself must pass.
+
+- [ ] **Step 7: Commit Task 4**
+
+```bash
+git add crates/ahandd/src/browser_setup/node.rs crates/ahandd/src/browser_setup/playwright.rs crates/ahandd/src/browser.rs
+git commit -m "feat(ahandd): use managed runtime paths for browser setup"
+```
+
+---
+
+### Task 5: Aggregate `getHostResource`
+
+**Files:**
+- Create: `crates/ahandd/src/plugin_runtime/host_resource.rs`
+- Modify: `crates/ahandd/src/plugin_runtime/mod.rs`
+- Test: module tests inside `host_resource.rs`
+
+- [ ] **Step 1: Write host resource aggregation tests**
+
+Create `crates/ahandd/src/plugin_runtime/host_resource.rs` with tests first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn snapshot_contains_first_party_plugins() {
+        let snapshot = get_host_resource().await.unwrap();
+        let ids: Vec<_> = snapshot.plugins.iter().map(|p| p.id.as_str()).collect();
+
+        assert_eq!(
+            ids,
+            vec!["browser-playwright-cli", "file", "node", "python", "shell"]
+        );
+    }
+
+    #[tokio::test]
+    async fn browser_plugin_reports_shell_and_node_dependencies() {
+        let snapshot = get_host_resource().await.unwrap();
+        let browser = snapshot
+            .plugins
+            .iter()
+            .find(|plugin| plugin.id == "browser-playwright-cli")
+            .unwrap();
+
+        assert_eq!(browser.dependencies, vec!["shell", "node"]);
+        assert_eq!(browser.capabilities, vec!["browser"]);
+        assert!(browser.help_prompt.as_ref().unwrap().contains("browser automation"));
+    }
+}
+```
+
+- [ ] **Step 2: Run host resource tests to verify they fail**
+
+Run: `cargo test -p ahandd plugin_runtime::host_resource`
+
+Expected: compile failure because `get_host_resource` is not implemented.
+
+- [ ] **Step 3: Implement host resource aggregation**
+
+Add this implementation above the tests:
+
+```rust
+use std::collections::BTreeMap;
+
+use super::builtin::builtin_registry;
+use super::resource::{
+    HostResourceSnapshot, HostResourceValue, InstalledPluginResource, PluginStatus,
+};
+use super::runtime_dir::RuntimeDirs;
+use crate::browser_setup::{self, CheckStatus};
+
+pub async fn get_host_resource() -> anyhow::Result<HostResourceSnapshot> {
+    let registry = builtin_registry()?;
+    let runtime = RuntimeDirs::new()?;
+    let mut plugins = Vec::new();
+
+    for manifest in registry.manifests() {
+        let (status, resources) = inspect_plugin_resources(&manifest.id, &runtime).await;
+        plugins.push(InstalledPluginResource {
+            id: manifest.id.clone(),
+            version: manifest.version.clone(),
+            status,
+            dependencies: manifest.dependencies.clone(),
+            capabilities: manifest.capabilities.clone(),
+            resources,
+            help_prompt: manifest.help.as_ref().map(|help| help.prompt.clone()),
+        });
+    }
+
+    Ok(HostResourceSnapshot {
+        runtime_version: env!("CARGO_PKG_VERSION").to_string(),
+        platform: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        plugins,
+    })
+}
+
+async fn inspect_plugin_resources(
+    plugin_id: &str,
+    runtime: &RuntimeDirs,
+) -> (PluginStatus, BTreeMap<String, HostResourceValue>) {
+    match plugin_id {
+        "shell" => inspect_shell(),
+        "file" => (PluginStatus::Installed, BTreeMap::new()),
+        "node" => inspect_node().await,
+        "python" => inspect_python(runtime).await,
+        "browser-playwright-cli" => inspect_browser_playwright().await,
+        _ => (PluginStatus::Missing, BTreeMap::new()),
+    }
+}
+
+fn inspect_shell() -> (PluginStatus, BTreeMap<String, HostResourceValue>) {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+    let mut resources = BTreeMap::new();
+    resources.insert(
+        "shell".to_string(),
+        HostResourceValue::Executable {
+            name: "shell".to_string(),
+            path: shell,
+            version: None,
+        },
+    );
+    (PluginStatus::Installed, resources)
+}
+
+async fn inspect_node() -> (PluginStatus, BTreeMap<String, HostResourceValue>) {
+    let report = browser_setup::node::inspect().await;
+    match report.status {
+        CheckStatus::Ok { version, path, .. } => {
+            let dirs = match RuntimeDirs::new() {
+                Ok(dirs) => dirs,
+                Err(_) => return (PluginStatus::Failed, BTreeMap::new()),
+            };
+            let mut resources = BTreeMap::new();
+            resources.insert(
+                "node".to_string(),
+                HostResourceValue::Executable {
+                    name: "node".to_string(),
+                    path: path.to_string_lossy().into_owned(),
+                    version: Some(version),
+                },
+            );
+            resources.insert(
+                "npm".to_string(),
+                HostResourceValue::Executable {
+                    name: "npm".to_string(),
+                    path: dirs.npm_bin().to_string_lossy().into_owned(),
+                    version: None,
+                },
+            );
+            (PluginStatus::Installed, resources)
+        }
+        CheckStatus::Outdated { .. } => (PluginStatus::Outdated, BTreeMap::new()),
+        CheckStatus::Failed { .. } => (PluginStatus::Failed, BTreeMap::new()),
+        _ => (PluginStatus::Missing, BTreeMap::new()),
+    }
+}
+
+async fn inspect_python(runtime: &RuntimeDirs) -> (PluginStatus, BTreeMap<String, HostResourceValue>) {
+    let python = runtime.python_bin();
+    if !python.exists() {
+        return (PluginStatus::Missing, BTreeMap::new());
+    }
+
+    let version = tokio::process::Command::new(&python)
+        .arg("--version")
+        .output()
+        .await
+        .ok()
+        .map(|out| {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let raw = if stdout.trim().is_empty() { stderr } else { stdout };
+            raw.trim().to_string()
+        });
+
+    let mut resources = BTreeMap::new();
+    resources.insert(
+        "python".to_string(),
+        HostResourceValue::Executable {
+            name: "python".to_string(),
+            path: python.to_string_lossy().into_owned(),
+            version,
+        },
+    );
+    (PluginStatus::Installed, resources)
+}
+
+async fn inspect_browser_playwright() -> (PluginStatus, BTreeMap<String, HostResourceValue>) {
+    let node_report = browser_setup::node::inspect().await;
+    if !matches!(node_report.status, CheckStatus::Ok { .. }) {
+        return (PluginStatus::Blocked, BTreeMap::new());
+    }
+
+    let report = browser_setup::playwright::inspect().await;
+    match report.status {
+        CheckStatus::Ok { version, path, .. } => {
+            let mut resources = BTreeMap::new();
+            resources.insert(
+                "playwrightCli".to_string(),
+                HostResourceValue::Executable {
+                    name: "playwright-cli".to_string(),
+                    path: path.to_string_lossy().into_owned(),
+                    version: Some(version),
+                },
+            );
+            (PluginStatus::Installed, resources)
+        }
+        CheckStatus::Failed { .. } => (PluginStatus::Failed, BTreeMap::new()),
+        CheckStatus::Outdated { .. } => (PluginStatus::Outdated, BTreeMap::new()),
+        _ => (PluginStatus::Missing, BTreeMap::new()),
+    }
+}
+```
+
+- [ ] **Step 4: Verify Task 5**
+
+Run: `cargo test -p ahandd plugin_runtime::host_resource`
+
+Expected: host resource tests pass. On machines without managed Node, `node` may be `missing` and `browser-playwright-cli` may be `blocked`; the tests do not assert local install state.
+
+- [ ] **Step 5: Commit Task 5**
+
+```bash
+git add crates/ahandd/src/plugin_runtime/host_resource.rs crates/ahandd/src/plugin_runtime/mod.rs
+git commit -m "feat(ahandd): expose host resource snapshot"
+```
+
+---
+
+### Task 6: Add Plugin CLI And Browser Setup Compatibility Aliases
+
+**Files:**
+- Modify: `crates/ahandd/src/main.rs`
+- Modify: `crates/ahandd/src/browser_setup/mod.rs`
+- Modify: `crates/ahandd/src/cli/browser_init.rs`
+- Test: existing browser doctor integration test and the command smoke tests listed in Task 8
+
+- [ ] **Step 1: Write alias tests for browser setup**
+
+Add these tests to the existing test module in `crates/ahandd/src/browser_setup/mod.rs`:
+
+```rust
+#[tokio::test]
+async fn inspect_accepts_plugin_id_aliases() {
+    assert!(inspect("node").await.is_some());
+    assert!(inspect("playwright").await.is_some());
+    assert!(inspect("browser-playwright-cli").await.is_some());
+}
+
+#[tokio::test]
+async fn run_step_rejects_file_plugin_because_it_has_no_installer() {
+    let progress = |_: ProgressEvent| {};
+    let err = run_step("file", false, progress).await.unwrap_err().to_string();
+    assert!(err.contains("does not have an install step"));
+}
+```
+
+- [ ] **Step 2: Run alias tests to verify they fail**
+
+Run: `cargo test -p ahandd browser_setup::tests::inspect_accepts_plugin_id_aliases browser_setup::tests::run_step_rejects_file_plugin_because_it_has_no_installer`
+
+Expected: `browser-playwright-cli` inspect returns `None` or `file` reports the old unknown-step message.
+
+- [ ] **Step 3: Add compatibility aliases in `browser_setup::inspect`**
+
+In `browser_setup/mod.rs`, update `inspect()`:
+
+```rust
+pub async fn inspect(name: &str) -> Option<CheckReport> {
+    match name {
+        "node" => Some(node::inspect().await),
+        "playwright" | "browser-playwright-cli" => Some(playwright::inspect().await),
+        "browser" => Some(inspect_browser()),
+        _ => None,
+    }
+}
+```
+
+Update `run_step()` match arms:
+
+```rust
+        "playwright" | "browser-playwright-cli" => {
+            let node_status = node::inspect().await;
+            if !matches!(node_status.status, CheckStatus::Ok { .. }) {
+                bail!(
+                    "browser-playwright-cli requires node to be installed first. \
+                     Run `ahandd browser-init --step node` first, or \
+                     `ahandd plugin install browser-playwright-cli`."
+                );
+            }
+            match playwright::ensure(force, progress_ref).await {
+                Ok(r) => Ok(r),
+                Err(e) => Err(wrap_failure(
+                    e,
+                    "browser-playwright-cli",
+                    "playwright-cli",
+                    progress_ref,
+                )),
+            }
+        }
+        "shell" | "file" | "python" => {
+            bail!("plugin `{name}` does not have an install step in this release")
+        }
+```
+
+Keep the existing `"node"` branch unchanged.
+
+- [ ] **Step 4: Add `plugin` subcommands to `main.rs`**
+
+Modify the `Cmd` enum in `crates/ahandd/src/main.rs`:
+
+```rust
+    /// Manage first-party aHand plugins
+    Plugin {
+        #[command(subcommand)]
+        command: PluginCmd,
+    },
+```
+
+Add a new enum near `Cmd`:
+
+```rust
+#[derive(Subcommand)]
+enum PluginCmd {
+    /// Inspect all plugins or a single plugin
+    Doctor {
+        plugin: Option<String>,
+    },
+    /// Install a plugin and required dependencies
+    Install {
+        plugin: String,
+        #[arg(long)]
+        force: bool,
+    },
+    /// Reinstall or repair a plugin
+    Repair {
+        plugin: String,
+    },
+    /// Print getHostResource JSON
+    HostResource {
+        #[arg(long)]
+        json: bool,
+    },
+}
+```
+
+In the early subcommand match, add:
+
+```rust
+            Cmd::Plugin { command } => {
+                return run_plugin_command(command).await;
+            }
+```
+
+Add this helper below `main()`:
+
+```rust
+async fn run_plugin_command(command: &PluginCmd) -> anyhow::Result<()> {
+    match command {
+        PluginCmd::Doctor { plugin } => {
+            let snapshot = plugin_runtime::get_host_resource().await?;
+            for item in snapshot.plugins {
+                if plugin.as_deref().is_some_and(|id| id != item.id) {
+                    continue;
+                }
+                println!("{}: {:?}", item.id, item.status);
+            }
+            Ok(())
+        }
+        PluginCmd::Install { plugin, force } => {
+            cli::browser_init::run(*force, Some(plugin.clone())).await
+        }
+        PluginCmd::Repair { plugin } => {
+            cli::browser_init::run(true, Some(plugin.clone())).await
+        }
+        PluginCmd::HostResource { json } => {
+            let snapshot = plugin_runtime::get_host_resource().await?;
+            if *json {
+                println!("{}", serde_json::to_string_pretty(&snapshot)?);
+            } else {
+                for plugin in snapshot.plugins {
+                    println!("{}: {:?}", plugin.id, plugin.status);
+                }
+            }
+            Ok(())
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Keep browser-init readable for plugin ids**
+
+In `crates/ahandd/src/cli/browser_init.rs`, replace the single-step success line:
+
+```rust
+println!("Step `{name}` complete.");
+```
+
+with:
+
+```rust
+println!("Plugin step `{name}` complete.");
+```
+
+No behavior changes are needed because `browser_setup::run_step()` now accepts both `playwright` and `browser-playwright-cli`.
+
+- [ ] **Step 6: Verify Task 6**
+
+Run:
+
+```bash
+cargo test -p ahandd browser_setup::tests
+cargo run -p ahandd -- plugin host-resource --json
+cargo run -p ahandd -- plugin doctor browser-playwright-cli
+cargo run -p ahandd -- browser-doctor
+```
+
+Expected:
+
+- tests pass.
+- `plugin host-resource --json` prints JSON with `runtimeVersion` and `plugins`.
+- `plugin doctor browser-playwright-cli` exits 0 and prints one plugin status.
+- `browser-doctor` exits 0 or 1 depending on local setup, with no panic.
+
+- [ ] **Step 7: Commit Task 6**
+
+```bash
+git add crates/ahandd/src/main.rs crates/ahandd/src/browser_setup/mod.rs crates/ahandd/src/cli/browser_init.rs
+git commit -m "feat(ahandd): add plugin runtime cli"
+```
+
+---
+
+### Task 7: Expose Host Resource Through Local Admin API
+
+**Files:**
+- Modify: `crates/ahandctl/Cargo.toml`
+- Modify: `crates/ahandctl/src/admin.rs`
+- Modify: `apps/admin/src/lib/api.ts`
+
+- [ ] **Step 1: Add the ahandd library dependency**
+
+Modify `crates/ahandctl/Cargo.toml`:
+
+```toml
+[dependencies]
+ahand-protocol = { path = "../ahand-protocol" }
+ahandd = { path = "../ahandd" }
+tokio.workspace = true
+```
+
+Keep all other dependencies unchanged.
+
+- [ ] **Step 2: Add admin route wiring**
+
+In `crates/ahandctl/src/admin.rs`, add `.or(host_resource_route(token_arc.clone()))` to the API route chain after `status_route(...)`:
+
+```rust
+    let api = warp::path("api").and(
+        status_route(token_arc.clone(), config_arc.clone())
+            .or(host_resource_route(token_arc.clone()))
+            .or(config_get_route(token_arc.clone(), config_arc.clone()))
+            .or(config_put_route(token_arc.clone(), config_arc.clone()))
+            .or(logs_route(token_arc.clone()))
+            .or(runs_list_route(token_arc.clone()))
+            .or(runs_get_route(token_arc.clone()))
+            .or(runs_file_route(token_arc.clone()))
+            .or(browser_init_route(token_arc.clone())),
+    );
+```
+
+Add this route near `status_route`:
+
+```rust
+fn host_resource_route(
+    token: Arc<String>,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    warp::path!("host-resource")
+        .and(warp::get())
+        .and(with_auth(token))
+        .and_then(|| async move {
+            match ahandd::plugin_runtime::get_host_resource().await {
+                Ok(snapshot) => Ok::<_, Rejection>(warp::reply::json(&snapshot)),
+                Err(e) => {
+                    eprintln!("Host resource error: {}", e);
+                    Err(reject::reject())
+                }
+            }
+        })
+}
+```
+
+- [ ] **Step 3: Add TypeScript API types**
+
+In `apps/admin/src/lib/api.ts`, add these interfaces below `StatusResponse`:
+
+```ts
+export type PluginStatus =
+  | "installed"
+  | "missing"
+  | "outdated"
+  | "failed"
+  | "blocked";
+
+export type HostResourceValue =
+  | { kind: "executable"; name: string; path: string; version?: string }
+  | { kind: "directory"; name: string; path: string }
+  | { kind: "env"; name: string; value: string }
+  | { kind: "config"; name: string; value: unknown };
+
+export interface InstalledPluginResource {
+  id: string;
+  version: string;
+  status: PluginStatus;
+  dependencies: string[];
+  capabilities: string[];
+  resources: Record<string, HostResourceValue>;
+  helpPrompt?: string;
+}
+
+export interface HostResourceSnapshot {
+  runtimeVersion: string;
+  platform: string;
+  arch: string;
+  plugins: InstalledPluginResource[];
+}
+```
+
+Add this method to `api`:
+
+```ts
+  async getHostResource(): Promise<HostResourceSnapshot> {
+    return fetchAPI("/host-resource");
+  },
+```
+
+- [ ] **Step 4: Verify Task 7**
+
+Run:
+
+```bash
+cargo check -p ahandctl
+cargo check -p ahandd
+pnpm --filter @ahand/admin build
+```
+
+Expected:
+
+- both Rust packages compile.
+- admin build completes without TypeScript errors.
+
+- [ ] **Step 5: Commit Task 7**
+
+```bash
+git add crates/ahandctl/Cargo.toml crates/ahandctl/src/admin.rs apps/admin/src/lib/api.ts
+git commit -m "feat(admin): expose host resource api"
+```
+
+---
+
+### Task 8: Final Verification And Compatibility Pass
+
+**Files:**
+- Modify only files required by verification failures found in this task.
+
+- [ ] **Step 1: Run focused Rust tests**
+
+Run:
+
+```bash
+cargo test -p ahandd plugin_runtime
+cargo test -p ahandd browser_setup
+cargo test -p ahandd --test browser_doctor
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run package checks**
+
+Run:
+
+```bash
+cargo check -p ahandd -p ahandctl
+pnpm --filter @ahand/admin build
+```
+
+Expected: all checks pass.
+
+- [ ] **Step 3: Run command smoke tests**
+
+Run:
+
+```bash
+cargo run -p ahandd -- plugin host-resource --json
+cargo run -p ahandd -- plugin doctor
+cargo run -p ahandd -- browser-doctor
+```
+
+Expected:
+
+- `plugin host-resource --json` prints valid JSON.
+- `plugin doctor` prints statuses for `browser-playwright-cli`, `file`, `node`, `python`, and `shell`.
+- `browser-doctor` exits 0 or 1 and does not panic.
+
+- [ ] **Step 4: Inspect working tree**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+```
+
+Expected: only intentional files from this plan are modified.
+
+- [ ] **Step 5: Commit final fixes if verification required changes**
+
+If Step 1, Step 2, or Step 3 required fixes, commit those fixes:
+
+```bash
+git add crates/ahandd crates/ahandctl apps/admin
+git commit -m "fix: stabilize plugin runtime stage one"
+```
+
+If no fixes were needed, do not create an empty commit.

--- a/docs/superpowers/specs/2026-05-12-ahand-plugin-runtime-design.md
+++ b/docs/superpowers/specs/2026-05-12-ahand-plugin-runtime-design.md
@@ -1,0 +1,413 @@
+# AHand Plugin Runtime Design
+
+**Date:** 2026-05-12
+**Status:** Approved design for planning
+
+## Overview
+
+AHand should upgrade its current hard-coded capability and dependency setup into a first-party plugin system. A plugin can provide host capabilities, managed runtimes, exported resource paths, setup/doctor behavior, and a short help prompt for agents. Plugins can depend on other plugins.
+
+The first plugin set is:
+
+```text
+shell
+node
+python
+file
+browser-playwright-cli -> shell, node
+```
+
+The implementation should land in stages. First, replace the current `browser_setup` hard-coded `node -> playwright` installation flow with plugin lifecycle plumbing. Then migrate capability routing so `shell`, `file`, and `browser-playwright-cli` are registered through the plugin registry rather than being special daemon branches.
+
+## Goals
+
+- Make aHand host capabilities installable, inspectable, and discoverable as plugins.
+- Keep runtime dependencies separate from project dependencies.
+- Let plugins depend on other plugins, with explicit dependency resolution and failure reporting.
+- Expose installed plugin state through a read-only `getHostResource` API.
+- Preserve current daemon policy, approval, audit, and protocol behavior during migration.
+- Avoid making `node` or `python` privileged concepts in the daemon. They are first-party runtime plugins.
+
+## Non-Goals
+
+- Third-party plugin marketplace support in the first implementation.
+- Dynamic native code loading into the daemon process.
+- Replacing the wire protocol in one large migration.
+- Automatically installing missing plugins as a side effect of `getHostResource`.
+- Moving project-specific dependencies into the aHand runtime cache.
+
+## Plugin Boundaries
+
+### `shell`
+
+`shell` is both a capability plugin and a dependency plugin.
+
+It provides:
+
+- Non-interactive command execution.
+- PTY execution.
+- stdin forwarding.
+- terminal resize handling.
+- cwd and env propagation.
+- stdout/stderr streaming.
+
+It is the foundation for tools that need process execution semantics. `browser-playwright-cli` depends on it because browser commands are executed as managed subprocesses.
+
+### `node`
+
+`node` is a runtime plugin.
+
+It provides:
+
+- Managed Node.js installation.
+- Managed npm path.
+- Node/npm version inspection.
+- exported executable resources for `node` and `npm`.
+
+It should be bootstrap-installed by daemon-owned Rust installer code, not by shell scripts. This avoids dependency cycles where installing the shell plugin would require the shell plugin.
+
+### `python`
+
+`python` is a runtime plugin.
+
+It provides:
+
+- Managed Python installation.
+- Python version inspection.
+- exported executable resource for `python`.
+- optional package directory resource when a bundled package set exists.
+
+No current first-stage capability depends on Python, but defining it early keeps parity with the expected primary runtime model.
+
+### `file`
+
+`file` is a capability plugin.
+
+It provides the existing file operation capability and owns file policy metadata:
+
+- path allowlist.
+- path denylist.
+- dangerous path approval escalation.
+- read/write byte limits.
+- operation-level risk classification.
+
+It does not depend on `shell`, `node`, or `python`.
+
+### `browser-playwright-cli`
+
+`browser-playwright-cli` is a capability plugin with runtime dependencies.
+
+It depends on:
+
+```text
+shell
+node
+```
+
+It provides:
+
+- browser automation capability.
+- playwright-cli inspection and repair.
+- browser command execution through `playwright-cli`.
+- exported `playwright-cli` executable resource.
+- browser-specific help prompt.
+
+The current `browser_setup::playwright` logic should move behind this plugin lifecycle while preserving the existing public CLI behavior during migration.
+
+## Plugin Manifest
+
+Each plugin has a TOML manifest owned by the plugin package. TOML matches the daemon's existing configuration style and stays easy to inspect manually.
+
+```toml
+id = "browser-playwright-cli"
+version = "0.1.0"
+display_name = "Browser Playwright CLI"
+
+dependencies = ["shell", "node"]
+capabilities = ["browser"]
+
+[resources.executables.playwrightCli]
+name = "playwright-cli"
+path = "bin/playwright-cli"
+
+[help]
+prompt = "Provides browser automation through playwright-cli. Use for browser open, click, fill, snapshot, screenshot, PDF, download, and close actions."
+```
+
+Runtime plugins use the same shape:
+
+```toml
+id = "node"
+version = "0.1.0"
+display_name = "Node.js Runtime"
+
+dependencies = []
+capabilities = []
+
+[resources.executables.node]
+name = "node"
+path = "dependencies/node/bin/node"
+
+[resources.executables.npm]
+name = "npm"
+path = "dependencies/node/bin/npm"
+
+[help]
+prompt = "Use the managed Node.js runtime for JavaScript-based local tools. Prefer this path over system node when a plugin depends on node."
+```
+
+## Lifecycle
+
+Plugins implement a common lifecycle:
+
+```text
+discover -> inspect -> install/repair -> activate -> export resources
+```
+
+- `discover`: load plugin manifests from the runtime bundle and user/plugin cache.
+- `inspect`: read-only check of plugin status, versions, exported paths, and dependency state.
+- `install/repair`: mutating setup flow. Downloads, extracts, verifies, or reinstalls managed dependencies.
+- `activate`: registers capabilities and handlers with the daemon.
+- `export resources`: contributes entries to the host resource registry.
+
+`inspect` must never mutate the host. `getHostResource` must call only read-only paths or consume cached inspect results.
+
+## Runtime Directory
+
+The aHand managed runtime should live outside project workspaces:
+
+```text
+~/.cache/ahand-runtimes/ahand-primary-runtime/
+  runtime.json
+  plugins/
+    shell/
+    node/
+    python/
+    file/
+    browser-playwright-cli/
+  dependencies/
+    node/
+    python/
+```
+
+`runtime.json` records:
+
+- bundle format version.
+- bundle version.
+- target platform.
+- target architecture.
+- installed plugin ids and versions.
+- plugin status summary.
+- managed Node/Python versions when present.
+
+The runtime cache is owned by aHand. It should not contain user project dependencies.
+
+## Host Resource Registry
+
+The daemon should expose a read-only `getHostResource` API that returns installed plugin state and exported resources.
+
+```ts
+type HostResourceSnapshot = {
+  runtimeVersion: string;
+  platform: "darwin" | "linux" | "windows";
+  arch: "arm64" | "x64";
+  plugins: InstalledPluginResource[];
+};
+
+type InstalledPluginResource = {
+  id: string;
+  version: string;
+  status: "installed" | "missing" | "outdated" | "failed";
+  dependencies: string[];
+  capabilities: string[];
+  resources: Record<string, HostResourceValue>;
+  helpPrompt?: string;
+};
+
+type HostResourceValue =
+  | { kind: "executable"; name: string; path: string; version?: string }
+  | { kind: "directory"; name: string; path: string }
+  | { kind: "env"; name: string; value: string }
+  | { kind: "config"; name: string; value: unknown };
+```
+
+Example:
+
+```json
+{
+  "runtimeVersion": "0.1.0",
+  "platform": "darwin",
+  "arch": "arm64",
+  "plugins": [
+    {
+      "id": "node",
+      "version": "0.1.0",
+      "status": "installed",
+      "dependencies": [],
+      "capabilities": [],
+      "resources": {
+        "node": {
+          "kind": "executable",
+          "name": "node",
+          "path": "~/.cache/ahand-runtimes/ahand-primary-runtime/dependencies/node/bin/node",
+          "version": "v24.14.0"
+        },
+        "npm": {
+          "kind": "executable",
+          "name": "npm",
+          "path": "~/.cache/ahand-runtimes/ahand-primary-runtime/dependencies/node/bin/npm"
+        }
+      },
+      "helpPrompt": "Use the managed Node.js runtime for JavaScript-based local tools. Prefer this path over system node when a plugin depends on node."
+    },
+    {
+      "id": "browser-playwright-cli",
+      "version": "0.1.0",
+      "status": "installed",
+      "dependencies": ["shell", "node"],
+      "capabilities": ["browser"],
+      "resources": {
+        "playwrightCli": {
+          "kind": "executable",
+          "name": "playwright-cli",
+          "path": "~/.cache/ahand-runtimes/ahand-primary-runtime/plugins/browser-playwright-cli/bin/playwright-cli"
+        }
+      },
+      "helpPrompt": "Provides browser automation through playwright-cli. Use for browser open, click, fill, snapshot, screenshot, PDF, download, and close actions."
+    }
+  ]
+}
+```
+
+Agents use this snapshot to decide which host capabilities are available and which executable paths to use. Missing or failed plugins should be visible, not silently hidden.
+
+## Dependency Resolution
+
+The plugin manager should resolve dependencies as a directed acyclic graph.
+
+Rules:
+
+- Missing dependency blocks activation of the dependent plugin.
+- Failed dependency sets the dependent plugin to `failed` or `blocked`.
+- Cycles are configuration errors and should fail daemon startup or plugin activation loudly.
+- `install all` installs dependencies before dependents.
+- `inspect all` reports every plugin independently and includes dependency status.
+
+For the first plugin set:
+
+```text
+browser-playwright-cli
+  -> shell
+  -> node
+```
+
+`file`, `python`, `shell`, and `node` have no plugin dependencies.
+
+## Capability Routing
+
+The migration should avoid a risky protocol rewrite.
+
+Stage 1 keeps existing protocol handlers:
+
+- `JobRequest` continues to execute through current executor paths.
+- `BrowserRequest` continues through current browser manager.
+- `FileRequest` continues through current file manager.
+
+But the setup and resource discovery path moves to plugins:
+
+- `browser-doctor` calls plugin inspect.
+- `browser-init` calls plugin install/repair.
+- `BrowserManager` receives the `playwright-cli` path from `browser-playwright-cli` resources.
+
+Stage 2 moves handler registration behind plugin activation:
+
+- `shell` registers the `JobRequest` execution handler.
+- `file` registers the file operation handler.
+- `browser-playwright-cli` registers the browser operation handler.
+
+The protocol can remain stable while dispatch becomes plugin-backed.
+
+## Policy, Approval, and Audit
+
+Plugins should not bypass existing safety controls.
+
+Each capability plugin declares policy metadata:
+
+- capability id.
+- operation names.
+- default risk level.
+- approval escalation hints.
+- config section ownership.
+
+Existing checks remain authoritative:
+
+- shell execution uses current session mode and command policy.
+- file operations use current file policy.
+- browser operations use current browser policy and domain controls.
+
+The plugin registry only makes capability ownership explicit. It does not weaken policy enforcement.
+
+## CLI Surface
+
+Existing commands should keep working:
+
+```bash
+ahandd browser-doctor
+ahandd browser-init
+ahandd browser-init --step node
+ahandd browser-init --step playwright
+```
+
+They should become compatibility wrappers over plugin commands:
+
+```bash
+ahandd plugin doctor
+ahandd plugin doctor browser-playwright-cli
+ahandd plugin install browser-playwright-cli
+ahandd plugin repair node
+```
+
+The compatibility commands can be deprecated later, after dashboard and SDK callers use plugin APIs.
+
+## Implementation Stages
+
+### Stage 1: Runtime Plugin Foundation
+
+- Add plugin manifest types.
+- Add plugin registry and dependency graph.
+- Add read-only inspect model.
+- Add `getHostResource` snapshot model.
+- Move Node setup logic behind the `node` plugin.
+- Move playwright-cli setup logic behind the `browser-playwright-cli` plugin.
+- Preserve current browser CLI commands as wrappers.
+
+### Stage 2: Capability Plugin Activation
+
+- Add capability registration hooks.
+- Register shell execution through the `shell` plugin.
+- Register file operations through the `file` plugin.
+- Register browser operations through the `browser-playwright-cli` plugin.
+- Keep existing wire protocol stable.
+
+### Stage 3: Packaging and Bundle Updates
+
+- Generate or ship first-party plugin packages.
+- Write `runtime.json` during install/update.
+- Add plugin cache repair flow.
+- Add dashboard/admin plugin status UI.
+
+## Testing Strategy
+
+- Unit-test manifest parsing and validation.
+- Unit-test dependency graph ordering and cycle rejection.
+- Unit-test `getHostResource` serialization.
+- Unit-test `node` and `browser-playwright-cli` inspect behavior with fake paths.
+- Keep existing browser setup tests, migrating expectations to plugin APIs.
+- Add integration tests that `browser-init` compatibility commands still work.
+- Add tests that a missing `node` blocks `browser-playwright-cli` activation.
+
+## First Implementation Decisions
+
+- Plugin manifests should use TOML on disk because existing daemon configuration is TOML and the format is easy to inspect manually.
+- Install state should be stored in `runtime.json` as the aggregate source of truth, with per-plugin status files added only if concurrent repair/update flows require them later.
+- The first `getHostResource` surface should be JSON over the existing local/admin API boundary. A protobuf message can be added after the JSON shape stabilizes and hub forwarding needs it.

--- a/docs/superpowers/specs/2026-05-12-ahand-plugin-runtime-design.md
+++ b/docs/superpowers/specs/2026-05-12-ahand-plugin-runtime-design.md
@@ -217,7 +217,7 @@ type HostResourceSnapshot = {
 type InstalledPluginResource = {
   id: string;
   version: string;
-  status: "installed" | "missing" | "outdated" | "failed";
+  status: "installed" | "missing" | "outdated" | "failed" | "blocked";
   dependencies: string[];
   capabilities: string[];
   resources: Record<string, HostResourceValue>;


### PR DESCRIPTION
## Summary
- Adds Stage 1 plugin runtime plumbing with built-in manifests, dependency ordering, host-resource snapshots, and CLI doctor/install surfaces.
- Moves browser setup paths under `~/.cache/ahand-runtimes/ahand-primary-runtime` and models `browser-playwright-cli` as dependent on `shell` and `node`.
- Exposes `getHostResource` through the admin API, tightens the TypeScript contract for plugin status/platform/arch, and includes the local Stage 1 implementation plan doc.

## Validation
- `cargo test -p ahandd plugin_runtime`
- `cargo test -p ahandd browser_setup`
- `cargo test -p ahandd --test browser_doctor`
- `cargo check -p ahandd -p ahandctl`
- `cargo build -p ahandd --bin ahandd`
- `pnpm --filter @ahand/admin exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @ahand/admin build`
- `target/debug/ahandd plugin host-resource --json`
- `target/debug/ahandd plugin doctor`
- `git diff --check c2f0754..HEAD`

## Notes
- `browser-doctor` exits with 1 on this host because the managed runtime does not yet have Node.js or playwright-cli installed; it reports the expected `browser-init --step node` and `browser-init --step playwright` remediation commands.
- The local worktree still has an unrelated unstaged `pnpm-lock.yaml` change from pnpm resolution noise; it was intentionally not included in this PR.
