### PR TITLE
fix(ahandd): bound app-tool approval wait by the invocation deadline

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,11 @@ const result  = await client.invokeAppTool(deviceId, "run_analysis", { dataset: 
 
 Session-mode gating applies to every invocation. `requires_approval: true` on a descriptor forces explicit approval regardless of the caller's session mode.
 
-> **Approval + timeout composition:** the hub waits at most `clamp(timeoutMs)+2 s ≤ 302 s` for
-> the daemon to respond, while the daemon's approval dialog defaults to a 24 h window. For
-> approval-gated tools, set `timeoutMs` ≥ expected approval latency (max 300 000 ms); an
-> approval granted after the hub window still executes the handler, but the result is discarded
-> and the audit `outcome` remains `timeout`. Correlate via a replay of the same call if needed.
+> **Approval + timeout composition:** the approval wait on the daemon side is bounded by
+> `min(approval policy timeout, clamp(timeoutMs))` — the request's clamped `timeoutMs` caps
+> the user's time to answer the dialog. A late approval finds the request already expired and
+> nothing executes. Set `timeoutMs` ≥ expected approval latency (max 300 000 ms); the request
+> timeout is now the hard deadline for both approval and execution.
 
 See `proto/ahand/v1/app_tool.proto` and `docs/remote-control-roadmap.md` (Section 5) for the full capability description.
 

--- a/crates/ahandd/src/ahand_client.rs
+++ b/crates/ahandd/src/ahand_client.rs
@@ -1888,6 +1888,13 @@ fn app_tool_result_envelope(device_id: &str, tool_call_id: &str, result_json: St
 /// approval waiter; here the entire execution is spawned because handler
 /// duration is unbounded (up to MAX_TIMEOUT_MS = 300s).
 ///
+/// Timeout semantics: `timeout_ms` bounds the WHOLE invocation (approval +
+/// execution). Approval wait = min(approval_timeout, clamp_timeout(timeout_ms));
+/// execution gets the remaining budget (floored at MIN_TIMEOUT_MS). This ensures
+/// the hub's `clamped_timeout + 2s` window always covers the daemon-side outcome
+/// and eliminates ghost execution (where a late approval would run a handler
+/// whose result nobody can receive because the hub has already moved on).
+///
 /// The approval waiter intentionally does NOT watch `close_rx` (unlike file-request
 /// waiters): the response rides the stamped outbox so a result produced across a
 /// reconnect is replayed to the hub; the cost is an orphaned waiter for up to
@@ -2064,7 +2071,15 @@ async fn handle_app_tool_request<T>(
         let tool_name = req.name.clone();
         let args_json = req.args_json.clone();
         let timeout_ms_req = req.timeout_ms;
-        let timeout = amgr.default_timeout();
+        // The call's clamped timeout is the TOTAL deadline for approval +
+        // execution. Bounding the approval wait by it guarantees the hub's
+        // `clamped + 2s` wait always covers the daemon-side outcome — no ghost
+        // execution after the caller's window closed (the hub mints a fresh
+        // tool_call_id per POST, so a late result would be unreachable anyway).
+        let total_deadline_ms = AppToolRegistry::clamp_timeout(timeout_ms_req);
+        let timeout = amgr
+            .default_timeout()
+            .min(Duration::from_millis(total_deadline_ms as u64));
         let approval_job_id_clone = approval_job_id.clone();
 
         tokio::spawn(async move {
@@ -2072,10 +2087,19 @@ async fn handle_app_tool_request<T>(
             let result = tokio::time::timeout(timeout, approval_rx).await;
             match result {
                 Ok(Ok(resp)) if resp.approved => {
+                    let approval_wait_ms = started.elapsed().as_millis() as u64;
+                    // Execution gets what's left of the total deadline
+                    // (clamp_timeout inside validate_and_execute floors this
+                    // at MIN_TIMEOUT_MS).
+                    let remaining_ms = (total_deadline_ms as u64)
+                        .saturating_sub(approval_wait_ms)
+                        .max(crate::app_tool_registry::MIN_TIMEOUT_MS as u64)
+                        as u32;
                     info!(
                         tool_call_id = %tool_call_id,
                         tool_name = %tool_name,
-                        approval_wait_ms = started.elapsed().as_millis() as u64,
+                        approval_wait_ms,
+                        remaining_ms,
                         "app tool approval granted"
                     );
                     // Proceed to args parse → permit → execute inside this task.
@@ -2084,7 +2108,7 @@ async fn handle_app_tool_request<T>(
                         tool_call_id,
                         tool_name,
                         args_json,
-                        timeout_ms_req,
+                        remaining_ms,
                         handler,
                         &tx_clone,
                         &app_tools_clone,

--- a/crates/ahandd/src/ahand_client.rs
+++ b/crates/ahandd/src/ahand_client.rs
@@ -1897,8 +1897,9 @@ fn app_tool_result_envelope(device_id: &str, tool_call_id: &str, result_json: St
 ///
 /// The approval waiter intentionally does NOT watch `close_rx` (unlike file-request
 /// waiters): the response rides the stamped outbox so a result produced across a
-/// reconnect is replayed to the hub; the cost is an orphaned waiter for up to
-/// `approval_timeout` (default 24 h) if the hub never responds after disconnect.
+/// reconnect is replayed to the hub; the cost is an orphaned waiter for at most
+/// `min(approval_timeout, 300 s)` for app tools — not watching `close_rx` is
+/// therefore cheap, because the waiter self-cancels within the invocation deadline.
 #[allow(clippy::too_many_arguments)]
 async fn handle_app_tool_request<T>(
     device_id: &str,
@@ -2039,6 +2040,23 @@ async fn handle_app_tool_request<T>(
             "app tool requires approval"
         );
 
+        // Compute the bounded approval-wait timeout BEFORE submitting so the
+        // advertised expires_ms in the ApprovalRequest matches the window the
+        // waiter actually uses (dial + dialog UI both show this value).
+        let timeout_ms_req = req.timeout_ms;
+        // The call's clamped timeout is the TOTAL deadline for approval +
+        // execution. Bounding the approval wait by it guarantees the hub's
+        // `clamped + 2s` wait always covers the daemon-side outcome — no ghost
+        // execution after the caller's window closed (the hub mints a fresh
+        // tool_call_id per POST, so a late result would be unreachable anyway).
+        // The operator's approval_timeout remains an upper bound — a caller's
+        // timeout_ms can shrink the window but never extend it beyond what the
+        // approval policy permits.
+        let total_deadline_ms = AppToolRegistry::clamp_timeout(timeout_ms_req);
+        let timeout = approval_mgr
+            .default_timeout()
+            .min(Duration::from_millis(total_deadline_ms as u64));
+
         // Mark running BEFORE sending the ApprovalRequest so that a
         // duplicate request arriving while approval is pending sees Running
         // and is silently ignored (idempotency window is closed now).
@@ -2046,7 +2064,13 @@ async fn handle_app_tool_request<T>(
         app_tools.mark_running(&req.tool_call_id).await;
 
         let (approval_req, approval_rx) = approval_mgr
-            .submit(synthetic.clone(), caller_uid, reason, previous_refusals)
+            .submit_with_timeout(
+                synthetic.clone(),
+                caller_uid,
+                reason,
+                previous_refusals,
+                timeout,
+            )
             .await;
 
         // Send ApprovalRequest to cloud via WS.
@@ -2070,16 +2094,6 @@ async fn handle_app_tool_request<T>(
         let tool_call_id = req.tool_call_id.clone();
         let tool_name = req.name.clone();
         let args_json = req.args_json.clone();
-        let timeout_ms_req = req.timeout_ms;
-        // The call's clamped timeout is the TOTAL deadline for approval +
-        // execution. Bounding the approval wait by it guarantees the hub's
-        // `clamped + 2s` wait always covers the daemon-side outcome — no ghost
-        // execution after the caller's window closed (the hub mints a fresh
-        // tool_call_id per POST, so a late result would be unreachable anyway).
-        let total_deadline_ms = AppToolRegistry::clamp_timeout(timeout_ms_req);
-        let timeout = amgr
-            .default_timeout()
-            .min(Duration::from_millis(total_deadline_ms as u64));
         let approval_job_id_clone = approval_job_id.clone();
 
         tokio::spawn(async move {

--- a/crates/ahandd/src/approval.rs
+++ b/crates/ahandd/src/approval.rs
@@ -41,6 +41,9 @@ impl ApprovalManager {
 
     /// Submit a job that needs approval. Returns the ApprovalRequest to broadcast
     /// and a oneshot Receiver that the caller awaits (with timeout).
+    ///
+    /// The advertised `expires_ms` is set to `now + default_timeout`, matching
+    /// the window used for job and file requests.
     pub async fn submit(
         &self,
         req: JobRequest,
@@ -48,8 +51,29 @@ impl ApprovalManager {
         reason: String,
         previous_refusals: Vec<RefusalContext>,
     ) -> (ApprovalRequest, oneshot::Receiver<ApprovalResponse>) {
+        self.submit_with_timeout(
+            req,
+            caller_uid,
+            reason,
+            previous_refusals,
+            self.default_timeout,
+        )
+        .await
+    }
+
+    /// Like `submit`, but with an explicit wait bound for this request — the
+    /// advertised `expires_ms` must match when the waiter actually gives up.
+    /// Job/file callers keep using `submit` (default_timeout applies).
+    pub async fn submit_with_timeout(
+        &self,
+        req: JobRequest,
+        caller_uid: &str,
+        reason: String,
+        previous_refusals: Vec<RefusalContext>,
+        timeout: Duration,
+    ) -> (ApprovalRequest, oneshot::Receiver<ApprovalResponse>) {
         let (tx, rx) = oneshot::channel();
-        let expires_ms = now_ms() + self.default_timeout.as_millis() as u64;
+        let expires_ms = now_ms() + timeout.as_millis() as u64;
 
         let approval_req = ApprovalRequest {
             job_id: req.job_id.clone(),
@@ -121,4 +145,85 @@ fn now_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ahand_protocol::JobRequest;
+
+    fn make_job_request(job_id: &str) -> JobRequest {
+        JobRequest {
+            job_id: job_id.to_string(),
+            tool: "test_tool".to_string(),
+            cwd: "/tmp".to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// submit_with_timeout: expires_ms ≈ now + bound (±2 s tolerance).
+    #[tokio::test]
+    async fn submit_with_timeout_sets_correct_expiry() {
+        let mgr = ApprovalManager::new(86400); // 24 h default_timeout
+        let bound = Duration::from_secs(5);
+        let before_ms = now_ms();
+        let (approval_req, _rx) = mgr
+            .submit_with_timeout(
+                make_job_request("job-1"),
+                "uid-1",
+                "reason".to_string(),
+                vec![],
+                bound,
+            )
+            .await;
+        let after_ms = now_ms();
+
+        let expected_lo = before_ms + bound.as_millis() as u64;
+        let expected_hi = after_ms + bound.as_millis() as u64;
+        assert!(
+            approval_req.expires_ms >= expected_lo,
+            "expires_ms {} below lower bound {}",
+            approval_req.expires_ms,
+            expected_lo
+        );
+        assert!(
+            approval_req.expires_ms <= expected_hi + 2_000,
+            "expires_ms {} exceeds upper bound {} + 2 s slack",
+            approval_req.expires_ms,
+            expected_hi
+        );
+    }
+
+    /// submit delegates to submit_with_timeout using default_timeout.
+    /// Verify expires_ms ≈ now + default_timeout (not the explicit bound).
+    #[tokio::test]
+    async fn submit_uses_default_timeout_for_expiry() {
+        let default_secs: u64 = 60;
+        let mgr = ApprovalManager::new(default_secs);
+        let before_ms = now_ms();
+        let (approval_req, _rx) = mgr
+            .submit(
+                make_job_request("job-2"),
+                "uid-2",
+                "reason".to_string(),
+                vec![],
+            )
+            .await;
+        let after_ms = now_ms();
+
+        let expected_lo = before_ms + default_secs * 1_000;
+        let expected_hi = after_ms + default_secs * 1_000;
+        assert!(
+            approval_req.expires_ms >= expected_lo,
+            "expires_ms {} below lower bound {}",
+            approval_req.expires_ms,
+            expected_lo
+        );
+        assert!(
+            approval_req.expires_ms <= expected_hi + 2_000,
+            "expires_ms {} exceeds upper bound {} + 2 s slack",
+            approval_req.expires_ms,
+            expected_hi
+        );
+    }
 }

--- a/crates/ahandd/tests/app_tools.rs
+++ b/crates/ahandd/tests/app_tools.rs
@@ -1614,3 +1614,146 @@ async fn second_invocation_sees_one_previous_refusal() {
 
     handle.shutdown().await.expect("shutdown clean");
 }
+
+// ── Task 1: approval wait bounded by the invocation deadline ─────────────────
+
+/// Task 1 / Case A: approval_timeout_secs=3600, timeout_ms=2_000.
+/// Nobody approves → APPROVAL_TIMEOUT fires from the request deadline, elapsed < 6s.
+#[tokio::test]
+async fn approval_wait_is_bounded_by_request_timeout() {
+    let (mock, handle, _tmp) = setup_gated_daemon(SessionMode::Strict, 3600).await;
+    let run_count = Arc::new(AtomicUsize::new(0));
+    register_counted_echo(&handle, "bounded_echo", false, Arc::clone(&run_count)).await;
+    mock.wait_for_app_tools_updates(2, Duration::from_secs(5))
+        .await
+        .expect("tool snapshot");
+    let started = std::time::Instant::now();
+    mock.send_app_tool_request("call-bounded-timeout", "bounded_echo", r#"{}"#, 2_000)
+        .expect("send ok");
+    mock.wait_for_approval_requests(1, Duration::from_secs(5))
+        .await
+        .expect("ApprovalRequest not received within 5s");
+    let responses = mock
+        .wait_for_app_tool_responses(1, Duration::from_secs(8))
+        .await
+        .expect("APPROVAL_TIMEOUT response not received within 8s");
+    let elapsed = started.elapsed();
+    let resp = &responses[0];
+    assert_eq!(resp.tool_call_id, "call-bounded-timeout");
+    match &resp.result {
+        Some(app_tool_response::Result::Error(err)) => {
+            assert_eq!(
+                err.code, "APPROVAL_TIMEOUT",
+                "expected APPROVAL_TIMEOUT, got: {}",
+                err.code
+            );
+        }
+        other => panic!("expected APPROVAL_TIMEOUT error, got {other:?}"),
+    }
+    assert!(
+        elapsed < Duration::from_secs(6),
+        "approval wait must be bounded by timeout_ms=2s not 3600s; elapsed={elapsed:?}"
+    );
+    assert_eq!(run_count.load(Ordering::SeqCst), 0, "handler must not run");
+    handle.shutdown().await.expect("shutdown clean");
+}
+
+/// Task 1 / Case B: approval_timeout_secs=3600, timeout_ms=10_000.
+/// Approve after ApprovalRequest arrives → ResultJson, handler ran once.
+#[tokio::test]
+async fn approve_within_deadline_executes_with_remaining_budget() {
+    let (mock, handle, _tmp) = setup_gated_daemon(SessionMode::Strict, 3600).await;
+    let run_count = Arc::new(AtomicUsize::new(0));
+    register_counted_echo(&handle, "budget_echo", false, Arc::clone(&run_count)).await;
+    mock.wait_for_app_tools_updates(2, Duration::from_secs(5))
+        .await
+        .expect("tool snapshot");
+    mock.send_app_tool_request("call-budget-approve", "budget_echo", r#"{}"#, 10_000)
+        .expect("send ok");
+    let approval_reqs = mock
+        .wait_for_approval_requests(1, Duration::from_secs(5))
+        .await
+        .expect("ApprovalRequest not received within 5s");
+    assert_eq!(
+        approval_reqs[0].job_id, "app-tool:call-budget-approve",
+        "job_id must be namespaced"
+    );
+    mock.send_approval_response("app-tool:call-budget-approve", true, "")
+        .expect("send approval ok");
+    let responses = mock
+        .wait_for_app_tool_responses(1, Duration::from_secs(8))
+        .await
+        .expect("AppToolResponse not received within 8s after approval");
+    let resp = &responses[0];
+    assert_eq!(resp.tool_call_id, "call-budget-approve");
+    assert!(
+        matches!(&resp.result, Some(app_tool_response::Result::ResultJson(_))),
+        "expected ResultJson after approval, got {:?}",
+        resp.result
+    );
+    assert_eq!(run_count.load(Ordering::SeqCst), 1, "handler ran once");
+    handle.shutdown().await.expect("shutdown clean");
+}
+
+/// Task 1 / Case C: approval_timeout_secs=3600, timeout_ms=3_000.
+/// Sleep 1_500ms after ApprovalRequest, then approve → remaining budget ≈1.5s
+/// (floored at MIN_TIMEOUT_MS). Handler sleeps 60s → EXECUTION_TIMEOUT fires.
+/// Total elapsed < 8s.
+#[tokio::test]
+async fn approval_consuming_budget_shrinks_execution_timeout() {
+    let (mock, handle, _tmp) = setup_gated_daemon(SessionMode::Strict, 3600).await;
+    let run_count = Arc::new(AtomicUsize::new(0));
+    let def = AppToolDef {
+        name: "slow_approved_tool".into(),
+        description: "Sleeps 60s".into(),
+        input_schema: json!({"type": "object", "properties": {}}),
+        requires_approval: true,
+    };
+    let run_count_clone = Arc::clone(&run_count);
+    let handler: AppToolHandler = Arc::new(move |_args| {
+        let c = Arc::clone(&run_count_clone);
+        Box::pin(async move {
+            c.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            Ok(json!({"done": true}))
+        })
+    });
+    handle
+        .register_app_tool(def, handler)
+        .await
+        .expect("register ok");
+    mock.wait_for_app_tools_updates(2, Duration::from_secs(5))
+        .await
+        .expect("tool snapshot");
+    let started = std::time::Instant::now();
+    mock.send_app_tool_request("call-shrink-budget", "slow_approved_tool", r#"{}"#, 3_000)
+        .expect("send ok");
+    mock.wait_for_approval_requests(1, Duration::from_secs(5))
+        .await
+        .expect("ApprovalRequest not received within 5s");
+    tokio::time::sleep(Duration::from_millis(1_500)).await;
+    mock.send_approval_response("app-tool:call-shrink-budget", true, "")
+        .expect("send approval ok");
+    let responses = mock
+        .wait_for_app_tool_responses(1, Duration::from_secs(8))
+        .await
+        .expect("EXECUTION_TIMEOUT response not received within 8s");
+    let elapsed = started.elapsed();
+    let resp = &responses[0];
+    assert_eq!(resp.tool_call_id, "call-shrink-budget");
+    match &resp.result {
+        Some(app_tool_response::Result::Error(err)) => {
+            assert_eq!(
+                err.code, "EXECUTION_TIMEOUT",
+                "expected EXECUTION_TIMEOUT, got: {}",
+                err.code
+            );
+        }
+        other => panic!("expected EXECUTION_TIMEOUT error, got {other:?}"),
+    }
+    assert!(
+        elapsed < Duration::from_secs(8),
+        "total elapsed must be < 8s; elapsed={elapsed:?}"
+    );
+    handle.shutdown().await.expect("shutdown clean");
+}

--- a/crates/ahandd/tests/app_tools.rs
+++ b/crates/ahandd/tests/app_tools.rs
@@ -1615,10 +1615,11 @@ async fn second_invocation_sees_one_previous_refusal() {
     handle.shutdown().await.expect("shutdown clean");
 }
 
-// ── Task 1: approval wait bounded by the invocation deadline ─────────────────
+// ── Approval deadline bound (2026-06-12 plan) ─────────────────────────────────
 
-/// Task 1 / Case A: approval_timeout_secs=3600, timeout_ms=2_000.
+/// Approval deadline / Case A: approval_timeout_secs=3600, timeout_ms=2_000.
 /// Nobody approves → APPROVAL_TIMEOUT fires from the request deadline, elapsed < 6s.
+/// Also verifies that expires_ms ≤ now + clamped_timeout + 2 s slack (NOT 24 h out).
 #[tokio::test]
 async fn approval_wait_is_bounded_by_request_timeout() {
     let (mock, handle, _tmp) = setup_gated_daemon(SessionMode::Strict, 3600).await;
@@ -1627,12 +1628,30 @@ async fn approval_wait_is_bounded_by_request_timeout() {
     mock.wait_for_app_tools_updates(2, Duration::from_secs(5))
         .await
         .expect("tool snapshot");
+    let send_time_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
     let started = std::time::Instant::now();
     mock.send_app_tool_request("call-bounded-timeout", "bounded_echo", r#"{}"#, 2_000)
         .expect("send ok");
-    mock.wait_for_approval_requests(1, Duration::from_secs(5))
+    let approval_reqs = mock
+        .wait_for_approval_requests(1, Duration::from_secs(5))
         .await
         .expect("ApprovalRequest not received within 5s");
+    // expires_ms must reflect the clamped invocation deadline (2 s), not the
+    // operator's 3600-second default.  Allow 2 s slack for scheduling jitter.
+    let clamped_timeout_ms: u64 = 2_000;
+    let slack_ms: u64 = 2_000;
+    let max_expected_expires_ms = send_time_ms + clamped_timeout_ms + slack_ms;
+    assert!(
+        approval_reqs[0].expires_ms <= max_expected_expires_ms,
+        "expires_ms={} should be ≤ now+{}ms+{}ms_slack={} (not 24h out)",
+        approval_reqs[0].expires_ms,
+        clamped_timeout_ms,
+        slack_ms,
+        max_expected_expires_ms
+    );
     let responses = mock
         .wait_for_app_tool_responses(1, Duration::from_secs(8))
         .await
@@ -1658,7 +1677,7 @@ async fn approval_wait_is_bounded_by_request_timeout() {
     handle.shutdown().await.expect("shutdown clean");
 }
 
-/// Task 1 / Case B: approval_timeout_secs=3600, timeout_ms=10_000.
+/// Approval deadline / Case B: approval_timeout_secs=3600, timeout_ms=10_000.
 /// Approve after ApprovalRequest arrives → ResultJson, handler ran once.
 #[tokio::test]
 async fn approve_within_deadline_executes_with_remaining_budget() {
@@ -1695,7 +1714,7 @@ async fn approve_within_deadline_executes_with_remaining_budget() {
     handle.shutdown().await.expect("shutdown clean");
 }
 
-/// Task 1 / Case C: approval_timeout_secs=3600, timeout_ms=3_000.
+/// Approval deadline / Case C: approval_timeout_secs=3600, timeout_ms=3_000.
 /// Sleep 1_500ms after ApprovalRequest, then approve → remaining budget ≈1.5s
 /// (floored at MIN_TIMEOUT_MS). Handler sleeps 60s → EXECUTION_TIMEOUT fires.
 /// Total elapsed < 8s.

--- a/packages/sdk/src/cloud-client.ts
+++ b/packages/sdk/src/cloud-client.ts
@@ -460,10 +460,10 @@ export interface InvokeAppToolOptions {
    * (1 s – 5 min).
    *
    * For approval-gated tools, set this to at least the expected approval
-   * latency (max `300_000`). An approval granted after the hub window still
-   * executes the handler on the daemon side, but the result is discarded and
-   * the audit `outcome` remains `"timeout"`. Correlate via a replay of the
-   * same call if needed.
+   * latency (max `300_000`). The approval wait on the daemon is bounded by
+   * `min(approval policy timeout, clamp(timeoutMs))` — a late approval finds
+   * the request already expired and nothing executes. This value is the hard
+   * deadline for both the approval dialog and execution.
    */
   timeoutMs?: number;
   signal?: AbortSignal;
@@ -1942,9 +1942,9 @@ export class CloudClient {
    * codes. See `proto/ahand/v1/app_tool.proto` comments for details.
    *
    * For approval-gated tools, set `opts.timeoutMs` ≥ expected approval
-   * latency (max `300_000`); an approval granted after the hub window
-   * still executes the handler, but the result is discarded and the audit
-   * `outcome` remains `"timeout"`.
+   * latency (max `300_000`). The approval wait is bounded by
+   * `min(approval policy timeout, clamp(timeoutMs))` — a late approval finds
+   * the request already expired and nothing executes.
    *
    * Returns `body.result` on success. When the daemon returns a
    * successful response but omits the `result` field, `null` is returned

--- a/proto/ahand/v1/app_tool.proto
+++ b/proto/ahand/v1/app_tool.proto
@@ -23,7 +23,7 @@ message AppToolRequest {
   string tool_call_id = 1;
   string name         = 2;
   string args_json    = 3; // JSON object matching input_schema_json
-  uint32 timeout_ms   = 4; // daemon clamps to [1_000, 300_000]; 0 => 60_000
+  uint32 timeout_ms   = 4; // daemon clamps to [1_000, 300_000]; 0 => 60_000; bounds approval wait + execution for approval-gated tools
 }
 
 // AppToolError - structured failure for one invocation; code is machine-readable, message is a human-readable remediation hint.


### PR DESCRIPTION
timeout_ms now bounds approval+execution for app tool calls; closes the ghost-execution window documented in the app tool registry spec (a late approval could execute a handler whose result no caller can receive). Approval wait = min(approval_timeout, clamped timeout_ms); execution gets the remaining budget. 3 new matrix tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)