### PR TITLE
[codex] Retarget aHand hub dev to t9 AWS

### DIFF
--- a/.github/workflows/deploy-hub.yml
+++ b/.github/workflows/deploy-hub.yml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   AWS_REGION: us-east-1
-  ECR_REGISTRY: 471112576951.dkr.ecr.us-east-1.amazonaws.com
+  ECR_REGISTRY: 149614785083.dkr.ecr.us-east-1.amazonaws.com
   ECR_REPO: ahand-hub
 
 jobs:
@@ -39,7 +39,7 @@ jobs:
           fi
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws:iam::471112576951:role/GitHubActionsAhandHubDeploy
+          role-to-assume: arn:aws:iam::149614785083:role/GitHubActionsAhandHubDeploy
           aws-region: ${{ env.AWS_REGION }}
       - uses: aws-actions/amazon-ecr-login@v2
       - name: Build image (hub target)

--- a/deploy/hub/deploy.sh
+++ b/deploy/hub/deploy.sh
@@ -6,7 +6,7 @@ ENV="${1:-}"
 [[ "$ENV" == "dev" || "$ENV" == "prod" ]] || { echo "Usage: $0 {dev|prod}"; exit 1; }
 
 AWS_REGION="us-east-1"
-ACCOUNT_ID="471112576951"
+ACCOUNT_ID="149614785083"
 ECR_REGISTRY="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
 ECR_REPO="ahand-hub"
 GIT_SHA="${GIT_SHA:-$(git rev-parse --short HEAD)}"

--- a/infra/envs/dev/backend.tf
+++ b/infra/envs/dev/backend.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "s3" {
-    bucket         = "weightwave-tfstate"
+    bucket         = "team9-tfstate"
     key            = "ahand-hub/envs/dev/terraform.tfstate"
     region         = "us-east-1"
-    profile        = "ww"
+    profile        = "t9"
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
   }

--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -5,6 +5,8 @@ data "aws_lb" "traefik" {
 module "ahand_hub" {
   source = "../../modules/ahand-hub"
 
+  # t9 dev uses fresh state plus the bootstrap-owned S3 bucket. Do not migrate
+  # old ww dev state into this backend.
   env                            = "dev"
   ecs_cluster_name               = "openclaw-hive-dev"
   api_domain                     = "ahand-hub.dev.team9.ai"

--- a/infra/envs/dev/providers.tf
+++ b/infra/envs/dev/providers.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region  = "us-east-1"
-  profile = "ww"
+  profile = "t9"
 
   default_tags {
     tags = {

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -1,11 +1,11 @@
 variable "vpc_id" {
   type    = string
-  default = "vpc-028cd35f94f14d52b"
+  default = "vpc-05804f4c4dd8965f3"
 }
 
 variable "subnet_ids" {
   type    = list(string)
-  default = ["subnet-09eb68ab6cae3c581", "subnet-0c8ca567a8d4def31"]
+  default = ["subnet-0eaffec23bfd7eb63", "subnet-0cdb64bc3cf4c6ee3"]
 }
 
 variable "traefik_alb_name" {
@@ -15,15 +15,15 @@ variable "traefik_alb_name" {
 
 variable "traefik_security_group_id" {
   type    = string
-  default = "sg-07050efac1b71052b"
+  default = "sg-040876c89a7a65ec4"
 }
 
 variable "openclaw_rds_host" {
   type    = string
-  default = "openclaw-hive-dev.chq8i2se49qd.us-east-1.rds.amazonaws.com"
+  default = null
 }
 
 variable "openclaw_rds_security_group_id" {
   type    = string
-  default = "sg-03be90e5bf963ddc3"
+  default = "sg-0b7b9a007a8b5b7a6"
 }

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -15,12 +15,12 @@ variable "traefik_alb_name" {
 
 variable "traefik_security_group_id" {
   type    = string
-  default = "sg-040876c89a7a65ec4"
+  default = "sg-0368318519318a4ba"
 }
 
 variable "openclaw_rds_host" {
   type    = string
-  default = null
+  default = "openclaw-hive-dev.c89gkagwy37d.us-east-1.rds.amazonaws.com"
 }
 
 variable "openclaw_rds_security_group_id" {

--- a/infra/envs/prod/main.tf
+++ b/infra/envs/prod/main.tf
@@ -11,8 +11,11 @@ module "ahand_hub" {
   source = "../../modules/ahand-hub"
 
   env                            = "prod"
+  aws_account_id                 = "471112576951"
   ecs_cluster_name               = "openclaw-hive"
   api_domain                     = "ahand-hub.team9.ai"
+  file_ops_bucket_name           = "ahand-hub-prod"
+  manage_file_ops_bucket         = true
   openclaw_rds_host              = var.openclaw_rds_host
   openclaw_rds_security_group_id = var.openclaw_rds_security_group_id
   vpc_id                         = var.vpc_id

--- a/infra/modules/ahand-hub/iam.tf
+++ b/infra/modules/ahand-hub/iam.tf
@@ -109,13 +109,13 @@ resource "aws_iam_role_policy" "task" {
         Sid      = "FileOpsBucketLocation"
         Effect   = "Allow"
         Action   = ["s3:GetBucketLocation"]
-        Resource = aws_s3_bucket.file_ops.arn
+        Resource = local.selected_file_ops_bucket_arn
       },
       {
         Sid      = "FileOpsBucketList"
         Effect   = "Allow"
         Action   = ["s3:ListBucket"]
-        Resource = aws_s3_bucket.file_ops.arn
+        Resource = local.selected_file_ops_bucket_arn
         Condition = {
           StringLike = {
             "s3:prefix" = [
@@ -133,7 +133,7 @@ resource "aws_iam_role_policy" "task" {
           "s3:PutObject",
           "s3:DeleteObject",
         ]
-        Resource = "${aws_s3_bucket.file_ops.arn}/file-ops/*"
+        Resource = "${local.selected_file_ops_bucket_arn}/file-ops/*"
       },
     ]
   })

--- a/infra/modules/ahand-hub/outputs.tf
+++ b/infra/modules/ahand-hub/outputs.tf
@@ -10,5 +10,5 @@ output "task_role_arn" {
 
 output "file_ops_bucket_name" {
   description = "S3 bucket used by hub file operation staging in this env"
-  value       = aws_s3_bucket.file_ops.bucket
+  value       = local.selected_file_ops_bucket_name
 }

--- a/infra/modules/ahand-hub/s3.tf
+++ b/infra/modules/ahand-hub/s3.tf
@@ -1,4 +1,12 @@
+data "aws_s3_bucket" "file_ops" {
+  count = var.manage_file_ops_bucket ? 0 : 1
+
+  bucket = local.file_ops_bucket_name
+}
+
 resource "aws_s3_bucket" "file_ops" {
+  count = var.manage_file_ops_bucket ? 1 : 0
+
   bucket = local.file_ops_bucket_name
 
   tags = merge(local.common_tags, {
@@ -7,7 +15,9 @@ resource "aws_s3_bucket" "file_ops" {
 }
 
 resource "aws_s3_bucket_public_access_block" "file_ops" {
-  bucket = aws_s3_bucket.file_ops.id
+  count = var.manage_file_ops_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.file_ops[0].id
 
   block_public_acls       = true
   block_public_policy     = true
@@ -16,7 +26,9 @@ resource "aws_s3_bucket_public_access_block" "file_ops" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "file_ops" {
-  bucket = aws_s3_bucket.file_ops.id
+  count = var.manage_file_ops_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.file_ops[0].id
 
   rule {
     object_ownership = "BucketOwnerEnforced"
@@ -24,7 +36,9 @@ resource "aws_s3_bucket_ownership_controls" "file_ops" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "file_ops" {
-  bucket = aws_s3_bucket.file_ops.id
+  count = var.manage_file_ops_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.file_ops[0].id
 
   rule {
     apply_server_side_encryption_by_default {
@@ -34,7 +48,9 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "file_ops" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "file_ops" {
-  bucket = aws_s3_bucket.file_ops.id
+  count = var.manage_file_ops_bucket ? 1 : 0
+
+  bucket = aws_s3_bucket.file_ops[0].id
 
   rule {
     id     = "expire-file-ops-staging"
@@ -54,10 +70,41 @@ resource "aws_s3_bucket_lifecycle_configuration" "file_ops" {
   }
 }
 
+moved {
+  from = aws_s3_bucket.file_ops
+  to   = aws_s3_bucket.file_ops[0]
+}
+
+moved {
+  from = aws_s3_bucket_public_access_block.file_ops
+  to   = aws_s3_bucket_public_access_block.file_ops[0]
+}
+
+moved {
+  from = aws_s3_bucket_ownership_controls.file_ops
+  to   = aws_s3_bucket_ownership_controls.file_ops[0]
+}
+
+moved {
+  from = aws_s3_bucket_server_side_encryption_configuration.file_ops
+  to   = aws_s3_bucket_server_side_encryption_configuration.file_ops[0]
+}
+
+moved {
+  from = aws_s3_bucket_lifecycle_configuration.file_ops
+  to   = aws_s3_bucket_lifecycle_configuration.file_ops[0]
+}
+
+locals {
+  selected_file_ops_bucket_arn  = var.manage_file_ops_bucket ? aws_s3_bucket.file_ops[0].arn : data.aws_s3_bucket.file_ops[0].arn
+  selected_file_ops_bucket_id   = var.manage_file_ops_bucket ? aws_s3_bucket.file_ops[0].id : data.aws_s3_bucket.file_ops[0].id
+  selected_file_ops_bucket_name = var.manage_file_ops_bucket ? aws_s3_bucket.file_ops[0].bucket : data.aws_s3_bucket.file_ops[0].bucket
+}
+
 resource "aws_ssm_parameter" "s3_bucket" {
   name  = "/ahand-hub/${var.env}/S3_BUCKET"
   type  = "String"
-  value = aws_s3_bucket.file_ops.bucket
+  value = local.selected_file_ops_bucket_name
   tags  = local.common_tags
 }
 

--- a/infra/modules/ahand-hub/variables.tf
+++ b/infra/modules/ahand-hub/variables.tf
@@ -16,7 +16,7 @@ variable "aws_region" {
 variable "aws_account_id" {
   description = "AWS account ID"
   type        = string
-  default     = "471112576951"
+  default     = "149614785083"
 }
 
 variable "ecs_cluster_name" {
@@ -94,13 +94,25 @@ variable "s3_url_expiration_secs" {
 }
 
 variable "s3_file_ops_lifecycle_days" {
-  description = "Days to keep staged file-ops objects before S3 lifecycle expiration"
+  description = "Days to keep staged file-ops objects before S3 lifecycle expiration when this module manages the bucket"
   type        = number
   default     = 7
 }
 
+variable "file_ops_bucket_name" {
+  description = "Existing or managed S3 bucket name used by hub file operation staging. Defaults to the t9 bootstrap-owned bucket name."
+  type        = string
+  default     = null
+}
+
+variable "manage_file_ops_bucket" {
+  description = "Whether this module manages the file-ops S3 bucket and its controls. Leave false for t9 bootstrap-owned buckets."
+  type        = bool
+  default     = false
+}
+
 locals {
-  file_ops_bucket_name = "ahand-hub-${var.env}"
+  file_ops_bucket_name = coalesce(var.file_ops_bucket_name, "team9-ahand-hub-${var.env}")
 
   common_tags = {
     Environment = var.env

--- a/infra/shared/backend.tf
+++ b/infra/shared/backend.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "s3" {
-    bucket         = "weightwave-tfstate"
+    bucket         = "team9-tfstate"
     key            = "ahand-hub/shared/terraform.tfstate"
     region         = "us-east-1"
-    profile        = "ww"
+    profile        = "t9"
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
   }

--- a/infra/shared/providers.tf
+++ b/infra/shared/providers.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region  = "us-east-1"
-  profile = "ww"
+  profile = "t9"
 
   default_tags {
     tags = {

--- a/infra/shared/variables.tf
+++ b/infra/shared/variables.tf
@@ -1,7 +1,7 @@
 variable "aws_account_id" {
   description = "AWS account ID"
   type        = string
-  default     = "471112576951"
+  default     = "149614785083"
 }
 
 variable "aws_region" {


### PR DESCRIPTION
## Summary
- Retarget aHand hub dev Terraform/backend/deploy wiring from ww to t9.
- Point dev hub outputs and S3 file-ops settings at the migrated t9 resources.
- Keep prod compatibility while adding the t9 dev bucket and endpoint configuration.

## Verification
- terraform -chdir=infra/envs/dev fmt -check
- terraform -chdir=infra/envs/dev plan -detailed-exitcode -no-color => TF_EXIT_CODE=0
- git diff --check