### PR TITLE
feat(hub): control job output stream + completed-job access expiry

### DIFF
--- a/crates/ahand-hub/src/control_jobs.rs
+++ b/crates/ahand-hub/src/control_jobs.rs
@@ -17,18 +17,20 @@
 //! trackers filter by `job_id` so a control-plane job doesn't collide
 //! with a dashboard job.
 //!
-//! Cleanup semantics: an entry is removed as soon as a terminal event
-//! (`Finished` or `Error`) is published to it. Leaking subscribers
-//! don't matter — `tokio::broadcast` drops senders naturally when the
-//! entry goes out of scope, which in turn closes any SSE streams. If
-//! a daemon never emits a terminal event (crash without final frame),
-//! the entry stays until the hub is restarted — the dashboard job
-//! flow already relies on the WS disconnect path to finalize jobs, but
-//! control-plane jobs don't have that hook, so callers should set a
-//! sensible `timeout_ms` on the daemon side.
+//! Cleanup semantics: a live entry is removed as soon as a terminal
+//! event (`Finished` or `Error`) is published to it. We keep a small
+//! completed-access record for the same retention window as job output
+//! so late `/output` subscribers can still be authorized. Leaking
+//! subscribers don't matter — `tokio::broadcast` drops senders naturally
+//! when the live entry goes out of scope, which in turn closes any SSE
+//! streams. If a daemon never emits a terminal event (crash without
+//! final frame), the live entry stays until the hub is restarted — the
+//! dashboard job flow already relies on the WS disconnect path to
+//! finalize jobs, but control-plane jobs don't have that hook, so
+//! callers should set a sensible `timeout_ms` on the daemon side.
 
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 use tokio::sync::broadcast;
@@ -39,6 +41,7 @@ use tokio::sync::broadcast;
 /// subscriber that falls behind simply sees `RecvError::Lagged` and
 /// the stream ends.
 const JOB_EVENT_CHANNEL_CAPACITY: usize = 1024;
+const DEFAULT_COMPLETED_ACCESS_RETENTION: Duration = Duration::from_secs(60 * 60);
 
 /// Single control-plane job event delivered to SSE subscribers.
 ///
@@ -85,6 +88,12 @@ pub struct ControlJobAccess {
     pub external_user_id: String,
 }
 
+#[derive(Clone)]
+struct CompletedControlJobAccess {
+    access: ControlJobAccess,
+    completed_at: Instant,
+}
+
 impl JobChannels {
     /// Subscribe for incoming events. The returned receiver lives
     /// independently of this channel handle and is dropped by the
@@ -109,16 +118,38 @@ impl JobChannels {
 ///   so POSTs with the same correlation id from the same user are
 ///   idempotent without leaking ids across users (a user could
 ///   legitimately reuse a correlation id another user also picked).
-#[derive(Default)]
 pub struct ControlJobTracker {
     jobs: DashMap<String, Arc<JobChannels>>,
-    completed_access: DashMap<String, ControlJobAccess>,
+    completed_access: DashMap<String, CompletedControlJobAccess>,
     correlation_index: DashMap<String, String>,
+    completed_access_retention: Duration,
+}
+
+impl Default for ControlJobTracker {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ControlJobTracker {
     pub fn new() -> Self {
-        Self::default()
+        Self::new_with_completed_access_retention(DEFAULT_COMPLETED_ACCESS_RETENTION)
+    }
+
+    pub fn new_with_completed_access_retention(completed_access_retention: Duration) -> Self {
+        Self {
+            jobs: DashMap::new(),
+            completed_access: DashMap::new(),
+            correlation_index: DashMap::new(),
+            completed_access_retention,
+        }
+    }
+
+    fn prune_completed_access(&self) {
+        let now = Instant::now();
+        self.completed_access.retain(|_, entry| {
+            now.duration_since(entry.completed_at) <= self.completed_access_retention
+        });
     }
 
     /// Register a new job and return a handle to it. Safe to call
@@ -143,6 +174,7 @@ impl ControlJobTracker {
             self.correlation_index
                 .insert(correlation_key(&external_user_id, &cid), job_id.clone());
         }
+        self.prune_completed_access();
         self.completed_access.remove(&job_id);
         self.jobs.insert(job_id, channels.clone());
         channels
@@ -153,13 +185,16 @@ impl ControlJobTracker {
     }
 
     pub fn access(&self, job_id: &str) -> Option<ControlJobAccess> {
+        self.prune_completed_access();
         if let Some(channels) = self.jobs.get(job_id) {
             return Some(ControlJobAccess {
                 device_id: channels.device_id.clone(),
                 external_user_id: channels.external_user_id.clone(),
             });
         }
-        self.completed_access.get(job_id).map(|entry| entry.clone())
+        self.completed_access
+            .get(job_id)
+            .map(|entry| entry.access.clone())
     }
 
     /// Returns the existing `job_id` if the `(external_user_id,
@@ -205,9 +240,12 @@ impl ControlJobTracker {
         channels.send(event);
         self.completed_access.insert(
             job_id.to_string(),
-            ControlJobAccess {
-                device_id: channels.device_id.clone(),
-                external_user_id: channels.external_user_id.clone(),
+            CompletedControlJobAccess {
+                access: ControlJobAccess {
+                    device_id: channels.device_id.clone(),
+                    external_user_id: channels.external_user_id.clone(),
+                },
+                completed_at: Instant::now(),
             },
         );
         if let Some(cid) = &channels.correlation_id {
@@ -345,6 +383,20 @@ mod tests {
         );
         assert_eq!(t.find_by_correlation("user", "corr"), None);
         assert!(t.is_empty());
+    }
+
+    #[test]
+    fn completed_access_expires_after_retention() {
+        let t = ControlJobTracker::new_with_completed_access_retention(Duration::ZERO);
+        t.register("job-1".into(), "dev".into(), "user".into(), None);
+        t.finalize(
+            "job-1",
+            ControlJobEvent::Finished {
+                exit_code: 0,
+                duration_ms: 5,
+            },
+        );
+        assert_eq!(t.access("job-1"), None);
     }
 
     #[test]

--- a/crates/ahand-hub/src/control_jobs.rs
+++ b/crates/ahand-hub/src/control_jobs.rs
@@ -79,6 +79,12 @@ pub struct JobChannels {
     pub started_at: Instant,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ControlJobAccess {
+    pub device_id: String,
+    pub external_user_id: String,
+}
+
 impl JobChannels {
     /// Subscribe for incoming events. The returned receiver lives
     /// independently of this channel handle and is dropped by the
@@ -106,6 +112,7 @@ impl JobChannels {
 #[derive(Default)]
 pub struct ControlJobTracker {
     jobs: DashMap<String, Arc<JobChannels>>,
+    completed_access: DashMap<String, ControlJobAccess>,
     correlation_index: DashMap<String, String>,
 }
 
@@ -136,12 +143,23 @@ impl ControlJobTracker {
             self.correlation_index
                 .insert(correlation_key(&external_user_id, &cid), job_id.clone());
         }
+        self.completed_access.remove(&job_id);
         self.jobs.insert(job_id, channels.clone());
         channels
     }
 
     pub fn get(&self, job_id: &str) -> Option<Arc<JobChannels>> {
         self.jobs.get(job_id).map(|entry| entry.clone())
+    }
+
+    pub fn access(&self, job_id: &str) -> Option<ControlJobAccess> {
+        if let Some(channels) = self.jobs.get(job_id) {
+            return Some(ControlJobAccess {
+                device_id: channels.device_id.clone(),
+                external_user_id: channels.external_user_id.clone(),
+            });
+        }
+        self.completed_access.get(job_id).map(|entry| entry.clone())
     }
 
     /// Returns the existing `job_id` if the `(external_user_id,
@@ -185,6 +203,13 @@ impl ControlJobTracker {
             return;
         };
         channels.send(event);
+        self.completed_access.insert(
+            job_id.to_string(),
+            ControlJobAccess {
+                device_id: channels.device_id.clone(),
+                external_user_id: channels.external_user_id.clone(),
+            },
+        );
         if let Some(cid) = &channels.correlation_id {
             let key = correlation_key(&channels.external_user_id, cid);
             // Only remove if the correlation entry still points at
@@ -311,6 +336,13 @@ mod tests {
             }
         );
         assert!(t.get("job-1").is_none());
+        assert_eq!(
+            t.access("job-1"),
+            Some(ControlJobAccess {
+                device_id: "dev".into(),
+                external_user_id: "user".into(),
+            })
+        );
         assert_eq!(t.find_by_correlation("user", "corr"), None);
         assert!(t.is_empty());
     }

--- a/crates/ahand-hub/src/http/control_plane.rs
+++ b/crates/ahand-hub/src/http/control_plane.rs
@@ -39,7 +39,7 @@ use axum::Json;
 use axum::Router;
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{Path, Request, State};
-use axum::http::{HeaderValue, StatusCode, header::AUTHORIZATION};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header::AUTHORIZATION};
 use axum::middleware::{self, Next};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
@@ -62,6 +62,7 @@ pub fn router(state: AppState) -> Router<AppState> {
     Router::new()
         .route("/api/control/jobs", post(create_job))
         .route("/api/control/jobs/{id}/stream", get(stream_job))
+        .route("/api/control/jobs/{id}/output", get(stream_job_output))
         .route("/api/control/jobs/{id}/cancel", post(cancel_job))
         .route("/api/control/browser", post(browser_command_control))
         .route(
@@ -206,6 +207,7 @@ async fn create_job(
         claims.external_user_id.clone(),
         req.correlation_id.clone().filter(|cid| !cid.is_empty()),
     );
+    state.output_stream.prime(&job_id);
 
     let timeout_ms = req.timeout_ms.unwrap_or(DEFAULT_JOB_TIMEOUT_MS);
     let envelope = ahand_protocol::Envelope {
@@ -269,11 +271,19 @@ fn spawn_control_job_timeout(state: AppState, job_id: String, device_id: String,
         };
         let _ = state.connections.send_envelope(&device_id, cancel).await;
 
+        let message = format!("job timed out after {timeout_ms}ms");
+        if let Err(err) = state
+            .output_stream
+            .push_finished(&job_id, 1, &message)
+            .await
+        {
+            tracing::warn!(job_id, error = %err, "failed recording control job timeout output");
+        }
         state.control_jobs.finalize(
             &job_id,
             ControlJobEvent::Error {
                 code: "timeout".into(),
-                message: format!("job timed out after {timeout_ms}ms"),
+                message,
             },
         );
     });
@@ -366,6 +376,62 @@ async fn stream_job(
             .interval(Duration::from_secs(15))
             .text("keepalive"),
     ))
+}
+
+async fn stream_job_output(
+    State(state): State<AppState>,
+    Extension(claims): Extension<ControlPlaneJwtClaims>,
+    headers: HeaderMap,
+    Path(job_id): Path<String>,
+) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, ControlError> {
+    if claims.scope != "jobs:execute" {
+        return Err(ControlError::Forbidden);
+    }
+    if state
+        .control_rate_limiter
+        .check_key(&claims.external_user_id)
+        .is_err()
+    {
+        return Err(ControlError::RateLimited);
+    }
+
+    let access = state
+        .control_jobs
+        .access(&job_id)
+        .ok_or(ControlError::JobNotFound)?;
+    if access.external_user_id != claims.external_user_id {
+        return Err(ControlError::JobNotFound);
+    }
+    if let Some(allowed) = &claims.device_ids
+        && !allowed.contains(&access.device_id)
+    {
+        return Err(ControlError::Forbidden);
+    }
+
+    let stream = state
+        .output_stream
+        .subscribe_from(job_id, parse_last_event_id(&headers)?)
+        .await
+        .map_err(|err| ControlError::Internal(err.to_string()))?;
+
+    Ok(Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(15))
+            .text("keepalive"),
+    ))
+}
+
+fn parse_last_event_id(headers: &HeaderMap) -> Result<Option<u64>, ControlError> {
+    let Some(value) = headers.get("last-event-id") else {
+        return Ok(None);
+    };
+    let raw = value
+        .to_str()
+        .map_err(|_| ControlError::BadRequest("Invalid Last-Event-ID header".into()))?;
+    let parsed = raw
+        .parse::<u64>()
+        .map_err(|_| ControlError::BadRequest("Invalid Last-Event-ID header".into()))?;
+    Ok(Some(parsed))
 }
 
 fn render_sse_event(event: &ControlJobEvent) -> Event {

--- a/crates/ahand-hub/src/state.rs
+++ b/crates/ahand-hub/src/state.rs
@@ -191,7 +191,11 @@ impl AppState {
         ));
 
         let browser_pending = Arc::new(DashMap::new());
-        let control_jobs = Arc::new(crate::control_jobs::ControlJobTracker::new());
+        let control_jobs = Arc::new(
+            crate::control_jobs::ControlJobTracker::new_with_completed_access_retention(
+                finished_retention,
+            ),
+        );
         let control_rate_limiter = Arc::new(default_control_plane_rate_limiter());
 
         // Webhook dispatcher — always present. When the URL/secret are

--- a/crates/ahand-hub/src/ws/device_gateway.rs
+++ b/crates/ahand-hub/src/ws/device_gateway.rs
@@ -854,7 +854,7 @@ async fn run_device_socket(socket: WebSocket, state: AppState) -> anyhow::Result
                         }
                         state.connections.observe_inbound(&device_id, envelope.seq, envelope.ack).await?;
                         queue_ack_only(&control_tx, &device_id, envelope.seq)?;
-                    } else if dispatch_control_plane_event(&state, &envelope) {
+                    } else if dispatch_control_plane_event(&state, &envelope).await {
                         // The control-plane tracker handled the frame, or
                         // the job id is a stale non-dashboard id that must
                         // not fall into JobRuntime's UUID-backed store.
@@ -1015,7 +1015,10 @@ fn queue_ack_only(
 /// UUID-backed runtime trying to parse a control-plane ULID. Returns `false`
 /// otherwise (not job-related, or a dashboard / JobRuntime job id the caller
 /// still needs to process).
-fn dispatch_control_plane_event(state: &AppState, envelope: &ahand_protocol::Envelope) -> bool {
+async fn dispatch_control_plane_event(
+    state: &AppState,
+    envelope: &ahand_protocol::Envelope,
+) -> bool {
     let Some(payload) = envelope.payload.as_ref() else {
         return false;
     };
@@ -1047,6 +1050,35 @@ fn dispatch_control_plane_event(state: &AppState, envelope: &ahand_protocol::Env
                     }
                 }
             };
+            match kind {
+                ahand_protocol::job_event::Event::StdoutChunk(chunk) => {
+                    if let Err(err) = state
+                        .output_stream
+                        .push_stdout(&event.job_id, chunk.clone())
+                        .await
+                    {
+                        tracing::warn!(job_id = %event.job_id, error = %err, "failed recording control job stdout");
+                    }
+                }
+                ahand_protocol::job_event::Event::StderrChunk(chunk) => {
+                    if let Err(err) = state
+                        .output_stream
+                        .push_stderr(&event.job_id, chunk.clone())
+                        .await
+                    {
+                        tracing::warn!(job_id = %event.job_id, error = %err, "failed recording control job stderr");
+                    }
+                }
+                ahand_protocol::job_event::Event::Progress(percent) => {
+                    if let Err(err) = state
+                        .output_stream
+                        .push_progress(&event.job_id, (*percent).min(100))
+                        .await
+                    {
+                        tracing::warn!(job_id = %event.job_id, error = %err, "failed recording control job progress");
+                    }
+                }
+            }
             state.control_jobs.publish(&event.job_id, control_event);
             true
         }
@@ -1082,12 +1114,26 @@ fn dispatch_control_plane_event(state: &AppState, envelope: &ahand_protocol::Env
                     },
                 }
             };
+            if let Err(err) = state
+                .output_stream
+                .push_finished(&finished.job_id, finished.exit_code, &finished.error)
+                .await
+            {
+                tracing::warn!(job_id = %finished.job_id, error = %err, "failed recording control job finish");
+            }
             state.control_jobs.finalize(&finished.job_id, event);
             true
         }
         ahand_protocol::envelope::Payload::JobRejected(rejected) => {
             if state.control_jobs.get(&rejected.job_id).is_none() {
                 return consume_unknown_non_dashboard_job_id(&rejected.job_id, "JobRejected");
+            }
+            if let Err(err) = state
+                .output_stream
+                .push_finished(&rejected.job_id, 1, &rejected.reason)
+                .await
+            {
+                tracing::warn!(job_id = %rejected.job_id, error = %err, "failed recording control job rejection");
             }
             state.control_jobs.finalize(
                 &rejected.job_id,

--- a/crates/ahand-hub/tests/control_plane.rs
+++ b/crates/ahand-hub/tests/control_plane.rs
@@ -1726,6 +1726,103 @@ async fn sse_late_joiner_after_terminal_event_gets_empty_stream() {
     server.shutdown().await;
 }
 
+#[tokio::test]
+async fn control_job_output_stream_replays_after_terminal_event() {
+    let server = spawn_server_with_state(test_state().await).await;
+    let mut device = attach_owned_device(&server, "cp-output", "user-output").await;
+    let token = mint_cp_jwt(&server, "user-output");
+
+    let job_id = post_create_job(
+        &server,
+        &token,
+        serde_json::json!({ "deviceId": "cp-output", "tool": "echo" }),
+    )
+    .await
+    .json::<serde_json::Value>()
+    .await
+    .unwrap()["jobId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let _ = recv_job_request(&mut device).await;
+
+    send_envelope(
+        &mut device,
+        ahand_protocol::Envelope {
+            device_id: "cp-output".into(),
+            msg_id: "output-1".into(),
+            ts_ms: now_ms(),
+            payload: Some(envelope::Payload::JobEvent(ahand_protocol::JobEvent {
+                job_id: job_id.clone(),
+                event: Some(ahand_protocol::job_event::Event::StdoutChunk(
+                    b"streamed line\n".to_vec(),
+                )),
+            })),
+            ..Default::default()
+        },
+    )
+    .await;
+    send_envelope(
+        &mut device,
+        ahand_protocol::Envelope {
+            device_id: "cp-output".into(),
+            msg_id: "output-finished".into(),
+            ts_ms: now_ms(),
+            payload: Some(envelope::Payload::JobFinished(
+                ahand_protocol::JobFinished {
+                    job_id: job_id.clone(),
+                    exit_code: 0,
+                    error: String::new(),
+                },
+            )),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    for _ in 0..50 {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        if server.state().control_jobs.get(&job_id).is_none() {
+            break;
+        }
+    }
+    assert!(
+        server.state().control_jobs.get(&job_id).is_none(),
+        "control job tracker should be finalized before late output subscribe"
+    );
+
+    let resp = reqwest::Client::new()
+        .get(format!(
+            "{}/api/control/jobs/{job_id}/output",
+            server.http_base_url()
+        ))
+        .bearer_auth(&token)
+        .header("Accept", "text/event-stream")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let mut stream = resp.bytes_stream();
+    let mut body = String::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.unwrap();
+        body.push_str(&String::from_utf8_lossy(&chunk));
+        if body.contains("event: finished") {
+            break;
+        }
+    }
+
+    assert!(body.contains("id: 1"), "body was: {body}");
+    assert!(body.contains("event: stdout"), "body was: {body}");
+    assert!(body.contains("data: streamed line"), "body was: {body}");
+    assert!(body.contains("event: finished"), "body was: {body}");
+    assert!(body.contains(r#""exit_code":0"#), "body was: {body}");
+
+    drop(device);
+    server.shutdown().await;
+}
+
 // ── R2-1: device_ids allowlist enforcement ────────────────────────────────────
 
 #[tokio::test]

--- a/packages/sdk/src/cloud-client.test.ts
+++ b/packages/sdk/src/cloud-client.test.ts
@@ -120,6 +120,29 @@ describe("CloudClient.spawn", () => {
     expect(calls[1].init?.headers).toMatchObject({ Authorization: "Bearer test-token" });
   });
 
+  it("notifies callers of the hub job id before streaming output", async () => {
+    const { fn } = mockFetch([
+      () => jsonResponse({ jobId: "job-001" }, 201),
+      () =>
+        sseResponse([
+          sseEvent("stdout", { chunk: "hello" }),
+          sseEvent("finished", { exitCode: 0, durationMs: 123 }),
+        ]),
+    ]);
+
+    const client = new CloudClient({ ...BASE_OPTS, fetch: fn });
+    const events: string[] = [];
+
+    await client.spawn({
+      deviceId: "dev-1",
+      tool: "bash",
+      onJobStarted: ({ jobId }) => events.push(`started:${jobId}`),
+      onStdout: (chunk) => events.push(`stdout:${chunk}`),
+    });
+
+    expect(events).toEqual(["started:job-001", "stdout:hello"]);
+  });
+
   it("sends optional fields (env, cwd, timeoutMs, correlationId, interactive)", async () => {
     const { fn, calls } = mockFetch([
       () => jsonResponse({ jobId: "job-x" }, 201),

--- a/packages/sdk/src/cloud-client.ts
+++ b/packages/sdk/src/cloud-client.ts
@@ -67,6 +67,11 @@ export interface SpawnParams {
   /** Callback for progress events. Thrown errors are swallowed. */
   onProgress?: (p: { percent: number; message?: string }) => void;
   /**
+   * Callback fired after the hub accepts the job and returns its id,
+   * before the SDK opens the SSE stream. Thrown errors are swallowed.
+   */
+  onJobStarted?: (job: { jobId: string }) => void;
+  /**
    * AbortSignal — aborting triggers best-effort
    * `POST /cancel` + closes SSE + rejects with an `abort` error.
    */
@@ -1206,6 +1211,13 @@ export class CloudClient {
         "Hub response missing jobId",
         { httpStatus: postRes.status },
       );
+    }
+    if (p.onJobStarted) {
+      try {
+        p.onJobStarted({ jobId });
+      } catch {
+        // Swallow — user callback's problem.
+      }
     }
 
     // Subscribe to the SSE stream. From here on, an abort triggers a


### PR DESCRIPTION
## Summary

Brings the two dev-only commits into main (dev↔main bidirectional sync, part 1):

- `feat: expose control job output stream` — stream control-job output
- `fix: expire completed control job access` — completed jobs no longer remain accessible indefinitely

After this merges, main will be merged back into dev to refresh it with plugin-runtime + M1 cross-platform work (dev is currently 69 commits behind).

## Test Plan
- [ ] hub-ci (rust/compose/dashboard) green on this PR
- [ ] client-ci green (no client-crate changes expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)