### PR TITLE
[codex] Plugin runtime stage 3 providers

### DIFF
--- a/crates/ahandd/src/ahand_client.rs
+++ b/crates/ahandd/src/ahand_client.rs
@@ -20,7 +20,7 @@ use crate::device_identity::DeviceIdentity;
 use crate::executor::{self, EnvelopeSink as _};
 use crate::file_manager::FileManager;
 use crate::outbox::{Outbox, prepare_outbound};
-use crate::plugin_runtime::{CapabilityKind, CapabilityUnavailable};
+use crate::plugin_runtime::{CapabilityKind, CapabilityUnavailable, JobProvider};
 use crate::registry::{IsKnown, JobRegistry};
 use crate::session::{SessionDecision, SessionManager};
 use crate::store::{Direction, RunStore};
@@ -915,6 +915,25 @@ fn file_unavailable_response(
     )
 }
 
+fn managed_runtime_interactive_rejection(
+    device_id: &str,
+    req: &ahand_protocol::JobRequest,
+) -> Envelope {
+    Envelope {
+        device_id: device_id.to_string(),
+        msg_id: new_msg_id(),
+        ts_ms: now_ms(),
+        payload: Some(envelope::Payload::JobRejected(JobRejected {
+            job_id: req.job_id.clone(),
+            reason: format!(
+                "managed runtime tool {} does not support interactive PTY jobs",
+                req.tool
+            ),
+        })),
+        ..Default::default()
+    }
+}
+
 /// Handle an incoming JobRequest with idempotency + session mode check.
 #[allow(clippy::too_many_arguments)]
 async fn handle_job_request<T>(
@@ -932,20 +951,28 @@ async fn handle_job_request<T>(
 ) where
     T: crate::executor::EnvelopeSink,
 {
-    let capability_router = match crate::plugin_runtime::build_router(browser_mgr, file_mgr).await {
-        Ok(router) => router,
+    let provider_registry =
+        match crate::plugin_runtime::build_provider_registry(browser_mgr, file_mgr).await {
+            Ok(registry) => registry,
+            Err(err) => {
+                reject_job_for_capability_error(
+                    device_id,
+                    &req,
+                    tx,
+                    format!("exec capability unavailable: failed to inspect host resources: {err}"),
+                );
+                return;
+            }
+        };
+    let job_provider = match provider_registry.resolve_job_provider(&req.tool) {
+        Ok(provider) => provider,
         Err(err) => {
-            reject_job_for_capability_error(
-                device_id,
-                &req,
-                tx,
-                format!("exec capability unavailable: failed to inspect host resources: {err}"),
-            );
+            reject_job_for_capability_error(device_id, &req, tx, err.to_protocol_message());
             return;
         }
     };
-    if let Err(unavailable) = capability_router.ensure(CapabilityKind::Exec) {
-        reject_job_for_capability_error(device_id, &req, tx, unavailable.to_protocol_message());
+    if req.interactive && matches!(job_provider, JobProvider::ManagedRuntime { .. }) {
+        let _ = tx.send(managed_runtime_interactive_rejection(device_id, &req));
         return;
     }
 
@@ -991,7 +1018,7 @@ async fn handle_job_request<T>(
             let _ = tx.send(reject_env);
         }
         SessionDecision::Allow => {
-            spawn_job(device_id, req, tx, registry, store).await;
+            spawn_job(device_id, req, job_provider, tx, registry, store).await;
         }
         SessionDecision::NeedsApproval {
             reason,
@@ -1026,13 +1053,14 @@ async fn handle_job_request<T>(
             let timeout = amgr.default_timeout();
             let job_id = req.job_id.clone();
             let cuid = caller_uid.to_string();
+            let job_provider = job_provider.clone();
 
             tokio::spawn(async move {
                 let result = tokio::time::timeout(timeout, approval_rx).await;
                 match result {
                     Ok(Ok(resp)) if resp.approved => {
                         info!(job_id = %job_id, "approval granted");
-                        spawn_job(&did, req, &tx_clone, &reg, &st).await;
+                        spawn_job(&did, req, job_provider, &tx_clone, &reg, &st).await;
                     }
                     Ok(Ok(resp)) => {
                         // Denied — record refusal if reason provided.
@@ -1082,6 +1110,7 @@ async fn handle_job_request<T>(
 async fn spawn_job<T>(
     device_id: &str,
     req: ahand_protocol::JobRequest,
+    provider: JobProvider,
     tx: &T,
     registry: &Arc<JobRegistry>,
     store: &Option<Arc<RunStore>>,
@@ -1098,6 +1127,11 @@ async fn spawn_job<T>(
     let (cancel_tx, cancel_rx) = mpsc::channel(1);
 
     if interactive {
+        if matches!(provider, JobProvider::ManagedRuntime { .. }) {
+            let _ = tx.send(managed_runtime_interactive_rejection(device_id, &req));
+            return;
+        }
+
         let (stdin_tx, stdin_rx) = mpsc::unbounded_channel::<executor::StdinInput>();
         reg.register_interactive(job_id.clone(), cancel_tx, stdin_tx)
             .await;
@@ -1120,7 +1154,14 @@ async fn spawn_job<T>(
 
         tokio::spawn(async move {
             let _permit = reg.acquire_permit().await;
-            let (exit_code, error) = executor::run_job(did, req, tx_clone, cancel_rx, st).await;
+            let (exit_code, error) = match provider {
+                JobProvider::DefaultExec => {
+                    executor::run_job(did, req, tx_clone, cancel_rx, st).await
+                }
+                JobProvider::ManagedRuntime { target, .. } => {
+                    executor::run_job_with_target(did, req, target, tx_clone, cancel_rx, st).await
+                }
+            };
             reg.remove(&job_id).await;
             reg.mark_completed(job_id, exit_code, error).await;
         });
@@ -1191,8 +1232,13 @@ async fn handle_browser_request<T>(
         "received browser request"
     );
 
-    let capability_router = match crate::plugin_runtime::build_router(browser_mgr, file_mgr).await {
-        Ok(router) => router,
+    let provider_registry = match crate::plugin_runtime::build_provider_registry(
+        browser_mgr,
+        file_mgr,
+    )
+    .await
+    {
+        Ok(registry) => registry,
         Err(err) => {
             let resp_env = Envelope {
                 device_id: device_id.to_string(),
@@ -1213,7 +1259,7 @@ async fn handle_browser_request<T>(
             return;
         }
     };
-    if let Err(unavailable) = capability_router.ensure(CapabilityKind::Browser) {
+    if let Err(unavailable) = provider_registry.ensure(CapabilityKind::Browser) {
         let resp_env = Envelope {
             device_id: device_id.to_string(),
             msg_id: new_msg_id(),
@@ -1367,19 +1413,22 @@ async fn handle_file_request<T>(
     // field hiding behind a generic "PolicyDenied" message.
     let req_paths_joined = file_mgr.request_paths(&req).join(", ");
 
-    let capability_router = match crate::plugin_runtime::build_router(browser_mgr, file_mgr).await {
-        Ok(router) => router,
-        Err(err) => {
-            send_file_response(crate::file_manager::error_response(
-                req.request_id.clone(),
-                ahand_protocol::FileErrorCode::PolicyDenied,
-                &req_paths_joined,
-                &format!("file capability unavailable: failed to inspect host resources: {err}"),
-            ));
-            return;
-        }
-    };
-    if let Err(unavailable) = capability_router.ensure(CapabilityKind::File) {
+    let provider_registry =
+        match crate::plugin_runtime::build_provider_registry(browser_mgr, file_mgr).await {
+            Ok(registry) => registry,
+            Err(err) => {
+                send_file_response(crate::file_manager::error_response(
+                    req.request_id.clone(),
+                    ahand_protocol::FileErrorCode::PolicyDenied,
+                    &req_paths_joined,
+                    &format!(
+                        "file capability unavailable: failed to inspect host resources: {err}"
+                    ),
+                ));
+                return;
+            }
+        };
+    if let Err(unavailable) = provider_registry.ensure(CapabilityKind::File) {
         send_file_response(file_unavailable_response(
             &req,
             &req_paths_joined,
@@ -1837,6 +1886,28 @@ mod tests {
                 );
             }
             other => panic!("expected file error response, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn managed_runtime_interactive_rejection_preserves_job_id() {
+        let req = ahand_protocol::JobRequest {
+            job_id: "node-interactive-1".to_string(),
+            tool: "plugin:node".to_string(),
+            interactive: true,
+            ..Default::default()
+        };
+
+        let env = super::managed_runtime_interactive_rejection("device-1", &req);
+
+        assert_eq!(env.device_id, "device-1");
+        match env.payload {
+            Some(envelope::Payload::JobRejected(rejected)) => {
+                assert_eq!(rejected.job_id, "node-interactive-1");
+                assert!(rejected.reason.contains("plugin:node"));
+                assert!(rejected.reason.contains("interactive"));
+            }
+            other => panic!("expected JobRejected, got {other:?}"),
         }
     }
 

--- a/crates/ahandd/src/browser_setup/mod.rs
+++ b/crates/ahandd/src/browser_setup/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Public API:
 //! - `inspect_all()`, `inspect(name)` — read-only diagnostic
-//! - `run_all(force, progress)` — install everything (or refresh)
+//! - `run_all(force, progress)` — install browser automation dependencies
 //! - `run_step(name, force, progress)` — install a single component
 //! - `detect_browser(config_override)`, `detect_all_browsers()` — browser detection
 
@@ -11,6 +11,7 @@ use anyhow::{Result, bail};
 pub mod browser_detect;
 pub mod node;
 pub mod playwright;
+pub mod python;
 pub mod types;
 
 pub use browser_detect::{
@@ -85,6 +86,7 @@ pub async fn inspect_all() -> Vec<CheckReport> {
 pub async fn inspect(name: &str) -> Option<CheckReport> {
     match name {
         "node" => Some(node::inspect().await),
+        "python" => Some(python::inspect().await),
         "playwright" | "browser-playwright-cli" => Some(playwright::inspect().await),
         "browser" => Some(inspect_browser()),
         _ => None,
@@ -123,7 +125,7 @@ pub async fn run_all(
     Ok(vec![node_report, playwright_report, browser_report])
 }
 
-/// Run a single install step. Valid names: `node`, `playwright`,
+/// Run a single install step. Valid names: `node`, `python`, `playwright`,
 /// `browser-playwright-cli`, plus non-installable plugin ids for diagnostics.
 /// Returns an error for `playwright`/`browser-playwright-cli` if Node is not
 /// already installed.
@@ -141,6 +143,10 @@ pub async fn run_step(
         "node" => match node::ensure(force, progress_ref).await {
             Ok(r) => Ok(r),
             Err(e) => Err(wrap_failure(e, "node", "Node.js", progress_ref)),
+        },
+        "python" => match python::ensure(force, progress_ref).await {
+            Ok(r) => Ok(r),
+            Err(e) => Err(wrap_failure(e, "python", "Python", progress_ref)),
         },
         "playwright" | "browser-playwright-cli" => {
             let node_status = node::inspect().await;
@@ -161,11 +167,11 @@ pub async fn run_step(
                 )),
             }
         }
-        "shell" | "file" | "python" => {
+        "shell" | "file" => {
             bail!("plugin `{name}` does not have an install step in this release")
         }
         other => bail!(
-            "unknown step `{other}`. Valid install steps: node, playwright, browser-playwright-cli"
+            "unknown step `{other}`. Valid install steps: node, python, playwright, browser-playwright-cli"
         ),
     }
 }
@@ -280,6 +286,7 @@ mod tests {
     #[tokio::test]
     async fn inspect_accepts_plugin_id_aliases() {
         assert!(inspect("node").await.is_some());
+        assert!(inspect("python").await.is_some());
         assert!(inspect("playwright").await.is_some());
         assert!(inspect("browser-playwright-cli").await.is_some());
     }

--- a/crates/ahandd/src/browser_setup/python.rs
+++ b/crates/ahandd/src/browser_setup/python.rs
@@ -1,0 +1,412 @@
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+
+use super::types::{CheckReport, CheckSource, CheckStatus, FixHint, Phase, ProgressEvent};
+
+pub const PYTHON_MIN_MAJOR: u32 = 3;
+pub const PYTHON_MIN_MINOR: u32 = 12;
+pub const PYTHON_VERSION: &str = "3.12.13";
+pub const PYTHON_BUILD_RELEASE: &str = "20260510";
+
+pub struct Dirs {
+    pub python: PathBuf,
+    runtime: crate::plugin_runtime::RuntimeDirs,
+}
+
+impl Dirs {
+    pub fn new() -> Result<Self> {
+        let runtime = crate::plugin_runtime::RuntimeDirs::new()?;
+        Ok(Self::from_runtime(runtime))
+    }
+
+    #[cfg(test)]
+    pub fn from_runtime_root(root: PathBuf) -> Self {
+        Self::from_runtime(crate::plugin_runtime::RuntimeDirs::from_root(root))
+    }
+
+    fn from_runtime(runtime: crate::plugin_runtime::RuntimeDirs) -> Self {
+        let python = runtime.python_dir();
+        Self { python, runtime }
+    }
+
+    pub fn local_python_bin(&self) -> PathBuf {
+        self.runtime.python_bin()
+    }
+}
+
+fn local_python_bin() -> Result<PathBuf> {
+    Ok(Dirs::new()?.local_python_bin())
+}
+
+pub async fn inspect() -> CheckReport {
+    let report = async {
+        let bin = local_python_bin()?;
+        if !bin.exists() {
+            return Ok::<CheckReport, anyhow::Error>(missing_report());
+        }
+
+        match read_python_version(&bin).await {
+            Some(version) if version.meets_minimum() => Ok(CheckReport {
+                name: "python",
+                label: "Python",
+                status: CheckStatus::Ok {
+                    version: version.to_string(),
+                    path: bin,
+                    source: CheckSource::Managed,
+                },
+                fix_hint: None,
+            }),
+            Some(version) => Ok(CheckReport {
+                name: "python",
+                label: "Python",
+                status: CheckStatus::Outdated {
+                    current: version.to_string(),
+                    required: format!("Python {PYTHON_MIN_MAJOR}.{PYTHON_MIN_MINOR}"),
+                    path: bin,
+                },
+                fix_hint: Some(FixHint::RunStep {
+                    command: "ahandd plugin install python --force".into(),
+                }),
+            }),
+            None => Ok(CheckReport {
+                name: "python",
+                label: "Python",
+                status: CheckStatus::Missing,
+                fix_hint: Some(FixHint::RunStep {
+                    command: "ahandd plugin install python --force".into(),
+                }),
+            }),
+        }
+    }
+    .await;
+
+    report.unwrap_or_else(|_| missing_report())
+}
+
+pub async fn ensure(
+    force: bool,
+    progress: &(dyn Fn(ProgressEvent) + Send + Sync),
+) -> Result<CheckReport> {
+    let dirs = Dirs::new()?;
+    let local_python = dirs.local_python_bin();
+
+    if !force && local_python.exists() {
+        if let Some(version) = read_python_version(&local_python).await
+            && version.meets_minimum()
+        {
+            emit(
+                progress,
+                Phase::Done,
+                format!("{} already installed at {}", version, dirs.python.display()),
+            );
+            return Ok(inspect().await);
+        }
+    }
+
+    if dirs.python.exists() {
+        let _ = std::fs::remove_dir_all(&dirs.python);
+    }
+
+    emit(
+        progress,
+        Phase::Starting,
+        format!(
+            "Installing Python {PYTHON_VERSION} to {}",
+            dirs.python.display()
+        ),
+    );
+
+    install_python(&dirs, progress).await.context(
+        "Failed to install Python. Check your network connection and retry, \
+         or install Python manually at the managed runtime path.",
+    )?;
+
+    if !local_python.exists() {
+        anyhow::bail!(
+            "Python installation completed but binary not found at {}.",
+            local_python.display()
+        );
+    }
+
+    let Some(version) = read_python_version(&local_python).await else {
+        anyhow::bail!(
+            "Python installation completed but version check failed at {}.",
+            local_python.display()
+        );
+    };
+    if !version.meets_minimum() {
+        anyhow::bail!(
+            "Python installation completed but version {} is below required Python {}.{}.",
+            version,
+            PYTHON_MIN_MAJOR,
+            PYTHON_MIN_MINOR
+        );
+    }
+
+    emit(
+        progress,
+        Phase::Done,
+        format!("Python {PYTHON_VERSION} ready at {}", dirs.python.display()),
+    );
+
+    Ok(inspect().await)
+}
+
+async fn install_python(
+    dirs: &Dirs,
+    progress: &(dyn Fn(ProgressEvent) + Send + Sync),
+) -> Result<()> {
+    let asset = python_asset_name()?;
+    let url = format!(
+        "https://github.com/astral-sh/python-build-standalone/releases/download/{PYTHON_BUILD_RELEASE}/{asset}"
+    );
+
+    emit(progress, Phase::Downloading, format!("Downloading {asset}"));
+
+    let bytes = download_bytes(&url).await.context(format!(
+        "Failed to download Python from {url} - check your network connection"
+    ))?;
+
+    std::fs::create_dir_all(&dirs.python).context(format!(
+        "Failed to create directory {}: permission denied or disk full",
+        dirs.python.display()
+    ))?;
+
+    emit(
+        progress,
+        Phase::Extracting,
+        "Extracting Python archive".into(),
+    );
+
+    let decoder = flate2::read::GzDecoder::new(std::io::Cursor::new(bytes));
+    let mut archive = tar::Archive::new(decoder);
+    archive.set_preserve_permissions(true);
+    for entry in archive
+        .entries()
+        .context("Failed to read Python archive - download may be corrupted")?
+    {
+        let mut entry = entry.context("Corrupted entry in Python archive")?;
+        let path = entry.path()?.into_owned();
+        let Some(dest) = archive_destination(&dirs.python, &path) else {
+            continue;
+        };
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        entry.unpack(&dest).context(format!(
+            "Failed to extract {} - disk may be full",
+            dest.display()
+        ))?;
+    }
+
+    emit(
+        progress,
+        Phase::Verifying,
+        "Verifying Python installation".into(),
+    );
+
+    Ok(())
+}
+
+fn archive_destination(root: &Path, archive_path: &Path) -> Option<PathBuf> {
+    let mut components = archive_path.components();
+    if !matches!(components.next()?, Component::Normal(_)) {
+        return None;
+    }
+
+    let mut dest = root.to_path_buf();
+    let mut has_child = false;
+    for component in components {
+        match component {
+            Component::Normal(part) => {
+                dest.push(part);
+                has_child = true;
+            }
+            Component::CurDir => {}
+            Component::Prefix(_) | Component::RootDir | Component::ParentDir => return None,
+        }
+    }
+
+    has_child.then_some(dest)
+}
+
+async fn download_bytes(url: &str) -> Result<Vec<u8>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(url)
+        .header("User-Agent", "ahandd")
+        .send()
+        .await
+        .context("HTTP request failed")?;
+
+    if !resp.status().is_success() {
+        anyhow::bail!("HTTP {} for {}", resp.status(), url);
+    }
+
+    let bytes = resp.bytes().await.context("failed to read response body")?;
+    Ok(bytes.to_vec())
+}
+
+fn python_asset_name() -> Result<String> {
+    let target = python_target_triple()?;
+    Ok(format!(
+        "cpython-{PYTHON_VERSION}+{PYTHON_BUILD_RELEASE}-{target}-install_only.tar.gz"
+    ))
+}
+
+fn python_target_triple() -> Result<&'static str> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => Ok("aarch64-apple-darwin"),
+        ("macos", "x86_64") => Ok("x86_64-apple-darwin"),
+        ("linux", "aarch64") => Ok("aarch64-unknown-linux-gnu"),
+        ("linux", "x86_64") => Ok("x86_64-unknown-linux-gnu"),
+        ("windows", "x86_64") => Ok("x86_64-pc-windows-msvc"),
+        (os, arch) => bail!("unsupported Python runtime platform {os}/{arch}"),
+    }
+}
+
+async fn read_python_version(python_bin: &Path) -> Option<PythonVersion> {
+    let output = tokio::process::Command::new(python_bin)
+        .arg("--version")
+        .output()
+        .await
+        .ok()?;
+    let mut version_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if version_str.is_empty() {
+        version_str = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    }
+    parse_python_version(&version_str)
+}
+
+fn parse_python_version(value: &str) -> Option<PythonVersion> {
+    let version = value.trim().strip_prefix("Python ")?;
+    let mut parts = version.split_whitespace().next()?.split('.');
+    Some(PythonVersion {
+        major: parts.next()?.parse().ok()?,
+        minor: parts.next()?.parse().ok()?,
+        patch: parts.next().and_then(|part| part.parse().ok()).unwrap_or(0),
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PythonVersion {
+    major: u32,
+    minor: u32,
+    patch: u32,
+}
+
+impl PythonVersion {
+    fn meets_minimum(self) -> bool {
+        (self.major, self.minor) >= (PYTHON_MIN_MAJOR, PYTHON_MIN_MINOR)
+    }
+}
+
+impl std::fmt::Display for PythonVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Python {}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+fn missing_report() -> CheckReport {
+    CheckReport {
+        name: "python",
+        label: "Python",
+        status: CheckStatus::Missing,
+        fix_hint: Some(FixHint::RunStep {
+            command: "ahandd plugin install python".into(),
+        }),
+    }
+}
+
+fn emit(progress: &(dyn Fn(ProgressEvent) + Send + Sync), phase: Phase, message: String) {
+    progress(ProgressEvent {
+        step: "python",
+        phase,
+        message,
+        percent: None,
+        stream: None,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn dirs_use_plugin_runtime_python_directory() {
+        let root = PathBuf::from("/tmp/ahand-primary-runtime");
+        let dirs = Dirs::from_runtime_root(root);
+
+        assert_eq!(
+            dirs.python,
+            PathBuf::from("/tmp/ahand-primary-runtime/dependencies/python")
+        );
+        assert_eq!(
+            dirs.local_python_bin(),
+            PathBuf::from("/tmp/ahand-primary-runtime/dependencies/python/bin/python3")
+        );
+    }
+
+    #[test]
+    fn python_asset_name_uses_install_only_archive_for_current_platform() {
+        let asset = python_asset_name().unwrap();
+
+        assert!(asset.starts_with("cpython-3.12.13+20260510-"));
+        assert!(asset.ends_with("-install_only.tar.gz"));
+    }
+
+    #[test]
+    fn parse_python_version_accepts_standard_output() {
+        assert_eq!(
+            parse_python_version("Python 3.12.13"),
+            Some(PythonVersion {
+                major: 3,
+                minor: 12,
+                patch: 13
+            })
+        );
+    }
+
+    #[test]
+    fn archive_destination_rejects_parent_components() {
+        let root = PathBuf::from("/tmp/ahand-primary-runtime/dependencies/python");
+
+        assert_eq!(
+            archive_destination(&root, Path::new("python/bin/python3")),
+            Some(root.join("bin").join("python3"))
+        );
+        assert_eq!(
+            archive_destination(&root, Path::new("python/../evil")),
+            None
+        );
+        assert_eq!(
+            archive_destination(&root, Path::new("/python/bin/python3")),
+            None
+        );
+    }
+
+    #[test]
+    fn emit_produces_python_step_events() {
+        let events: Arc<Mutex<Vec<ProgressEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let cb_events = events.clone();
+        let cb = move |e: ProgressEvent| {
+            cb_events.lock().unwrap().push(e);
+        };
+
+        emit(&cb, Phase::Starting, "Starting Python install".into());
+        emit(&cb, Phase::Downloading, "Downloading tarball".into());
+        emit(&cb, Phase::Extracting, "Extracting archive".into());
+        emit(&cb, Phase::Verifying, "Verifying install".into());
+        emit(&cb, Phase::Done, "Python ready".into());
+
+        let events = events.lock().unwrap();
+        assert_eq!(events.len(), 5);
+        for event in events.iter() {
+            assert_eq!(event.step, "python");
+            assert!(event.stream.is_none());
+            assert!(event.percent.is_none());
+        }
+    }
+}

--- a/crates/ahandd/src/executor.rs
+++ b/crates/ahandd/src/executor.rs
@@ -48,6 +48,21 @@ pub struct ResolvedTool {
     pub leading_args: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionTarget {
+    pub path: String,
+    pub leading_args: Vec<String>,
+}
+
+impl From<ResolvedTool> for ExecutionTarget {
+    fn from(value: ResolvedTool) -> Self {
+        Self {
+            path: value.path,
+            leading_args: value.leading_args,
+        }
+    }
+}
+
 /// Resolve `tool` against the daemon's environment.
 ///
 /// Special tokens `"$SHELL"` and `"shell"` mean "the user's default login
@@ -88,6 +103,24 @@ pub async fn run_job<T>(
     device_id: String,
     req: JobRequest,
     tx: T,
+    cancel_rx: mpsc::Receiver<()>,
+    store: Option<Arc<RunStore>>,
+) -> (i32, String)
+where
+    T: EnvelopeSink,
+{
+    let target = ExecutionTarget::from(resolve_tool(
+        &req.tool,
+        std::env::var("SHELL").ok().as_deref(),
+    ));
+    run_job_with_target(device_id, req, target, tx, cancel_rx, store).await
+}
+
+pub async fn run_job_with_target<T>(
+    device_id: String,
+    req: JobRequest,
+    target: ExecutionTarget,
+    tx: T,
     mut cancel_rx: mpsc::Receiver<()>,
     store: Option<Arc<RunStore>>,
 ) -> (i32, String)
@@ -101,10 +134,8 @@ where
         s.start_run(&job_id, &req);
     }
 
-    let resolved = resolve_tool(&req.tool, std::env::var("SHELL").ok().as_deref());
-
-    let mut cmd = Command::new(&resolved.path);
-    for leading in &resolved.leading_args {
+    let mut cmd = Command::new(&target.path);
+    for leading in &target.leading_args {
         cmd.arg(leading);
     }
     cmd.args(&req.args);
@@ -538,7 +569,8 @@ fn new_msg_id() -> String {
 
 #[cfg(test)]
 mod tool_resolution_tests {
-    use super::{ResolvedTool, resolve_tool};
+    use super::{ExecutionTarget, ResolvedTool, resolve_tool, run_job_with_target};
+    use ahand_protocol::JobRequest;
 
     #[test]
     fn dollar_shell_sentinel_resolves_to_shell_env_with_login_flag() {
@@ -636,5 +668,53 @@ mod tool_resolution_tests {
                 leading_args: vec![],
             }
         );
+    }
+
+    #[tokio::test]
+    async fn run_job_with_target_uses_explicit_executable_path() {
+        use std::os::unix::fs::PermissionsExt;
+        use tokio::sync::mpsc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("managed-runtime");
+        std::fs::write(&script, "#!/bin/sh\necho managed:$1\n").unwrap();
+        let mut perms = std::fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).unwrap();
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (_cancel_tx, cancel_rx) = mpsc::channel(1);
+        let req = JobRequest {
+            job_id: "managed-runtime-job".to_string(),
+            tool: "plugin:node".to_string(),
+            args: vec!["ok".to_string()],
+            ..Default::default()
+        };
+
+        let (exit_code, error) = run_job_with_target(
+            "device-1".to_string(),
+            req,
+            ExecutionTarget {
+                path: script.to_string_lossy().to_string(),
+                leading_args: Vec::new(),
+            },
+            tx,
+            cancel_rx,
+            None,
+        )
+        .await;
+
+        assert_eq!(exit_code, 0);
+        assert_eq!(error, "");
+
+        let mut saw_stdout = false;
+        while let Ok(env) = rx.try_recv() {
+            if let Some(ahand_protocol::envelope::Payload::JobEvent(event)) = env.payload {
+                if let Some(ahand_protocol::job_event::Event::StdoutChunk(bytes)) = event.event {
+                    saw_stdout |= String::from_utf8_lossy(&bytes).contains("managed:ok");
+                }
+            }
+        }
+        assert!(saw_stdout, "managed runtime stdout should be streamed");
     }
 }

--- a/crates/ahandd/src/executor.rs
+++ b/crates/ahandd/src/executor.rs
@@ -145,8 +145,12 @@ where
     }
 
     for (k, v) in &req.env {
-        cmd.env(k, v);
+        if !crate::plugin_runtime::path_env::is_path_env_key(k) {
+            cmd.env(k, v);
+        }
     }
+    let path = crate::plugin_runtime::path_env::child_process_path(&req.env).await;
+    cmd.env("PATH", path);
 
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());

--- a/crates/ahandd/src/ipc.rs
+++ b/crates/ahandd/src/ipc.rs
@@ -12,7 +12,7 @@ use crate::approval::ApprovalManager;
 use crate::browser::BrowserManager;
 use crate::executor;
 use crate::file_manager::FileManager;
-use crate::plugin_runtime::{CapabilityKind, CapabilityUnavailable};
+use crate::plugin_runtime::{CapabilityKind, CapabilityUnavailable, JobProvider};
 use crate::registry::{IsKnown, JobRegistry};
 use crate::session::{SessionDecision, SessionManager};
 use crate::store::RunStore;
@@ -168,13 +168,13 @@ async fn handle_ipc_conn(
 
         match envelope.payload {
             Some(envelope::Payload::JobRequest(req)) => {
-                let capability_router = match crate::plugin_runtime::build_router(
+                let provider_registry = match crate::plugin_runtime::build_provider_registry(
                     &browser_mgr,
                     &file_mgr,
                 )
                 .await
                 {
-                    Ok(router) => router,
+                    Ok(registry) => registry,
                     Err(err) => {
                         warn!(
                             job_id = %req.job_id,
@@ -190,15 +190,30 @@ async fn handle_ipc_conn(
                         continue;
                     }
                 };
-                if let Err(unavailable) = capability_router.ensure(CapabilityKind::Exec) {
-                    let reason = unavailable.to_protocol_message();
+                let job_provider = match provider_registry.resolve_job_provider(&req.tool) {
+                    Ok(provider) => provider,
+                    Err(unavailable) => {
+                        let reason = unavailable.to_protocol_message();
+                        warn!(
+                            job_id = %req.job_id,
+                            tool = %req.tool,
+                            reason = %reason,
+                            "IPC: job rejected by capability provider"
+                        );
+                        let _ =
+                            tx.send(job_capability_rejection_envelope(&device_id, &req, reason));
+                        continue;
+                    }
+                };
+                if req.interactive && matches!(job_provider, JobProvider::ManagedRuntime { .. }) {
                     warn!(
                         job_id = %req.job_id,
                         tool = %req.tool,
-                        reason = %reason,
-                        "IPC: job rejected by capability router"
+                        "IPC: managed runtime job rejected because interactive PTY is unsupported"
                     );
-                    let _ = tx.send(job_capability_rejection_envelope(&device_id, &req, reason));
+                    let _ = tx.send(managed_runtime_interactive_rejection_envelope(
+                        &device_id, &req,
+                    ));
                     continue;
                 }
 
@@ -249,6 +264,7 @@ async fn handle_ipc_conn(
                         let did = device_id.clone();
                         let reg = Arc::clone(&registry);
                         let st = store.clone();
+                        let provider = job_provider.clone();
 
                         let (cancel_tx, cancel_rx) = mpsc::channel(1);
                         reg.register(job_id.clone(), cancel_tx).await;
@@ -259,7 +275,8 @@ async fn handle_ipc_conn(
                         tokio::spawn(async move {
                             let _permit = reg.acquire_permit().await;
                             let (exit_code, error) =
-                                executor::run_job(did, req, tx_clone, cancel_rx, st).await;
+                                run_job_with_provider(did, req, provider, tx_clone, cancel_rx, st)
+                                    .await;
                             reg.remove(&job_id).await;
                             reg.mark_completed(job_id, exit_code, error).await;
                         });
@@ -297,6 +314,7 @@ async fn handle_ipc_conn(
                         let timeout = amgr.default_timeout();
                         let job_id = req.job_id.clone();
                         let cuid = caller_uid.clone();
+                        let provider = job_provider.clone();
 
                         tokio::spawn(async move {
                             let result = tokio::time::timeout(timeout, approval_rx).await;
@@ -306,8 +324,10 @@ async fn handle_ipc_conn(
                                     let (cancel_tx, cancel_rx) = mpsc::channel(1);
                                     reg.register(job_id.clone(), cancel_tx).await;
                                     let _permit = reg.acquire_permit().await;
-                                    let (exit_code, error) =
-                                        executor::run_job(did, req, tx_clone, cancel_rx, st).await;
+                                    let (exit_code, error) = run_job_with_provider(
+                                        did, req, provider, tx_clone, cancel_rx, st,
+                                    )
+                                    .await;
                                     reg.remove(&job_id).await;
                                     reg.mark_completed(job_id, exit_code, error).await;
                                 }
@@ -409,13 +429,13 @@ async fn handle_ipc_conn(
                     "IPC: received browser request"
                 );
 
-                let capability_router = match crate::plugin_runtime::build_router(
+                let provider_registry = match crate::plugin_runtime::build_provider_registry(
                     &browser_mgr,
                     &file_mgr,
                 )
                 .await
                 {
-                    Ok(router) => router,
+                    Ok(registry) => registry,
                     Err(err) => {
                         let resp_env = Envelope {
                             device_id: device_id.clone(),
@@ -437,7 +457,7 @@ async fn handle_ipc_conn(
                     }
                 };
 
-                if let Err(unavailable) = capability_router.ensure(CapabilityKind::Browser) {
+                if let Err(unavailable) = provider_registry.ensure(CapabilityKind::Browser) {
                     let resp_env = Envelope {
                         device_id: device_id.clone(),
                         msg_id: new_msg_id(),
@@ -532,6 +552,41 @@ fn job_capability_rejection_envelope(
             reason,
         })),
         ..Default::default()
+    }
+}
+
+fn managed_runtime_interactive_rejection_envelope(
+    device_id: &str,
+    req: &ahand_protocol::JobRequest,
+) -> Envelope {
+    Envelope {
+        device_id: device_id.to_string(),
+        msg_id: new_msg_id(),
+        ts_ms: now_ms(),
+        payload: Some(envelope::Payload::JobRejected(JobRejected {
+            job_id: req.job_id.clone(),
+            reason: format!(
+                "managed runtime tool {} does not support interactive PTY jobs",
+                req.tool
+            ),
+        })),
+        ..Default::default()
+    }
+}
+
+async fn run_job_with_provider(
+    device_id: String,
+    req: ahand_protocol::JobRequest,
+    provider: JobProvider,
+    tx: mpsc::UnboundedSender<Envelope>,
+    cancel_rx: mpsc::Receiver<()>,
+    store: Option<Arc<RunStore>>,
+) -> (i32, String) {
+    match provider {
+        JobProvider::DefaultExec => executor::run_job(device_id, req, tx, cancel_rx, store).await,
+        JobProvider::ManagedRuntime { target, .. } => {
+            executor::run_job_with_target(device_id, req, target, tx, cancel_rx, store).await
+        }
     }
 }
 
@@ -646,6 +701,28 @@ mod tests {
                         .reason
                         .contains("exec capability unavailable: host shell unavailable")
                 );
+            }
+            other => panic!("expected JobRejected envelope, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ipc_managed_runtime_interactive_rejection_preserves_job_id() {
+        let req = ahand_protocol::JobRequest {
+            job_id: "ipc-python-interactive-1".to_string(),
+            tool: "plugin:python".to_string(),
+            interactive: true,
+            ..Default::default()
+        };
+
+        let env = managed_runtime_interactive_rejection_envelope("device-1", &req);
+
+        assert_eq!(env.device_id, "device-1");
+        match env.payload {
+            Some(envelope::Payload::JobRejected(rejected)) => {
+                assert_eq!(rejected.job_id, "ipc-python-interactive-1");
+                assert!(rejected.reason.contains("plugin:python"));
+                assert!(rejected.reason.contains("interactive"));
             }
             other => panic!("expected JobRejected envelope, got {other:?}"),
         }

--- a/crates/ahandd/src/main.rs
+++ b/crates/ahandd/src/main.rs
@@ -99,7 +99,7 @@ enum Cmd {
         /// Force reinstall (clean existing installation first)
         #[arg(long)]
         force: bool,
-        /// Run only a single step: node or playwright
+        /// Run only a single step: node, python, or playwright
         #[arg(long)]
         step: Option<String>,
     },
@@ -542,7 +542,7 @@ fn collect_plugin_and_dependencies(
 }
 
 fn has_install_step(plugin: &str) -> bool {
-    matches!(plugin, "node" | "browser-playwright-cli")
+    matches!(plugin, "node" | "python" | "browser-playwright-cli")
 }
 
 fn write_pid_file(data_dir: &Option<PathBuf>) -> Option<PathBuf> {
@@ -584,6 +584,14 @@ mod plugin_cli_tests {
     #[test]
     fn node_plugin_install_steps_include_only_node() {
         assert_eq!(install_steps_for("node").unwrap(), vec!["node".to_string()]);
+    }
+
+    #[test]
+    fn python_plugin_install_steps_include_only_python() {
+        assert_eq!(
+            install_steps_for("python").unwrap(),
+            vec!["python".to_string()]
+        );
     }
 
     #[test]

--- a/crates/ahandd/src/openclaw/handler.rs
+++ b/crates/ahandd/src/openclaw/handler.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -266,13 +266,16 @@ impl OpenClawHandler {
             cmd.current_dir(dir);
         }
 
-        // Apply environment overrides with sanitization
-        if let Some(overrides) = env_overrides {
-            let sanitized = sanitize_env(overrides);
-            for (key, value) in sanitized {
+        let command_env = env_overrides
+            .map(sanitize_env)
+            .unwrap_or_else(|| env::vars().collect());
+        for (key, value) in &command_env {
+            if !crate::plugin_runtime::path_env::is_path_env_key(key) {
                 cmd.env(key, value);
             }
         }
+        let path = crate::plugin_runtime::path_env::child_process_path(&command_env).await;
+        cmd.env("PATH", path);
 
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
@@ -441,8 +444,11 @@ impl OpenClawHandler {
         };
 
         let mut found: HashMap<String, String> = HashMap::new();
-        let path_env = env::var("PATH").unwrap_or_default();
-        let path_dirs: Vec<&str> = path_env.split(':').collect();
+        let base_path = env::var("PATH").unwrap_or_default();
+        let path_env =
+            crate::plugin_runtime::path_env::path_with_installed_runtime_bins_or_base(&base_path)
+                .await;
+        let path_dirs: Vec<PathBuf> = std::env::split_paths(&path_env).collect();
 
         for bin in &params.bins {
             let bin = bin.trim();
@@ -451,7 +457,7 @@ impl OpenClawHandler {
             }
 
             for dir in &path_dirs {
-                let candidate = Path::new(dir).join(bin);
+                let candidate = dir.join(bin);
                 if candidate.exists() && candidate.is_file() {
                     found.insert(bin.to_string(), candidate.to_string_lossy().to_string());
                     break;
@@ -1344,7 +1350,10 @@ fn sanitize_env(overrides: &HashMap<String, String>) -> HashMap<String, String> 
             }
             // Only allow PATH if it prepends to current PATH
             if trimmed == base_path || trimmed.ends_with(&format!(":{}", base_path)) {
-                result.insert(key.clone(), value.clone());
+                result.retain(|existing_key, _| {
+                    !crate::plugin_runtime::path_env::is_path_env_key(existing_key)
+                });
+                result.insert("PATH".to_string(), value.clone());
             }
             continue;
         }

--- a/crates/ahandd/src/plugin_runtime/activation.rs
+++ b/crates/ahandd/src/plugin_runtime/activation.rs
@@ -36,6 +36,8 @@ pub fn router_from_plugins(
         exec_entry(plugins),
         file_entry(plugins, config),
         browser_entry(plugins, config),
+        runtime_entry(plugins, CapabilityKind::NodeExec, "node", "node"),
+        runtime_entry(plugins, CapabilityKind::PythonExec, "python", "python"),
     ])
 }
 
@@ -156,6 +158,66 @@ fn browser_entry(plugins: &[InstalledPluginResource], config: ActivationConfig) 
             },
         }),
     }
+}
+
+fn runtime_entry(
+    plugins: &[InstalledPluginResource],
+    capability: CapabilityKind,
+    plugin_id: &str,
+    resource_name: &str,
+) -> CapabilityEntry {
+    match plugin_status(plugins, plugin_id) {
+        Some(PluginStatus::Installed) => {
+            if has_executable_resource(plugins, plugin_id, resource_name) {
+                CapabilityEntry::active(capability, plugin_id)
+            } else {
+                CapabilityEntry::unavailable(CapabilityUnavailable {
+                    capability,
+                    plugin_id: plugin_id.to_string(),
+                    status: PluginStatus::Missing,
+                    reason: format!("{plugin_id} executable resource is missing"),
+                    remediation: CapabilityRemediation::InstallPlugin {
+                        plugin_id: plugin_id.to_string(),
+                    },
+                })
+            }
+        }
+        Some(status) => CapabilityEntry::unavailable(CapabilityUnavailable {
+            capability,
+            plugin_id: plugin_id.to_string(),
+            status,
+            reason: format!("{plugin_id} plugin is {}", status_word(status)),
+            remediation: CapabilityRemediation::InstallPlugin {
+                plugin_id: plugin_id.to_string(),
+            },
+        }),
+        None => CapabilityEntry::unavailable(CapabilityUnavailable {
+            capability,
+            plugin_id: plugin_id.to_string(),
+            status: PluginStatus::Missing,
+            reason: format!("{plugin_id} plugin is not registered"),
+            remediation: CapabilityRemediation::InstallPlugin {
+                plugin_id: plugin_id.to_string(),
+            },
+        }),
+    }
+}
+
+fn has_executable_resource(
+    plugins: &[InstalledPluginResource],
+    plugin_id: &str,
+    resource_name: &str,
+) -> bool {
+    plugins
+        .iter()
+        .find(|plugin| plugin.id == plugin_id)
+        .and_then(|plugin| plugin.resources.get(resource_name))
+        .is_some_and(|resource| {
+            matches!(
+                resource,
+                crate::plugin_runtime::HostResourceValue::Executable { .. }
+            )
+        })
 }
 
 fn first_missing_dependency(
@@ -290,6 +352,51 @@ mod tests {
                 message: "enable browser capabilities in host configuration".to_string()
             }
         );
+    }
+
+    #[test]
+    fn node_exec_active_when_node_resource_is_exported() {
+        let mut plugins = base_plugins();
+        plugins[2].resources.insert(
+            "node".to_string(),
+            crate::plugin_runtime::HostResourceValue::Executable {
+                name: "node".to_string(),
+                path: "/tmp/ahand/node/bin/node".to_string(),
+                version: Some("v24.13.0".to_string()),
+            },
+        );
+
+        let router = router_from_plugins(
+            &plugins,
+            ActivationConfig {
+                browser_enabled: true,
+                file_enabled: true,
+                system_browser_available: true,
+            },
+        );
+
+        assert!(router.ensure(CapabilityKind::NodeExec).is_ok());
+    }
+
+    #[test]
+    fn python_exec_missing_recommends_installing_python_plugin() {
+        let plugins = base_plugins();
+
+        let router = router_from_plugins(
+            &plugins,
+            ActivationConfig {
+                browser_enabled: true,
+                file_enabled: true,
+                system_browser_available: true,
+            },
+        );
+
+        let err = router.ensure(CapabilityKind::PythonExec).unwrap_err();
+        assert_eq!(err.plugin_id, "python");
+        assert!(matches!(
+            err.remediation,
+            CapabilityRemediation::InstallPlugin { ref plugin_id } if plugin_id == "python"
+        ));
     }
 
     #[test]

--- a/crates/ahandd/src/plugin_runtime/capability.rs
+++ b/crates/ahandd/src/plugin_runtime/capability.rs
@@ -7,6 +7,8 @@ pub enum CapabilityKind {
     Exec,
     File,
     Browser,
+    NodeExec,
+    PythonExec,
 }
 
 impl CapabilityKind {
@@ -15,6 +17,8 @@ impl CapabilityKind {
             Self::Exec => "exec",
             Self::File => "file",
             Self::Browser => "browser-playwright-cli",
+            Self::NodeExec => "node-exec",
+            Self::PythonExec => "python-exec",
         }
     }
 
@@ -23,6 +27,8 @@ impl CapabilityKind {
             Self::Exec => "exec",
             Self::File => "file",
             Self::Browser => "browser",
+            Self::NodeExec => "node",
+            Self::PythonExec => "python",
         }
     }
 }
@@ -152,6 +158,8 @@ impl CapabilityRouter {
             CapabilityKind::Exec,
             CapabilityKind::File,
             CapabilityKind::Browser,
+            CapabilityKind::NodeExec,
+            CapabilityKind::PythonExec,
         ]
         .into_iter()
         .filter(|capability| self.ensure(*capability).is_ok())
@@ -211,6 +219,20 @@ mod tests {
         assert_eq!(
             router.active_wire_capabilities(),
             vec!["exec", "file", "browser-playwright-cli"]
+        );
+    }
+
+    #[test]
+    fn active_wire_capabilities_include_managed_runtime_exec_when_active() {
+        let router = CapabilityRouter::new(vec![
+            CapabilityEntry::active(CapabilityKind::Exec, "shell"),
+            CapabilityEntry::active(CapabilityKind::NodeExec, "node"),
+            CapabilityEntry::active(CapabilityKind::PythonExec, "python"),
+        ]);
+
+        assert_eq!(
+            router.active_wire_capabilities(),
+            vec!["exec", "node-exec", "python-exec"]
         );
     }
 

--- a/crates/ahandd/src/plugin_runtime/mod.rs
+++ b/crates/ahandd/src/plugin_runtime/mod.rs
@@ -4,6 +4,7 @@ pub mod capability;
 pub mod builtin;
 pub mod host_resource;
 pub mod manifest;
+pub mod provider;
 pub mod registry;
 pub mod resource;
 pub mod runtime_dir;
@@ -15,6 +16,10 @@ pub use capability::{
 };
 pub use host_resource::get_host_resource;
 pub use manifest::{ExecutableResourceManifest, HelpManifest, PluginManifest, ResourceManifest};
+pub use provider::{
+    CapabilityProviderRegistry, JobProvider, JobProviderKind, build_provider_registry,
+    resolve_job_provider_kind,
+};
 pub use registry::PluginRegistry;
 pub use resource::{
     HostResourceSnapshot, HostResourceValue, InstalledPluginResource, PluginStatus,

--- a/crates/ahandd/src/plugin_runtime/mod.rs
+++ b/crates/ahandd/src/plugin_runtime/mod.rs
@@ -4,6 +4,7 @@ pub mod capability;
 pub mod builtin;
 pub mod host_resource;
 pub mod manifest;
+pub mod path_env;
 pub mod provider;
 pub mod registry;
 pub mod resource;

--- a/crates/ahandd/src/plugin_runtime/path_env.rs
+++ b/crates/ahandd/src/plugin_runtime/path_env.rs
@@ -1,0 +1,231 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use tracing::warn;
+
+use crate::plugin_runtime::{HostResourceValue, InstalledPluginResource, PluginStatus};
+
+const MANAGED_RUNTIME_EXECUTABLES: &[(&str, &str)] = &[("node", "node"), ("python", "python")];
+
+pub fn runtime_path_dirs(plugins: &[InstalledPluginResource]) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+
+    for (plugin_id, resource_key) in MANAGED_RUNTIME_EXECUTABLES {
+        let Some(plugin) = plugins
+            .iter()
+            .find(|plugin| plugin.id == *plugin_id && plugin.status == PluginStatus::Installed)
+        else {
+            continue;
+        };
+        let Some(HostResourceValue::Executable { path, .. }) = plugin.resources.get(*resource_key)
+        else {
+            continue;
+        };
+        let Some(parent) = Path::new(path).parent() else {
+            continue;
+        };
+
+        push_unique_path(&mut dirs, parent.to_path_buf());
+    }
+
+    dirs
+}
+
+pub fn prepend_path_dirs(base_path: &str, dirs: &[PathBuf]) -> String {
+    let mut paths = Vec::new();
+    for dir in dirs {
+        push_unique_path(&mut paths, dir.clone());
+    }
+
+    if !base_path.is_empty() {
+        for existing in std::env::split_paths(base_path) {
+            push_unique_path(&mut paths, existing);
+        }
+    }
+
+    std::env::join_paths(&paths)
+        .map(|joined| joined.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| fallback_join(base_path, dirs))
+}
+
+pub async fn path_with_installed_runtime_bins(base_path: &str) -> anyhow::Result<String> {
+    let snapshot = super::get_host_resource().await?;
+    let runtime_dirs = runtime_path_dirs(&snapshot.plugins);
+    Ok(prepend_path_dirs(base_path, &runtime_dirs))
+}
+
+pub async fn path_with_installed_runtime_bins_or_base(base_path: &str) -> String {
+    match path_with_installed_runtime_bins(base_path).await {
+        Ok(path) => path,
+        Err(error) => {
+            warn!(%error, "failed to resolve managed runtime PATH entries");
+            base_path.to_string()
+        }
+    }
+}
+
+pub fn is_path_env_key(key: &str) -> bool {
+    key.eq_ignore_ascii_case("PATH")
+}
+
+pub fn path_env_value(envs: &HashMap<String, String>) -> Option<&str> {
+    envs.get("PATH").map(String::as_str).or_else(|| {
+        envs.iter()
+            .find(|(key, _)| is_path_env_key(key))
+            .map(|(_, value)| value.as_str())
+    })
+}
+
+pub async fn child_process_path(envs: &HashMap<String, String>) -> String {
+    let base_path = path_env_value(envs)
+        .map(str::to_string)
+        .unwrap_or_else(|| std::env::var("PATH").unwrap_or_default());
+    path_with_installed_runtime_bins_or_base(&base_path).await
+}
+
+fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if path.as_os_str().is_empty() {
+        return;
+    }
+    if !paths.iter().any(|existing| existing == &path) {
+        paths.push(path);
+    }
+}
+
+fn fallback_join(base_path: &str, dirs: &[PathBuf]) -> String {
+    let separator = if cfg!(windows) { ";" } else { ":" };
+    let mut parts: Vec<String> = Vec::new();
+
+    for dir in dirs {
+        let value = dir.to_string_lossy();
+        if !value.is_empty() && !parts.iter().any(|part| part == value.as_ref()) {
+            parts.push(value.into_owned());
+        }
+    }
+
+    if !base_path.is_empty() {
+        parts.push(base_path.to_string());
+    }
+
+    parts.join(separator)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    use crate::plugin_runtime::{HostResourceValue, InstalledPluginResource, PluginStatus};
+
+    fn plugin(
+        id: &str,
+        status: PluginStatus,
+        resources: BTreeMap<String, HostResourceValue>,
+    ) -> InstalledPluginResource {
+        InstalledPluginResource {
+            id: id.to_string(),
+            version: "0.1.0".to_string(),
+            status,
+            dependencies: Vec::new(),
+            capabilities: Vec::new(),
+            resources,
+            help_prompt: None,
+        }
+    }
+
+    fn executable(key: &str, path: &str) -> BTreeMap<String, HostResourceValue> {
+        let mut resources = BTreeMap::new();
+        resources.insert(
+            key.to_string(),
+            HostResourceValue::Executable {
+                name: key.to_string(),
+                path: path.to_string(),
+                version: Some("test".to_string()),
+            },
+        );
+        resources
+    }
+
+    #[test]
+    fn runtime_path_dirs_uses_installed_node_and_python_executables() {
+        let plugins = vec![
+            plugin(
+                "node",
+                PluginStatus::Installed,
+                executable("node", "/runtime/dependencies/node/bin/node"),
+            ),
+            plugin(
+                "python",
+                PluginStatus::Installed,
+                executable("python", "/runtime/dependencies/python/bin/python3"),
+            ),
+            plugin(
+                "browser-playwright-cli",
+                PluginStatus::Installed,
+                executable("playwright", "/runtime/dependencies/node/bin/playwright"),
+            ),
+            plugin(
+                "node",
+                PluginStatus::Missing,
+                executable("node", "/ignored/node/bin/node"),
+            ),
+        ];
+
+        let dirs = super::runtime_path_dirs(&plugins);
+
+        assert_eq!(
+            dirs,
+            vec![
+                PathBuf::from("/runtime/dependencies/node/bin"),
+                PathBuf::from("/runtime/dependencies/python/bin"),
+            ]
+        );
+    }
+
+    #[test]
+    fn prepend_path_dirs_adds_runtime_bins_before_existing_path_and_deduplicates() {
+        let base_path = std::env::join_paths([
+            PathBuf::from("/usr/local/bin"),
+            PathBuf::from("/runtime/dependencies/node/bin"),
+            PathBuf::from("/usr/bin"),
+        ])
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+        let dirs = vec![
+            PathBuf::from("/runtime/dependencies/node/bin"),
+            PathBuf::from("/runtime/dependencies/python/bin"),
+            PathBuf::from("/runtime/dependencies/node/bin"),
+        ];
+
+        let actual = super::prepend_path_dirs(&base_path, &dirs);
+        let actual_dirs: Vec<PathBuf> = std::env::split_paths(&actual).collect();
+
+        assert_eq!(
+            actual_dirs,
+            vec![
+                PathBuf::from("/runtime/dependencies/node/bin"),
+                PathBuf::from("/runtime/dependencies/python/bin"),
+                PathBuf::from("/usr/local/bin"),
+                PathBuf::from("/usr/bin"),
+            ]
+        );
+    }
+
+    #[test]
+    fn path_env_value_accepts_case_variants() {
+        let mut envs = std::collections::HashMap::new();
+        envs.insert("Path".to_string(), "/custom/bin".to_string());
+
+        assert_eq!(super::path_env_value(&envs), Some("/custom/bin"));
+    }
+
+    #[test]
+    fn path_env_value_prefers_canonical_path_key() {
+        let mut envs = std::collections::HashMap::new();
+        envs.insert("Path".to_string(), "/custom/bin".to_string());
+        envs.insert("PATH".to_string(), "/canonical/bin".to_string());
+
+        assert_eq!(super::path_env_value(&envs), Some("/canonical/bin"));
+    }
+}

--- a/crates/ahandd/src/plugin_runtime/provider.rs
+++ b/crates/ahandd/src/plugin_runtime/provider.rs
@@ -1,0 +1,204 @@
+use std::collections::BTreeMap;
+
+use crate::browser::BrowserManager;
+use crate::executor::ExecutionTarget;
+use crate::file_manager::FileManager;
+
+use super::{
+    ActivationConfig, CapabilityKind, CapabilityRemediation, CapabilityRouter,
+    CapabilityUnavailable, HostResourceValue, InstalledPluginResource, PluginStatus,
+    router_from_plugins,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JobProviderKind {
+    DefaultExec,
+    ManagedRuntime(CapabilityKind),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JobProvider {
+    DefaultExec,
+    ManagedRuntime {
+        capability: CapabilityKind,
+        target: ExecutionTarget,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct CapabilityProviderRegistry {
+    router: CapabilityRouter,
+    runtime_targets: BTreeMap<CapabilityKind, ExecutionTarget>,
+}
+
+pub async fn build_provider_registry(
+    browser_mgr: &BrowserManager,
+    file_mgr: &FileManager,
+) -> anyhow::Result<CapabilityProviderRegistry> {
+    let snapshot = super::get_host_resource().await?;
+    Ok(CapabilityProviderRegistry::from_plugins(
+        &snapshot.plugins,
+        ActivationConfig {
+            browser_enabled: browser_mgr.is_enabled(),
+            file_enabled: file_mgr.is_enabled(),
+            system_browser_available: browser_mgr.has_system_browser(),
+        },
+    ))
+}
+
+impl CapabilityProviderRegistry {
+    pub fn from_plugins(plugins: &[InstalledPluginResource], config: ActivationConfig) -> Self {
+        let router = router_from_plugins(plugins, config);
+        let mut runtime_targets = BTreeMap::new();
+        if let Some(target) = executable_target(plugins, "node", "node") {
+            runtime_targets.insert(CapabilityKind::NodeExec, target);
+        }
+        if let Some(target) = executable_target(plugins, "python", "python") {
+            runtime_targets.insert(CapabilityKind::PythonExec, target);
+        }
+        Self {
+            router,
+            runtime_targets,
+        }
+    }
+
+    pub fn ensure(&self, capability: CapabilityKind) -> Result<(), CapabilityUnavailable> {
+        self.router.ensure(capability)
+    }
+
+    pub fn active_wire_capabilities(&self) -> Vec<&'static str> {
+        self.router.active_wire_capabilities()
+    }
+
+    pub fn resolve_job_provider(&self, tool: &str) -> Result<JobProvider, CapabilityUnavailable> {
+        match resolve_job_provider_kind(tool) {
+            JobProviderKind::DefaultExec => {
+                self.ensure(CapabilityKind::Exec)?;
+                Ok(JobProvider::DefaultExec)
+            }
+            JobProviderKind::ManagedRuntime(capability) => {
+                self.ensure(capability)?;
+                let target = self
+                    .runtime_targets
+                    .get(&capability)
+                    .cloned()
+                    .ok_or_else(|| missing_runtime_target(capability))?;
+                Ok(JobProvider::ManagedRuntime { capability, target })
+            }
+        }
+    }
+}
+
+pub fn resolve_job_provider_kind(tool: &str) -> JobProviderKind {
+    match tool {
+        "plugin:node" => JobProviderKind::ManagedRuntime(CapabilityKind::NodeExec),
+        "plugin:python" => JobProviderKind::ManagedRuntime(CapabilityKind::PythonExec),
+        _ => JobProviderKind::DefaultExec,
+    }
+}
+
+fn executable_target(
+    plugins: &[InstalledPluginResource],
+    plugin_id: &str,
+    resource_name: &str,
+) -> Option<ExecutionTarget> {
+    let plugin = plugins.iter().find(|plugin| plugin.id == plugin_id)?;
+    match plugin.resources.get(resource_name)? {
+        HostResourceValue::Executable { path, .. } => Some(ExecutionTarget {
+            path: path.clone(),
+            leading_args: Vec::new(),
+        }),
+        _ => None,
+    }
+}
+
+fn missing_runtime_target(capability: CapabilityKind) -> CapabilityUnavailable {
+    let plugin_id = match capability {
+        CapabilityKind::NodeExec => "node",
+        CapabilityKind::PythonExec => "python",
+        _ => capability.wire_name(),
+    };
+    CapabilityUnavailable {
+        capability,
+        plugin_id: plugin_id.to_string(),
+        status: PluginStatus::Missing,
+        reason: format!("{plugin_id} executable resource is missing"),
+        remediation: CapabilityRemediation::InstallPlugin {
+            plugin_id: plugin_id.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin_runtime::CapabilityKind;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn explicit_plugin_tokens_select_managed_runtime_providers() {
+        assert_eq!(
+            resolve_job_provider_kind("plugin:node"),
+            JobProviderKind::ManagedRuntime(CapabilityKind::NodeExec)
+        );
+        assert_eq!(
+            resolve_job_provider_kind("plugin:python"),
+            JobProviderKind::ManagedRuntime(CapabilityKind::PythonExec)
+        );
+    }
+
+    #[test]
+    fn plain_node_and_python_stay_default_exec_provider() {
+        assert_eq!(
+            resolve_job_provider_kind("node"),
+            JobProviderKind::DefaultExec
+        );
+        assert_eq!(
+            resolve_job_provider_kind("python"),
+            JobProviderKind::DefaultExec
+        );
+    }
+
+    #[test]
+    fn managed_runtime_provider_uses_exported_executable_path() {
+        let mut node_resources = BTreeMap::new();
+        node_resources.insert(
+            "node".to_string(),
+            HostResourceValue::Executable {
+                name: "node".to_string(),
+                path: "/tmp/ahand/node/bin/node".to_string(),
+                version: Some("v24.13.0".to_string()),
+            },
+        );
+        let plugins = vec![InstalledPluginResource {
+            id: "node".to_string(),
+            version: "0.1.0".to_string(),
+            status: PluginStatus::Installed,
+            dependencies: Vec::new(),
+            capabilities: Vec::new(),
+            resources: node_resources,
+            help_prompt: None,
+        }];
+        let registry = CapabilityProviderRegistry::from_plugins(
+            &plugins,
+            ActivationConfig {
+                browser_enabled: false,
+                file_enabled: false,
+                system_browser_available: false,
+            },
+        );
+
+        let provider = registry.resolve_job_provider("plugin:node").unwrap();
+
+        assert_eq!(
+            provider,
+            JobProvider::ManagedRuntime {
+                capability: CapabilityKind::NodeExec,
+                target: ExecutionTarget {
+                    path: "/tmp/ahand/node/bin/node".to_string(),
+                    leading_args: Vec::new(),
+                },
+            }
+        );
+    }
+}

--- a/docs/superpowers/plans/2026-05-19-ahand-plugin-runtime-stage3.md
+++ b/docs/superpowers/plans/2026-05-19-ahand-plugin-runtime-stage3.md
@@ -952,3 +952,23 @@ Expected: draft PR created against Stage 2.
 - [x] Add a managed Python installer using pinned python-build-standalone `3.12.13+20260510` `install_only` assets.
 - [x] Wire `browser_setup::run_step("python")` and `ahandd plugin install python`.
 - [x] Verify a real install under a temporary `HOME`: `doctor python` moves from `Missing` to `Installed`, `host-resource` exports `dependencies/python/bin/python3`, and the exported binary reports `Python 3.12.13`.
+
+---
+
+## Task 8: Add Managed Runtime PATH Enrichment
+
+**Reason:** After local managed Node/Python installation completes, crate-mode command execution should be able to run `node`, `npm`, `python`, or `python3` without agents hard-coding absolute paths from `getHostResource()`.
+
+**Files:**
+- `crates/ahandd/src/plugin_runtime/path_env.rs`
+- `crates/ahandd/src/plugin_runtime/mod.rs`
+- `crates/ahandd/src/executor.rs`
+- `crates/ahandd/src/openclaw/handler.rs`
+- `docs/superpowers/specs/2026-05-19-ahand-plugin-runtime-stage3-design.md`
+- `docs/superpowers/plans/2026-05-19-ahand-plugin-runtime-stage3.md`
+
+- [x] Add shared PATH construction that reads installed `node` / `python` executable resources from the host-resource snapshot.
+- [x] Prepend managed runtime `bin` directories ahead of the caller's base `PATH`, with duplicate removal.
+- [x] Apply the enriched `PATH` to default `JobRequest` execution.
+- [x] Apply the enriched `PATH` to OpenClaw `system.run` and `system.which`.
+- [x] Add unit tests for installed-resource detection, PATH ordering, de-duplication, and case-insensitive PATH key handling.

--- a/docs/superpowers/plans/2026-05-19-ahand-plugin-runtime-stage3.md
+++ b/docs/superpowers/plans/2026-05-19-ahand-plugin-runtime-stage3.md
@@ -934,3 +934,21 @@ gh pr create --draft --repo team9ai/aHand --base codex/plugin-runtime-stage2 --h
 ```
 
 Expected: draft PR created against Stage 2.
+
+---
+
+## Task 7: Repair Python Plugin Installer
+
+**Reason:** Manual install verification found that `python` had manifest, runtime path, and host-resource detection, but `ahandd plugin install python` still returned "does not have an install step in this release".
+
+**Files:**
+- `crates/ahandd/src/browser_setup/python.rs`
+- `crates/ahandd/src/browser_setup/mod.rs`
+- `crates/ahandd/src/main.rs`
+- `docs/superpowers/specs/2026-05-19-ahand-plugin-runtime-stage3-design.md`
+- `docs/superpowers/plans/2026-05-19-ahand-plugin-runtime-stage3.md`
+
+- [x] Add red tests for `python` install step routing and setup inspect recognition.
+- [x] Add a managed Python installer using pinned python-build-standalone `3.12.13+20260510` `install_only` assets.
+- [x] Wire `browser_setup::run_step("python")` and `ahandd plugin install python`.
+- [x] Verify a real install under a temporary `HOME`: `doctor python` moves from `Missing` to `Installed`, `host-resource` exports `dependencies/python/bin/python3`, and the exported binary reports `Python 3.12.13`.

--- a/docs/superpowers/plans/2026-05-19-ahand-plugin-runtime-stage3.md
+++ b/docs/superpowers/plans/2026-05-19-ahand-plugin-runtime-stage3.md
@@ -1,0 +1,936 @@
+# AHand Plugin Runtime Stage 3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add first-party capability providers and explicit managed `node` / `python` runtime execution without changing existing PATH-based `JobRequest.tool` behavior.
+
+**Architecture:** Extend Stage 2 capability activation with `NodeExec` and `PythonExec`, then add a provider registry that resolves `JobRequest.tool` to either the existing shell-backed executor or a managed runtime executable. Existing file and browser flows keep their concrete managers but resolve through the provider registry before dispatch.
+
+**Tech Stack:** Rust, Tokio, prost protocol envelopes, existing `ahandd` executor, `plugin_runtime`, `BrowserManager`, `FileManager`.
+
+---
+
+## File Structure
+
+- Modify `crates/ahandd/src/plugin_runtime/capability.rs`
+  - Add `NodeExec` and `PythonExec` capability ids and wire/display names.
+  - Include them in active Hello capability enumeration when present and active.
+- Modify `crates/ahandd/src/plugin_runtime/activation.rs`
+  - Add activation entries for `node-exec` and `python-exec`.
+  - Require installed plugin status plus exported executable resource.
+- Create `crates/ahandd/src/plugin_runtime/provider.rs`
+  - Define provider registry and `JobProvider` selection.
+  - Resolve `plugin:node` and `plugin:python` explicitly.
+  - Export `build_provider_registry(...)` for cloud WS and IPC.
+- Modify `crates/ahandd/src/plugin_runtime/mod.rs`
+  - Export provider types.
+- Modify `crates/ahandd/src/executor.rs`
+  - Add `ExecutionTarget`.
+  - Add `run_job_with_target`.
+  - Keep `run_job` as compatibility wrapper around `resolve_tool`.
+- Modify `crates/ahandd/src/ahand_client.rs`
+  - Use provider registry for Job/File/Browser capability checks.
+  - Pass resolved job provider into job spawning.
+  - Reject managed runtime interactive jobs.
+- Modify `crates/ahandd/src/ipc.rs`
+  - Mirror cloud job/browser provider resolution.
+  - Reject managed runtime interactive jobs.
+- Modify tests in the same modules plus `crates/ahandd/tests/job_request_tool.rs`
+  - Keep old `node` / `python` pass-through contract.
+  - Add explicit `plugin:node` / `plugin:python` provider tests.
+
+---
+
+## Task 1: Extend Capability Activation For Managed Runtime Execution
+
+**Files:**
+- Modify: `crates/ahandd/src/plugin_runtime/capability.rs`
+- Modify: `crates/ahandd/src/plugin_runtime/activation.rs`
+
+- [ ] **Step 1: Write failing capability tests**
+
+Add tests to `crates/ahandd/src/plugin_runtime/capability.rs`:
+
+```rust
+#[test]
+fn active_wire_capabilities_include_managed_runtime_exec_when_active() {
+    let router = CapabilityRouter::new(vec![
+        CapabilityEntry::active(CapabilityKind::Exec, "shell"),
+        CapabilityEntry::active(CapabilityKind::NodeExec, "node"),
+        CapabilityEntry::active(CapabilityKind::PythonExec, "python"),
+    ]);
+
+    assert_eq!(
+        router.active_wire_capabilities(),
+        vec!["exec", "node-exec", "python-exec"]
+    );
+}
+```
+
+Add tests to `crates/ahandd/src/plugin_runtime/activation.rs`:
+
+```rust
+#[test]
+fn node_exec_active_when_node_resource_is_exported() {
+    let mut plugins = base_plugins();
+    plugins[2].resources.insert(
+        "node".to_string(),
+        crate::plugin_runtime::HostResourceValue::Executable {
+            name: "node".to_string(),
+            path: "/tmp/ahand/node/bin/node".to_string(),
+            version: Some("v24.13.0".to_string()),
+        },
+    );
+
+    let router = router_from_plugins(
+        &plugins,
+        ActivationConfig {
+            browser_enabled: true,
+            file_enabled: true,
+            system_browser_available: true,
+        },
+    );
+
+    assert!(router.ensure(CapabilityKind::NodeExec).is_ok());
+}
+
+#[test]
+fn python_exec_missing_recommends_installing_python_plugin() {
+    let plugins = base_plugins();
+
+    let router = router_from_plugins(
+        &plugins,
+        ActivationConfig {
+            browser_enabled: true,
+            file_enabled: true,
+            system_browser_available: true,
+        },
+    );
+
+    let err = router.ensure(CapabilityKind::PythonExec).unwrap_err();
+    assert_eq!(err.plugin_id, "python");
+    assert!(matches!(
+        err.remediation,
+        CapabilityRemediation::InstallPlugin { ref plugin_id } if plugin_id == "python"
+    ));
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+cargo test -p ahandd plugin_runtime::capability::tests::active_wire_capabilities_include_managed_runtime_exec_when_active
+cargo test -p ahandd plugin_runtime::activation::tests::node_exec_active_when_node_resource_is_exported
+cargo test -p ahandd plugin_runtime::activation::tests::python_exec_missing_recommends_installing_python_plugin
+```
+
+Expected: compile failures because `CapabilityKind::NodeExec` and `CapabilityKind::PythonExec` do not exist.
+
+- [ ] **Step 3: Implement capability ids and activation**
+
+In `capability.rs`, extend `CapabilityKind`:
+
+```rust
+pub enum CapabilityKind {
+    Exec,
+    File,
+    Browser,
+    NodeExec,
+    PythonExec,
+}
+```
+
+Update `wire_name()`:
+
+```rust
+Self::NodeExec => "node-exec",
+Self::PythonExec => "python-exec",
+```
+
+Update `display_name()`:
+
+```rust
+Self::NodeExec => "node",
+Self::PythonExec => "python",
+```
+
+Update `active_wire_capabilities()` order:
+
+```rust
+[
+    CapabilityKind::Exec,
+    CapabilityKind::File,
+    CapabilityKind::Browser,
+    CapabilityKind::NodeExec,
+    CapabilityKind::PythonExec,
+]
+```
+
+In `activation.rs`, add entries to `CapabilityRouter::new(...)`:
+
+```rust
+runtime_entry(plugins, CapabilityKind::NodeExec, "node", "node"),
+runtime_entry(plugins, CapabilityKind::PythonExec, "python", "python"),
+```
+
+Add helpers:
+
+```rust
+fn runtime_entry(
+    plugins: &[InstalledPluginResource],
+    capability: CapabilityKind,
+    plugin_id: &str,
+    resource_name: &str,
+) -> CapabilityEntry {
+    match plugin_status(plugins, plugin_id) {
+        Some(PluginStatus::Installed) if has_executable_resource(plugins, plugin_id, resource_name) => {
+            CapabilityEntry::active(capability, plugin_id)
+        }
+        Some(PluginStatus::Installed) => CapabilityEntry::unavailable(CapabilityUnavailable {
+            capability,
+            plugin_id: plugin_id.to_string(),
+            status: PluginStatus::Missing,
+            reason: format!("{plugin_id} executable resource is missing"),
+            remediation: CapabilityRemediation::InstallPlugin {
+                plugin_id: plugin_id.to_string(),
+            },
+        }),
+        Some(status) => CapabilityEntry::unavailable(CapabilityUnavailable {
+            capability,
+            plugin_id: plugin_id.to_string(),
+            status,
+            reason: format!("{plugin_id} plugin is {}", status_word(status)),
+            remediation: CapabilityRemediation::InstallPlugin {
+                plugin_id: plugin_id.to_string(),
+            },
+        }),
+        None => CapabilityEntry::unavailable(CapabilityUnavailable {
+            capability,
+            plugin_id: plugin_id.to_string(),
+            status: PluginStatus::Missing,
+            reason: format!("{plugin_id} plugin is not registered"),
+            remediation: CapabilityRemediation::InstallPlugin {
+                plugin_id: plugin_id.to_string(),
+            },
+        }),
+    }
+}
+
+fn has_executable_resource(
+    plugins: &[InstalledPluginResource],
+    plugin_id: &str,
+    resource_name: &str,
+) -> bool {
+    plugins
+        .iter()
+        .find(|plugin| plugin.id == plugin_id)
+        .and_then(|plugin| plugin.resources.get(resource_name))
+        .is_some_and(|resource| matches!(
+            resource,
+            crate::plugin_runtime::HostResourceValue::Executable { .. }
+        ))
+}
+```
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p ahandd plugin_runtime::capability
+cargo test -p ahandd plugin_runtime::activation
+```
+
+Expected: all targeted tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ahandd/src/plugin_runtime/capability.rs crates/ahandd/src/plugin_runtime/activation.rs
+git commit -m "feat(ahandd): activate managed runtime exec capabilities"
+```
+
+---
+
+## Task 2: Add Explicit Executor Target Support
+
+**Files:**
+- Modify: `crates/ahandd/src/executor.rs`
+
+- [ ] **Step 1: Write failing executor test**
+
+Add to `crates/ahandd/src/executor.rs` tests:
+
+```rust
+#[tokio::test]
+async fn run_job_with_target_uses_explicit_executable_path() {
+    use std::os::unix::fs::PermissionsExt;
+    use tokio::sync::mpsc;
+
+    let dir = tempfile::tempdir().unwrap();
+    let script = dir.path().join("managed-runtime");
+    std::fs::write(&script, "#!/bin/sh\necho managed:$1\n").unwrap();
+    let mut perms = std::fs::metadata(&script).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script, perms).unwrap();
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let (_cancel_tx, cancel_rx) = mpsc::channel(1);
+    let req = JobRequest {
+        job_id: "managed-runtime-job".to_string(),
+        tool: "plugin:node".to_string(),
+        args: vec!["ok".to_string()],
+        ..Default::default()
+    };
+
+    let (exit_code, error) = run_job_with_target(
+        "device-1".to_string(),
+        req,
+        ExecutionTarget {
+            path: script.to_string_lossy().to_string(),
+            leading_args: Vec::new(),
+        },
+        tx,
+        cancel_rx,
+        None,
+    )
+    .await;
+
+    assert_eq!(exit_code, 0);
+    assert_eq!(error, "");
+
+    let mut saw_stdout = false;
+    while let Ok(env) = rx.try_recv() {
+        if let Some(ahand_protocol::envelope::Payload::JobEvent(event)) = env.payload {
+            if let Some(ahand_protocol::job_event::Event::StdoutChunk(bytes)) = event.event {
+                saw_stdout |= String::from_utf8_lossy(&bytes).contains("managed:ok");
+            }
+        }
+    }
+    assert!(saw_stdout, "managed runtime stdout should be streamed");
+}
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+cargo test -p ahandd executor::tool_resolution_tests::run_job_with_target_uses_explicit_executable_path
+```
+
+Expected: compile failure because `ExecutionTarget` and `run_job_with_target` do not exist.
+
+- [ ] **Step 3: Implement explicit target runner**
+
+In `executor.rs`, add:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionTarget {
+    pub path: String,
+    pub leading_args: Vec<String>,
+}
+
+impl From<ResolvedTool> for ExecutionTarget {
+    fn from(value: ResolvedTool) -> Self {
+        Self {
+            path: value.path,
+            leading_args: value.leading_args,
+        }
+    }
+}
+```
+
+Refactor `run_job`:
+
+```rust
+pub async fn run_job<T>(...) -> (i32, String)
+where
+    T: EnvelopeSink,
+{
+    let target = ExecutionTarget::from(resolve_tool(
+        &req.tool,
+        std::env::var("SHELL").ok().as_deref(),
+    ));
+    run_job_with_target(device_id, req, target, tx, cancel_rx, store).await
+}
+```
+
+Add `run_job_with_target` by moving the current body of `run_job` and replacing internal `resolve_tool(...)` usage with the passed `target`:
+
+```rust
+let mut cmd = Command::new(&target.path);
+for leading in &target.leading_args {
+    cmd.arg(leading);
+}
+cmd.args(&req.args);
+```
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p ahandd executor::tool_resolution_tests
+cargo test -p ahandd --test job_request_tool
+```
+
+Expected: executor tests pass; external job tool contract still passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ahandd/src/executor.rs
+git commit -m "feat(ahandd): run jobs with explicit execution targets"
+```
+
+---
+
+## Task 3: Add Provider Registry And Job Tool Selection
+
+**Files:**
+- Create: `crates/ahandd/src/plugin_runtime/provider.rs`
+- Modify: `crates/ahandd/src/plugin_runtime/mod.rs`
+
+- [ ] **Step 1: Write failing provider tests**
+
+Create `crates/ahandd/src/plugin_runtime/provider.rs` with tests first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_plugin_tokens_select_managed_runtime_providers() {
+        assert_eq!(
+            resolve_job_provider_kind("plugin:node"),
+            JobProviderKind::ManagedRuntime(CapabilityKind::NodeExec)
+        );
+        assert_eq!(
+            resolve_job_provider_kind("plugin:python"),
+            JobProviderKind::ManagedRuntime(CapabilityKind::PythonExec)
+        );
+    }
+
+    #[test]
+    fn plain_node_and_python_stay_default_exec_provider() {
+        assert_eq!(resolve_job_provider_kind("node"), JobProviderKind::DefaultExec);
+        assert_eq!(resolve_job_provider_kind("python"), JobProviderKind::DefaultExec);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+cargo test -p ahandd plugin_runtime::provider
+```
+
+Expected: compile failure because the module and provider types do not exist.
+
+- [ ] **Step 3: Implement provider module**
+
+Add `crates/ahandd/src/plugin_runtime/provider.rs`:
+
+```rust
+use std::collections::BTreeMap;
+
+use crate::browser::BrowserManager;
+use crate::executor::ExecutionTarget;
+use crate::file_manager::FileManager;
+
+use super::{
+    ActivationConfig, CapabilityKind, CapabilityRemediation, CapabilityRouter,
+    CapabilityUnavailable, HostResourceValue, InstalledPluginResource, PluginStatus,
+    router_from_plugins,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JobProviderKind {
+    DefaultExec,
+    ManagedRuntime(CapabilityKind),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JobProvider {
+    DefaultExec,
+    ManagedRuntime {
+        capability: CapabilityKind,
+        target: ExecutionTarget,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct CapabilityProviderRegistry {
+    router: CapabilityRouter,
+    runtime_targets: BTreeMap<CapabilityKind, ExecutionTarget>,
+}
+
+pub async fn build_provider_registry(
+    browser_mgr: &BrowserManager,
+    file_mgr: &FileManager,
+) -> anyhow::Result<CapabilityProviderRegistry> {
+    let snapshot = super::get_host_resource().await?;
+    Ok(CapabilityProviderRegistry::from_plugins(
+        &snapshot.plugins,
+        ActivationConfig {
+            browser_enabled: browser_mgr.is_enabled(),
+            file_enabled: file_mgr.is_enabled(),
+            system_browser_available: browser_mgr.has_system_browser(),
+        },
+    ))
+}
+
+impl CapabilityProviderRegistry {
+    pub fn from_plugins(
+        plugins: &[InstalledPluginResource],
+        config: ActivationConfig,
+    ) -> Self {
+        let router = router_from_plugins(plugins, config);
+        let mut runtime_targets = BTreeMap::new();
+        if let Some(target) = executable_target(plugins, "node", "node") {
+            runtime_targets.insert(CapabilityKind::NodeExec, target);
+        }
+        if let Some(target) = executable_target(plugins, "python", "python") {
+            runtime_targets.insert(CapabilityKind::PythonExec, target);
+        }
+        Self {
+            router,
+            runtime_targets,
+        }
+    }
+
+    pub fn ensure(&self, capability: CapabilityKind) -> Result<(), super::CapabilityUnavailable> {
+        self.router.ensure(capability)
+    }
+
+    pub fn active_wire_capabilities(&self) -> Vec<&'static str> {
+        self.router.active_wire_capabilities()
+    }
+
+    pub fn resolve_job_provider(
+        &self,
+        tool: &str,
+    ) -> Result<JobProvider, super::CapabilityUnavailable> {
+        match resolve_job_provider_kind(tool) {
+            JobProviderKind::DefaultExec => {
+                self.ensure(CapabilityKind::Exec)?;
+                Ok(JobProvider::DefaultExec)
+            }
+            JobProviderKind::ManagedRuntime(capability) => {
+                self.ensure(capability)?;
+                let target = self
+                    .runtime_targets
+                    .get(&capability)
+                    .cloned()
+                    .ok_or_else(|| missing_runtime_target(capability))?;
+                Ok(JobProvider::ManagedRuntime { capability, target })
+            }
+        }
+    }
+}
+
+pub fn resolve_job_provider_kind(tool: &str) -> JobProviderKind {
+    match tool {
+        "plugin:node" => JobProviderKind::ManagedRuntime(CapabilityKind::NodeExec),
+        "plugin:python" => JobProviderKind::ManagedRuntime(CapabilityKind::PythonExec),
+        _ => JobProviderKind::DefaultExec,
+    }
+}
+
+fn executable_target(
+    plugins: &[InstalledPluginResource],
+    plugin_id: &str,
+    resource_name: &str,
+) -> Option<ExecutionTarget> {
+    let plugin = plugins.iter().find(|plugin| plugin.id == plugin_id)?;
+    match plugin.resources.get(resource_name)? {
+        HostResourceValue::Executable { path, .. } => Some(ExecutionTarget {
+            path: path.clone(),
+            leading_args: Vec::new(),
+        }),
+        _ => None,
+    }
+}
+
+fn missing_runtime_target(capability: CapabilityKind) -> CapabilityUnavailable {
+    let plugin_id = match capability {
+        CapabilityKind::NodeExec => "node",
+        CapabilityKind::PythonExec => "python",
+        _ => capability.wire_name(),
+    };
+    CapabilityUnavailable {
+        capability,
+        plugin_id: plugin_id.to_string(),
+        status: PluginStatus::Missing,
+        reason: format!("{plugin_id} executable resource is missing"),
+        remediation: CapabilityRemediation::InstallPlugin {
+            plugin_id: plugin_id.to_string(),
+        },
+    }
+}
+```
+
+Modify `mod.rs`:
+
+```rust
+pub mod provider;
+pub use provider::{
+    CapabilityProviderRegistry, JobProvider, JobProviderKind, build_provider_registry,
+    resolve_job_provider_kind,
+};
+```
+
+- [ ] **Step 4: Run provider tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p ahandd plugin_runtime::provider
+```
+
+Expected: provider tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ahandd/src/plugin_runtime/provider.rs crates/ahandd/src/plugin_runtime/mod.rs
+git commit -m "feat(ahandd): add capability provider registry"
+```
+
+---
+
+## Task 4: Route Cloud Job Dispatch Through Providers
+
+**Files:**
+- Modify: `crates/ahandd/src/ahand_client.rs`
+
+- [ ] **Step 1: Write failing cloud provider tests**
+
+Add tests to `crates/ahandd/src/ahand_client.rs`:
+
+```rust
+#[test]
+fn managed_runtime_interactive_rejection_preserves_job_id() {
+    let req = ahand_protocol::JobRequest {
+        job_id: "node-interactive-1".to_string(),
+        tool: "plugin:node".to_string(),
+        interactive: true,
+        ..Default::default()
+    };
+
+    let env = super::managed_runtime_interactive_rejection("device-1", &req);
+
+    assert_eq!(env.device_id, "device-1");
+    match env.payload {
+        Some(envelope::Payload::JobRejected(rejected)) => {
+            assert_eq!(rejected.job_id, "node-interactive-1");
+            assert!(rejected.reason.contains("plugin:node"));
+            assert!(rejected.reason.contains("interactive"));
+        }
+        other => panic!("expected JobRejected, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+cargo test -p ahandd managed_runtime_interactive_rejection_preserves_job_id
+```
+
+Expected: compile failure because `managed_runtime_interactive_rejection` does not exist.
+
+- [ ] **Step 3: Implement cloud provider dispatch**
+
+Add helper:
+
+```rust
+fn managed_runtime_interactive_rejection(
+    device_id: &str,
+    req: &ahand_protocol::JobRequest,
+) -> Envelope {
+    Envelope {
+        device_id: device_id.to_string(),
+        msg_id: new_msg_id(),
+        ts_ms: now_ms(),
+        payload: Some(envelope::Payload::JobRejected(JobRejected {
+            job_id: req.job_id.clone(),
+            reason: format!(
+                "managed runtime tool {} does not support interactive PTY jobs",
+                req.tool
+            ),
+        })),
+        ..Default::default()
+    }
+}
+```
+
+In `handle_job_request`, replace `build_router(...)` with:
+
+```rust
+let provider_registry =
+    match crate::plugin_runtime::build_provider_registry(browser_mgr, file_mgr).await {
+        Ok(registry) => registry,
+        Err(err) => { ... }
+    };
+let job_provider = match provider_registry.resolve_job_provider(&req.tool) {
+    Ok(provider) => provider,
+    Err(unavailable) => { ... }
+};
+if req.interactive && matches!(job_provider, crate::plugin_runtime::JobProvider::ManagedRuntime { .. }) {
+    let _ = tx.send(managed_runtime_interactive_rejection(device_id, &req));
+    return;
+}
+```
+
+Change `spawn_job` signature:
+
+```rust
+async fn spawn_job<T>(
+    device_id: &str,
+    req: ahand_protocol::JobRequest,
+    provider: crate::plugin_runtime::JobProvider,
+    tx: &T,
+    registry: &Arc<JobRegistry>,
+    store: &Option<Arc<RunStore>>,
+)
+```
+
+In non-interactive branch:
+
+```rust
+match provider {
+    crate::plugin_runtime::JobProvider::DefaultExec => {
+        executor::run_job(did, req, tx_clone, cancel_rx, st).await
+    }
+    crate::plugin_runtime::JobProvider::ManagedRuntime { target, .. } => {
+        executor::run_job_with_target(did, req, target, tx_clone, cancel_rx, st).await
+    }
+}
+```
+
+Pass `job_provider.clone()` into the Allow and approval-granted paths.
+
+For `handle_browser_request` and `handle_file_request`, replace `build_router(...)` with `build_provider_registry(...)` and call `provider_registry.ensure(CapabilityKind::Browser/File)`.
+
+- [ ] **Step 4: Run cloud tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p ahandd ahand_client
+cargo test -p ahandd --test hub_handshake
+cargo test -p ahandd --test hello_signature
+```
+
+Expected: all targeted tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ahandd/src/ahand_client.rs
+git commit -m "feat(ahandd): route cloud jobs through capability providers"
+```
+
+---
+
+## Task 5: Route Debug IPC Job Dispatch Through Providers
+
+**Files:**
+- Modify: `crates/ahandd/src/ipc.rs`
+
+- [ ] **Step 1: Write failing IPC provider test**
+
+Add to `crates/ahandd/src/ipc.rs` tests:
+
+```rust
+#[test]
+fn ipc_managed_runtime_interactive_rejection_preserves_job_id() {
+    let req = ahand_protocol::JobRequest {
+        job_id: "ipc-python-interactive-1".to_string(),
+        tool: "plugin:python".to_string(),
+        interactive: true,
+        ..Default::default()
+    };
+
+    let env = managed_runtime_interactive_rejection_envelope("device-1", &req);
+
+    match env.payload {
+        Some(envelope::Payload::JobRejected(rejected)) => {
+            assert_eq!(rejected.job_id, "ipc-python-interactive-1");
+            assert!(rejected.reason.contains("plugin:python"));
+            assert!(rejected.reason.contains("interactive"));
+        }
+        other => panic!("expected JobRejected, got {other:?}"),
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+cargo test -p ahandd ipc_managed_runtime_interactive_rejection_preserves_job_id
+```
+
+Expected: compile failure because helper does not exist.
+
+- [ ] **Step 3: Implement IPC provider dispatch**
+
+Add helper:
+
+```rust
+fn managed_runtime_interactive_rejection_envelope(
+    device_id: &str,
+    req: &ahand_protocol::JobRequest,
+) -> Envelope {
+    Envelope {
+        device_id: device_id.to_string(),
+        msg_id: new_msg_id(),
+        ts_ms: now_ms(),
+        payload: Some(envelope::Payload::JobRejected(JobRejected {
+            job_id: req.job_id.clone(),
+            reason: format!(
+                "managed runtime tool {} does not support interactive PTY jobs",
+                req.tool
+            ),
+        })),
+        ..Default::default()
+    }
+}
+```
+
+In IPC `JobRequest` branch:
+
+```rust
+let provider_registry =
+    match crate::plugin_runtime::build_provider_registry(&browser_mgr, &file_mgr).await { ... };
+let job_provider = match provider_registry.resolve_job_provider(&req.tool) { ... };
+if req.interactive && matches!(job_provider, crate::plugin_runtime::JobProvider::ManagedRuntime { .. }) {
+    let _ = tx.send(managed_runtime_interactive_rejection_envelope(&device_id, &req));
+    continue;
+}
+```
+
+In Allow and approval-granted task execution, call:
+
+```rust
+match job_provider {
+    crate::plugin_runtime::JobProvider::DefaultExec => {
+        executor::run_job(did, req, tx_clone, cancel_rx, st).await
+    }
+    crate::plugin_runtime::JobProvider::ManagedRuntime { target, .. } => {
+        executor::run_job_with_target(did, req, target, tx_clone, cancel_rx, st).await
+    }
+}
+```
+
+In BrowserRequest branch, replace `build_router(...)` with `build_provider_registry(...)`.
+
+- [ ] **Step 4: Run IPC tests to verify GREEN**
+
+Run:
+
+```bash
+cargo test -p ahandd ipc
+cargo check -p ahandd
+```
+
+Expected: IPC tests and check pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/ahandd/src/ipc.rs
+git commit -m "feat(ahandd): route ipc jobs through capability providers"
+```
+
+---
+
+## Task 6: Verify Runtime Resource CLI And Full Stage 3 Behavior
+
+**Files:**
+- No code edits expected.
+
+- [ ] **Step 1: Run formatting check for touched Rust files**
+
+Run:
+
+```bash
+rustfmt --edition 2024 --config skip_children=true --check \
+  crates/ahandd/src/ahand_client.rs \
+  crates/ahandd/src/executor.rs \
+  crates/ahandd/src/ipc.rs \
+  crates/ahandd/src/plugin_runtime/activation.rs \
+  crates/ahandd/src/plugin_runtime/capability.rs \
+  crates/ahandd/src/plugin_runtime/mod.rs \
+  crates/ahandd/src/plugin_runtime/provider.rs
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2: Run targeted tests**
+
+Run:
+
+```bash
+cargo test -p ahandd plugin_runtime
+cargo test -p ahandd executor::tool_resolution_tests
+cargo test -p ahandd ahand_client
+cargo test -p ahandd ipc
+cargo test -p ahandd --test job_request_tool
+cargo test -p ahandd --test hub_handshake
+cargo test -p ahandd --test hello_signature
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Run build/check smoke tests**
+
+Run:
+
+```bash
+cargo check -p ahandd -p ahandctl
+cargo build -p ahandd --bin ahandd
+target/debug/ahandd plugin host-resource --json >/tmp/ahand-stage3-host-resource.json
+jq -r '[.platform,.arch,((.plugins|map(.id)|sort)|join(","))] | @tsv' /tmp/ahand-stage3-host-resource.json
+target/debug/ahandd plugin doctor
+```
+
+Expected:
+
+- build/check exit 0.
+- host-resource includes `browser-playwright-cli,file,node,python,shell`.
+- doctor prints statuses for those five plugins.
+
+- [ ] **Step 4: Run diff and status checks**
+
+Run:
+
+```bash
+git diff --check codex/plugin-runtime-stage2..HEAD
+git status --short
+```
+
+Expected: no whitespace errors; clean worktree.
+
+- [ ] **Step 5: Push and create PR**
+
+Run:
+
+```bash
+git push -u origin codex/plugin-runtime-stage3
+gh pr create --draft --repo team9ai/aHand --base codex/plugin-runtime-stage2 --head codex/plugin-runtime-stage3 --title "[codex] Plugin runtime stage 3 providers" --body-file /tmp/ahand-stage3-pr.md
+```
+
+Expected: draft PR created against Stage 2.

--- a/docs/superpowers/specs/2026-05-19-ahand-plugin-runtime-stage3-design.md
+++ b/docs/superpowers/specs/2026-05-19-ahand-plugin-runtime-stage3-design.md
@@ -129,6 +129,7 @@ Owner: `python`
 Provider behavior:
 
 - Active only when the `python` plugin is installed and exports a `python` executable resource.
+- `ahandd plugin install python` installs a managed CPython runtime from a pinned python-build-standalone release asset into `dependencies/python`.
 - Selected by explicit `JobRequest.tool` token:
 
 ```text
@@ -281,11 +282,13 @@ Add tests before implementation:
 - managed runtime interactive requests return `JobRejected`.
 - Hello advertises active `node-exec` / `python-exec` additively.
 - Existing `job_request_tool` contract stays green for `node` / `python` PATH semantics.
+- CLI install coverage verifies `python` has an install step and `browser_setup::inspect("python")` recognizes the plugin.
 
 ## Acceptance Criteria
 
 - Stage 3 introduces a first-party provider registry used by cloud WS and debug IPC dispatch.
 - `plugin:node` and `plugin:python` execute managed runtime binaries directly when installed.
+- `ahandd plugin install python` installs Python and `getHostResource()` exports the managed `python` executable path and version.
 - Plain `node` and `python` retain current PATH-based execution.
 - Hello advertises `node-exec` and `python-exec` only when active.
 - Missing runtime plugins return host-neutral install guidance.

--- a/docs/superpowers/specs/2026-05-19-ahand-plugin-runtime-stage3-design.md
+++ b/docs/superpowers/specs/2026-05-19-ahand-plugin-runtime-stage3-design.md
@@ -15,9 +15,9 @@ node-exec   -> node plugin
 python-exec -> python plugin
 ```
 
-These capabilities must not change existing `JobRequest.tool = "node"` or `JobRequest.tool = "python"` behavior. Those existing values remain PATH-based executable names. Managed runtime execution is selected only through explicit provider-owned tool tokens.
+These capabilities must not reinterpret existing `JobRequest.tool = "node"` or `JobRequest.tool = "python"` as provider tokens. Those existing values remain PATH-based executable names. Managed runtime execution is selected only through explicit provider-owned tool tokens, while the default child process `PATH` may be enriched with installed managed runtime bins as described below.
 
-OpenClaw remains out of scope.
+Full OpenClaw provider migration remains out of scope. OpenClaw `system.run` and `system.which` share the managed runtime `PATH` enrichment so crate-mode hosts can find locally installed managed Node/Python runtimes.
 
 ## Goals
 
@@ -26,6 +26,7 @@ OpenClaw remains out of scope.
 - Preserve current protocol payloads and current request/response envelopes.
 - Add explicit managed runtime direct execution for the `node` and `python` plugins.
 - Keep `node` and `python` shell-independent: provider execution should run the managed binary path directly, not via shell.
+- Prepend installed managed Node/Python `bin` directories to child process `PATH` for default exec and OpenClaw command execution.
 - Keep existing policy, approval, idempotency, cancellation, PTY, file policy, and browser domain behavior intact.
 - Keep unavailable capability responses host-neutral and compatible with team9 crate-mode hosts.
 
@@ -37,7 +38,7 @@ OpenClaw remains out of scope.
 - Automatic plugin installation during dispatch.
 - OpenClaw command handler migration.
 - Changing protobuf schemas.
-- Changing the meaning of existing `JobRequest.tool = "node"` or `"python"`.
+- Reinterpreting existing `JobRequest.tool = "node"` or `"python"` as managed runtime provider tokens.
 
 ## Capability Provider Model
 
@@ -85,6 +86,8 @@ Provider behavior:
 - Existing `JobRequest` flow remains the default shell-backed execution path.
 - `JobRequest.tool = "$SHELL"` and `"shell"` keep current login-shell behavior.
 - Literal tools keep current PATH/path resolution behavior.
+- Child process `PATH` prepends managed runtime `bin` directories only when `getHostResource()` reports the local `node` or `python` plugin as `installed` and exports the corresponding executable resource.
+- If a request supplies a `PATH` environment override, that value is used as the base path and the managed runtime `bin` directories are prepended to it.
 - Interactive jobs continue using PTY support.
 
 ### `file`
@@ -151,7 +154,7 @@ plugin:node   -> managed node runtime provider
 plugin:python -> managed python runtime provider
 ```
 
-This avoids surprising users who currently rely on shell PATH behavior while allowing agents to deliberately choose the managed runtime after reading `getHostResource()`.
+The provider registry still avoids silently converting plain `node` / `python` tool tokens into managed runtime providers. However, child commands now receive a daemon-computed `PATH`: if local managed Node/Python installation is complete, their `bin` directories are placed before the caller's base `PATH`. This lets crate-mode hosts run commands like `node --version` or `python3 --version` after installation without hard-coding absolute runtime paths.
 
 Future protocol versions may add structured fields for provider selection. Stage 3 intentionally avoids schema changes.
 

--- a/docs/superpowers/specs/2026-05-19-ahand-plugin-runtime-stage3-design.md
+++ b/docs/superpowers/specs/2026-05-19-ahand-plugin-runtime-stage3-design.md
@@ -1,0 +1,293 @@
+# AHand Plugin Runtime Stage 3 Design
+
+**Date:** 2026-05-19
+**Status:** Draft for review
+**Base:** Stage 2 plugin runtime dispatch activation in `codex/plugin-runtime-stage2`
+
+## Overview
+
+Stage 3 turns Stage 2's capability gates into first-party capability providers. Stage 2 already decides whether a capability is active before dispatch. Stage 3 makes the active capability own the execution adapter too, so cloud WebSocket and debug IPC dispatch can resolve a provider from a registry rather than hard-coding `executor`, `FileManager`, and `BrowserManager` calls directly at every entry point.
+
+This stage also introduces explicit managed runtime execution capabilities:
+
+```text
+node-exec   -> node plugin
+python-exec -> python plugin
+```
+
+These capabilities must not change existing `JobRequest.tool = "node"` or `JobRequest.tool = "python"` behavior. Those existing values remain PATH-based executable names. Managed runtime execution is selected only through explicit provider-owned tool tokens.
+
+OpenClaw remains out of scope.
+
+## Goals
+
+- Add a first-party capability provider registry for the current daemon-owned capabilities.
+- Move cloud WebSocket and debug IPC execution paths to provider lookup after Stage 2 activation checks.
+- Preserve current protocol payloads and current request/response envelopes.
+- Add explicit managed runtime direct execution for the `node` and `python` plugins.
+- Keep `node` and `python` shell-independent: provider execution should run the managed binary path directly, not via shell.
+- Keep existing policy, approval, idempotency, cancellation, PTY, file policy, and browser domain behavior intact.
+- Keep unavailable capability responses host-neutral and compatible with team9 crate-mode hosts.
+
+## Non-Goals
+
+- Third-party plugin package loading.
+- Dynamic plugin ABI or sandboxing.
+- Dashboard plugin management UI.
+- Automatic plugin installation during dispatch.
+- OpenClaw command handler migration.
+- Changing protobuf schemas.
+- Changing the meaning of existing `JobRequest.tool = "node"` or `"python"`.
+
+## Capability Provider Model
+
+Stage 3 adds an internal provider layer under `crates/ahandd/src/plugin_runtime/`. A provider is a first-party adapter that knows how to execute one capability after the capability router says it is active.
+
+Recommended shape:
+
+```rust
+pub enum CapabilityProviderKind {
+    Exec,
+    File,
+    Browser,
+    NodeExec,
+    PythonExec,
+}
+
+pub struct CapabilityProviderRegistry {
+    providers: BTreeMap<CapabilityProviderKind, CapabilityProviderEntry>,
+}
+
+pub struct CapabilityProviderEntry {
+    pub capability: CapabilityProviderKind,
+    pub owner_plugin_id: String,
+    pub activation: CapabilityEntry,
+}
+```
+
+The exact type names can change during implementation, but Stage 3 should keep a clear boundary:
+
+1. `activation.rs` derives active/unavailable state from host resources and config.
+2. `provider.rs` registers first-party providers from activation state.
+3. cloud WS and debug IPC dispatch resolve providers from the registry.
+4. provider execution delegates to existing concrete managers.
+
+The provider registry is not a plugin installer and must not mutate runtime resources.
+
+## Capability Set
+
+### `exec`
+
+Owner: `shell`
+
+Provider behavior:
+
+- Existing `JobRequest` flow remains the default shell-backed execution path.
+- `JobRequest.tool = "$SHELL"` and `"shell"` keep current login-shell behavior.
+- Literal tools keep current PATH/path resolution behavior.
+- Interactive jobs continue using PTY support.
+
+### `file`
+
+Owner: `file`
+
+Provider behavior:
+
+- Existing `FileManager` policy, approval, and dispatch stay authoritative.
+- Stage 3 should only change where the handler is resolved from, not the file operation semantics.
+
+### `browser-playwright-cli`
+
+Owner: `browser-playwright-cli`
+
+Provider behavior:
+
+- Existing `BrowserManager` domain policy and command execution stay authoritative.
+- Browser session tracking and close handling stay unchanged.
+
+### `node-exec`
+
+Owner: `node`
+
+Provider behavior:
+
+- Active only when the `node` plugin is installed and exports a `node` executable resource.
+- Selected by explicit `JobRequest.tool` token:
+
+```text
+plugin:node
+```
+
+- The provider runs the managed Node binary directly with `req.args`.
+- `req.cwd`, `req.env`, cancellation, stdout/stderr events, run store, idempotency, and non-interactive job lifecycle match the current executor path.
+- Interactive PTY is not supported in Stage 3. If a `plugin:node` request has `interactive = true`, return `JobRejected` with a clear reason.
+
+### `python-exec`
+
+Owner: `python`
+
+Provider behavior:
+
+- Active only when the `python` plugin is installed and exports a `python` executable resource.
+- Selected by explicit `JobRequest.tool` token:
+
+```text
+plugin:python
+```
+
+- The provider runs the managed Python binary directly with `req.args`.
+- `req.cwd`, `req.env`, cancellation, stdout/stderr events, run store, idempotency, and non-interactive job lifecycle match the current executor path.
+- Interactive PTY is not supported in Stage 3. If a `plugin:python` request has `interactive = true`, return `JobRejected` with a clear reason.
+
+## Tool Token Semantics
+
+Stage 3 introduces explicit plugin tool tokens while preserving existing tool resolution:
+
+```text
+node          -> current PATH-based executable resolution
+python        -> current PATH-based executable resolution
+plugin:node   -> managed node runtime provider
+plugin:python -> managed python runtime provider
+```
+
+This avoids surprising users who currently rely on shell PATH behavior while allowing agents to deliberately choose the managed runtime after reading `getHostResource()`.
+
+Future protocol versions may add structured fields for provider selection. Stage 3 intentionally avoids schema changes.
+
+## Activation
+
+Stage 2 `CapabilityKind` should be extended to include:
+
+```rust
+NodeExec
+PythonExec
+```
+
+Wire capability names:
+
+```text
+node-exec
+python-exec
+```
+
+These names may be advertised in Hello when active. They are additive and do not change existing capability names.
+
+Activation rules:
+
+- `node-exec` active when the `node` plugin status is `Installed` and the host resource snapshot contains a `node` executable resource.
+- `python-exec` active when the `python` plugin status is `Installed` and the host resource snapshot contains a `python` executable resource.
+- Missing or failed runtimes use `InstallPlugin { plugin_id }` remediation.
+- Runtime capability unavailable responses should mention the explicit tool token, for example:
+
+```text
+node capability unavailable: plugin node is missing because node plugin is missing; install plugin node through the host plugin installer
+```
+
+Exact wording can be adjusted, but it must remain host-neutral and must not hard-code `ahandd plugin install`.
+
+## Dispatch Flow
+
+### JobRequest
+
+Stage 3 splits JobRequest provider selection:
+
+```text
+JobRequest
+  -> resolve job provider from req.tool
+  -> CapabilityRouter.ensure(provider capability)
+  -> if unavailable: JobRejected
+  -> existing idempotency/session/approval flow
+  -> provider executes job
+```
+
+Provider resolution:
+
+```text
+plugin:node   -> NodeExec provider
+plugin:python -> PythonExec provider
+anything else -> Exec provider
+```
+
+Approval and idempotency must still happen before execution. Provider resolution is allowed before approval so the daemon can reject unavailable managed runtimes without prompting for an operation it cannot run.
+
+### FileRequest
+
+```text
+FileRequest
+  -> provider registry resolves File
+  -> CapabilityRouter.ensure(File)
+  -> existing policy/session/approval flow
+  -> File provider delegates to FileManager
+```
+
+### BrowserRequest
+
+```text
+BrowserRequest
+  -> provider registry resolves Browser
+  -> CapabilityRouter.ensure(Browser)
+  -> existing session/domain checks
+  -> Browser provider delegates to BrowserManager
+```
+
+## Executor Changes
+
+The existing `executor::run_job` resolves `JobRequest.tool` internally. Stage 3 needs a way for providers to pass an already-resolved executable path without changing default behavior.
+
+Recommended minimal change:
+
+```rust
+pub struct ExecutionTarget {
+    pub path: String,
+    pub leading_args: Vec<String>,
+}
+
+pub async fn run_job_with_target<T>(
+    device_id: String,
+    req: JobRequest,
+    target: ExecutionTarget,
+    tx: T,
+    cancel_rx: mpsc::Receiver<()>,
+    store: Option<Arc<RunStore>>,
+) -> (i32, String)
+```
+
+`run_job()` becomes a compatibility wrapper that calls `resolve_tool()` and then `run_job_with_target()`. This keeps existing tests and external behavior stable.
+
+PTY execution remains shell/default-exec only in Stage 3.
+
+## Error Semantics
+
+Stage 3 keeps protocol-level errors in existing message types:
+
+- unavailable job providers -> `JobRejected`
+- unsupported interactive managed runtime job -> `JobRejected`
+- unavailable file provider -> `FileResponse` policy-style error
+- unavailable browser provider -> `BrowserResponse` error
+
+The provider registry may use structured `CapabilityUnavailable` internally, but rendered protocol errors must remain stable strings.
+
+## Testing Strategy
+
+Add tests before implementation:
+
+- Router advertises `node-exec` when node resource is installed.
+- Router advertises `python-exec` when python resource is installed.
+- Missing node returns install remediation for `node-exec`.
+- Missing python returns install remediation for `python-exec`.
+- `plugin:node` resolves to `NodeExec`; `node` resolves to default `Exec`.
+- `plugin:python` resolves to `PythonExec`; `python` resolves to default `Exec`.
+- `executor::run_job_with_target` runs an explicit executable path and does not call `resolve_tool`.
+- managed runtime interactive requests return `JobRejected`.
+- Hello advertises active `node-exec` / `python-exec` additively.
+- Existing `job_request_tool` contract stays green for `node` / `python` PATH semantics.
+
+## Acceptance Criteria
+
+- Stage 3 introduces a first-party provider registry used by cloud WS and debug IPC dispatch.
+- `plugin:node` and `plugin:python` execute managed runtime binaries directly when installed.
+- Plain `node` and `python` retain current PATH-based execution.
+- Hello advertises `node-exec` and `python-exec` only when active.
+- Missing runtime plugins return host-neutral install guidance.
+- Existing exec/file/browser behavior remains compatible.
+- OpenClaw code paths are unchanged.


### PR DESCRIPTION
## Summary
- Adds managed runtime exec capabilities for node and python, advertised as node-exec/python-exec when installed with executable resources.
- Adds a capability provider registry and explicit plugin:node / plugin:python job routing without changing plain node/python PATH behavior.
- Routes cloud and IPC job dispatch through providers, with managed runtime interactive PTY requests rejected explicitly.

## Test Plan
- rustfmt --edition 2024 --config skip_children=true --check crates/ahandd/src/ahand_client.rs crates/ahandd/src/executor.rs crates/ahandd/src/ipc.rs crates/ahandd/src/plugin_runtime/activation.rs crates/ahandd/src/plugin_runtime/capability.rs crates/ahandd/src/plugin_runtime/mod.rs crates/ahandd/src/plugin_runtime/provider.rs
- cargo test -p ahandd plugin_runtime
- cargo test -p ahandd executor::tool_resolution_tests
- cargo test -p ahandd ahand_client
- cargo test -p ahandd ipc
- cargo test -p ahandd --test job_request_tool
- cargo test -p ahandd --test hub_handshake
- cargo test -q -p ahandd --test hello_signature
- cargo check -p ahandd -p ahandctl
- cargo build -p ahandd --bin ahandd
- target/debug/ahandd plugin host-resource --json >/tmp/ahand-stage3-host-resource.json
- jq -r "[.platform,.arch,((.plugins|map(.id)|sort)|join(","))] | @tsv" /tmp/ahand-stage3-host-resource.json
- target/debug/ahandd plugin doctor
- git diff --check codex/plugin-runtime-stage2..HEAD

## Notes
- On this machine, plugin doctor reports node/python Missing and browser-playwright-cli Blocked because managed runtimes are not installed locally; host-resource still enumerates all five first-party plugins.