### PR TITLE
feat(ahandd): in-process approval API for embedders

### DIFF
--- a/crates/ahandd/src/ahand_client.rs
+++ b/crates/ahandd/src/ahand_client.rs
@@ -648,16 +648,13 @@ async fn connect_with_auth(
             }
             Some(envelope::Payload::ApprovalResponse(resp)) => {
                 info!(job_id = %resp.job_id, approved = resp.approved, "received approval response from cloud");
-                // Record refusal if reason is provided.
-                if !resp.approved && !resp.reason.is_empty() {
-                    if let Some((req, _)) = approval_mgr.resolve(&resp).await {
-                        session_mgr
-                            .record_refusal(caller_uid, &req.tool, &resp.reason)
-                            .await;
-                    }
-                } else {
-                    approval_mgr.resolve(&resp).await;
-                }
+                crate::approval::apply_approval_response(
+                    approval_mgr,
+                    session_mgr,
+                    &resp,
+                    caller_uid,
+                )
+                .await;
             }
             Some(envelope::Payload::SetSessionMode(msg)) => {
                 handle_set_session_mode(device_id, session_mgr, &msg, &tx).await;

--- a/crates/ahandd/src/approval.rs
+++ b/crates/ahandd/src/approval.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use ahand_protocol::{ApprovalRequest, ApprovalResponse, JobRequest, RefusalContext};
@@ -137,6 +138,41 @@ impl ApprovalManager {
     /// The default timeout duration for approval requests.
     pub fn default_timeout(&self) -> Duration {
         self.default_timeout
+    }
+}
+
+/// Shared terminal handling for an [`ApprovalResponse`] arriving from any
+/// surface (cloud WS, local IPC, in-process embedder): resolve the pending
+/// entry; a denial carrying a non-empty reason records a refusal for the
+/// resolved tool. Returns `true` when a pending entry was resolved.
+///
+/// Callers that want a surface-specific log line (e.g. "received approval
+/// response from cloud") should emit it **before** calling this helper.
+/// The `principal` field identifies the source for future per-principal
+/// refusal tracking (currently ignored by `SessionManager::record_refusal`,
+/// which is tool-keyed today).
+pub(crate) async fn apply_approval_response(
+    approval_mgr: &Arc<ApprovalManager>,
+    session_mgr: &Arc<crate::session::SessionManager>,
+    resp: &ApprovalResponse,
+    principal: &str,
+) -> bool {
+    info!(
+        job_id = %resp.job_id,
+        approved = resp.approved,
+        principal,
+        "applying approval response"
+    );
+    if !resp.approved && !resp.reason.is_empty() {
+        if let Some((req, _)) = approval_mgr.resolve(resp).await {
+            session_mgr
+                .record_refusal(principal, &req.tool, &resp.reason)
+                .await;
+            return true;
+        }
+        false
+    } else {
+        approval_mgr.resolve(resp).await.is_some()
     }
 }
 

--- a/crates/ahandd/src/ipc.rs
+++ b/crates/ahandd/src/ipc.rs
@@ -364,15 +364,13 @@ where
             }
             Some(envelope::Payload::ApprovalResponse(resp)) => {
                 info!(job_id = %resp.job_id, approved = resp.approved, "IPC: received approval response");
-                if !resp.approved && !resp.reason.is_empty() {
-                    if let Some((req, _)) = approval_mgr.resolve(&resp).await {
-                        session_mgr
-                            .record_refusal(&caller_id, &req.tool, &resp.reason)
-                            .await;
-                    }
-                } else {
-                    approval_mgr.resolve(&resp).await;
-                }
+                crate::approval::apply_approval_response(
+                    &approval_mgr,
+                    &session_mgr,
+                    &resp,
+                    &caller_id,
+                )
+                .await;
             }
             Some(envelope::Payload::SetSessionMode(msg)) => {
                 let mode = SessionMode::try_from(msg.mode).unwrap_or(SessionMode::Inactive);

--- a/crates/ahandd/src/lib.rs
+++ b/crates/ahandd/src/lib.rs
@@ -15,8 +15,10 @@ pub mod store;
 pub mod updater;
 
 mod public_api;
+pub use ahand_protocol::ApprovalRequest;
 pub use device_identity::DeviceIdentity;
 pub use public_api::{
-    AppToolDef, AppToolError, AppToolHandler, DaemonConfig, DaemonConfigBuilder, DaemonHandle,
-    DaemonStatus, ErrorKind, SessionMode, load_or_create_identity, spawn,
+    AppToolDef, AppToolError, AppToolHandler, ApprovalSubscription, DaemonConfig,
+    DaemonConfigBuilder, DaemonHandle, DaemonStatus, ErrorKind, SessionMode,
+    load_or_create_identity, spawn,
 };

--- a/crates/ahandd/src/public_api.rs
+++ b/crates/ahandd/src/public_api.rs
@@ -21,6 +21,8 @@ use tokio::task::JoinHandle;
 
 pub use ahand_protocol::SessionMode;
 
+use ahand_protocol::{ApprovalRequest, Envelope, envelope};
+
 use crate::ahand_client::{self, ClientReporter, ConnectOutcome};
 use crate::app_tool_registry::AppToolRegistry;
 use crate::approval::ApprovalManager;
@@ -202,13 +204,54 @@ impl PartialEq for DaemonStatus {
 /// Handle returned by [`spawn`]. Drop-safe — `shutdown()` is the preferred
 /// cleanup path, but dropping the handle also cancels the inner task via
 /// the embedded `oneshot` sender going out of scope.
-#[derive(Debug)]
 pub struct DaemonHandle {
     shutdown_tx: Option<oneshot::Sender<()>>,
     join: JoinHandle<anyhow::Result<()>>,
     status_rx: watch::Receiver<DaemonStatus>,
     device_id: String,
     app_tools: Arc<AppToolRegistry>,
+    approval_broadcast_tx: broadcast::Sender<Envelope>,
+    approval_mgr: Arc<ApprovalManager>,
+    session_mgr: Arc<SessionManager>,
+}
+
+impl std::fmt::Debug for DaemonHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DaemonHandle")
+            .field("device_id", &self.device_id)
+            .field("status", &self.status_rx.borrow().clone())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Stream of approval requests for in-process embedders (Tauri apps etc.).
+///
+/// Wraps the daemon's internal `Envelope` broadcast and yields only
+/// [`ApprovalRequest`] payloads. Lagged subscribers skip missed messages
+/// (tokio broadcast semantics); `None` means the daemon shut down.
+pub struct ApprovalSubscription {
+    rx: broadcast::Receiver<Envelope>,
+}
+
+impl ApprovalSubscription {
+    /// Receive the next [`ApprovalRequest`].
+    ///
+    /// Returns `None` when the daemon broadcast channel is closed (i.e. the
+    /// daemon has shut down). Automatically skips lagged-out envelopes and
+    /// non-approval-request payloads.
+    pub async fn recv(&mut self) -> Option<ApprovalRequest> {
+        loop {
+            match self.rx.recv().await {
+                Ok(env) => {
+                    if let Some(envelope::Payload::ApprovalRequest(req)) = env.payload {
+                        return Some(req);
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => return None,
+            }
+        }
+    }
 }
 
 static ACTIVE_DAEMONS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
@@ -306,6 +349,49 @@ impl DaemonHandle {
     pub async fn unregister_app_tool(&self, name: &str) -> bool {
         self.app_tools.unregister(name).await
     }
+
+    /// Subscribe to in-process approval requests.
+    ///
+    /// Job, file, and app-tool paths all broadcast here. Each subscriber
+    /// receives every request independently (broadcast semantics). Lagged
+    /// subscribers automatically skip missed messages rather than blocking.
+    pub fn subscribe_approvals(&self) -> ApprovalSubscription {
+        ApprovalSubscription {
+            rx: self.approval_broadcast_tx.subscribe(),
+        }
+    }
+
+    /// Answer a pending approval from the embedding application.
+    ///
+    /// Mirrors the WS/IPC `ApprovalResponse` handling exactly:
+    /// - deny with non-empty `reason` → `resolve` + `record_refusal` (principal
+    ///   recorded as `"local"`)
+    /// - approve or deny without reason → `resolve` only
+    ///
+    /// `job_id` is [`ApprovalRequest::job_id`] verbatim (already namespaced,
+    /// e.g. `"app-tool:{id}"`).
+    ///
+    /// Returns `false` when no matching pending approval exists (already
+    /// resolved or expired).
+    pub async fn respond_approval(&self, job_id: &str, approved: bool, reason: &str) -> bool {
+        let resp = ahand_protocol::ApprovalResponse {
+            job_id: job_id.to_string(),
+            approved,
+            reason: reason.to_string(),
+            remember: false,
+        };
+        if !approved && !reason.is_empty() {
+            if let Some((req, _)) = self.approval_mgr.resolve(&resp).await {
+                self.session_mgr
+                    .record_refusal("local", &req.tool, reason)
+                    .await;
+                return true;
+            }
+            false
+        } else {
+            self.approval_mgr.resolve(&resp).await.is_some()
+        }
+    }
 }
 
 /// Spawn an `ahandd` instance wired against the cloud hub described by `config`.
@@ -361,6 +447,10 @@ pub async fn spawn(config: DaemonConfig) -> anyhow::Result<DaemonHandle> {
     let reporter: Arc<dyn ClientReporter> =
         Arc::new(StatusReporter::new(reporter_status_tx, reporter_device_id));
 
+    let approval_broadcast_tx_for_handle = approval_broadcast_tx.clone();
+    let approval_mgr_for_handle = Arc::clone(&approval_mgr);
+    let session_mgr_for_handle = Arc::clone(&session_mgr);
+
     let app_tools_for_task = Arc::clone(&app_tools);
     let join = tokio::spawn(async move {
         let _active_guard = active_guard;
@@ -407,6 +497,9 @@ pub async fn spawn(config: DaemonConfig) -> anyhow::Result<DaemonHandle> {
         status_rx,
         device_id,
         app_tools,
+        approval_broadcast_tx: approval_broadcast_tx_for_handle,
+        approval_mgr: approval_mgr_for_handle,
+        session_mgr: session_mgr_for_handle,
     })
 }
 

--- a/crates/ahandd/src/public_api.rs
+++ b/crates/ahandd/src/public_api.rs
@@ -355,6 +355,44 @@ impl DaemonHandle {
     /// Job, file, and app-tool paths all broadcast here. Each subscriber
     /// receives every request independently (broadcast semantics). Lagged
     /// subscribers automatically skip missed messages rather than blocking.
+    ///
+    /// # When requests appear
+    ///
+    /// Under the builder default [`SessionMode::AutoAccept`], approval requests
+    /// fire **only** for app tools registered with `requires_approval: true`
+    /// (and for policy-escalated file operations). Under
+    /// [`SessionMode::Strict`] every job, file, and app-tool call goes through
+    /// approval. An embedder subscribing under the default configuration may
+    /// therefore never receive a request unless it registers tools with
+    /// `requires_approval: true` or explicitly switches to `Strict` mode.
+    ///
+    /// ## `job_id` namespaces
+    ///
+    /// The `job_id` field on each [`ApprovalRequest`] is already namespaced:
+    ///
+    /// 1. **Real jobs** — raw `job_id` from the cloud `JobRequest`; tool is
+    ///    whatever the cloud sent (e.g. `"bash"`, `"computer"`).
+    /// 2. **File requests** — `"file-req:{request_id}"`; tool is `"file"`.
+    ///    The prefix prevents a `request_id` from evicting a same-named real
+    ///    job entry.
+    /// 3. **App-tool calls** — `"app-tool:{tool_call_id}"`; tool is
+    ///    `"app:{name}"`. The prefix prevents a cloud-chosen `tool_call_id`
+    ///    from colliding with a real job's pending entry.
+    ///
+    /// Pass the `job_id` verbatim to [`DaemonHandle::respond_approval`].
+    ///
+    /// ## Expiry
+    ///
+    /// Each request carries an `expires_ms` timestamp derived from
+    /// [`DaemonConfig::approval_timeout`]. For app tools the effective window
+    /// is further bounded by the call's own `timeout_ms`: approval must arrive
+    /// within `min(approval_timeout, timeout_ms)` of the request being sent.
+    ///
+    /// ## Subscribe-before-traffic and multi-subscriber semantics
+    ///
+    /// This channel does **not** replay missed messages — subscribe before
+    /// sending traffic (or before spawning the task that will send traffic).
+    /// Every active subscriber independently receives every request.
     pub fn subscribe_approvals(&self) -> ApprovalSubscription {
         ApprovalSubscription {
             rx: self.approval_broadcast_tx.subscribe(),
@@ -364,9 +402,12 @@ impl DaemonHandle {
     /// Answer a pending approval from the embedding application.
     ///
     /// Mirrors the WS/IPC `ApprovalResponse` handling exactly:
-    /// - deny with non-empty `reason` → `resolve` + `record_refusal` (principal
-    ///   recorded as `"local"`)
+    /// - deny with non-empty `reason` → `resolve` + `record_refusal`
     /// - approve or deny without reason → `resolve` only
+    ///
+    /// The refusal log is keyed by tool name today (`SessionManager::record_refusal`
+    /// ignores the caller principal). The `"local"` principal passed internally
+    /// is a forward-looking sentinel for when per-principal tracking is added.
     ///
     /// `job_id` is [`ApprovalRequest::job_id`] verbatim (already namespaced,
     /// e.g. `"app-tool:{id}"`).
@@ -380,17 +421,13 @@ impl DaemonHandle {
             reason: reason.to_string(),
             remember: false,
         };
-        if !approved && !reason.is_empty() {
-            if let Some((req, _)) = self.approval_mgr.resolve(&resp).await {
-                self.session_mgr
-                    .record_refusal("local", &req.tool, reason)
-                    .await;
-                return true;
-            }
-            false
-        } else {
-            self.approval_mgr.resolve(&resp).await.is_some()
-        }
+        crate::approval::apply_approval_response(
+            &self.approval_mgr,
+            &self.session_mgr,
+            &resp,
+            "local",
+        )
+        .await
     }
 }
 

--- a/crates/ahandd/tests/app_tools.rs
+++ b/crates/ahandd/tests/app_tools.rs
@@ -1776,3 +1776,174 @@ async fn approval_consuming_budget_shrinks_execution_timeout() {
     );
     handle.shutdown().await.expect("shutdown clean");
 }
+
+// ── Task 7: in-process approval API ──────────────────────────────────────────
+
+/// Helper: register a counted-echo tool and return the counter.
+/// Wraps the existing `register_counted_echo` helper, creating the counter
+/// internally so callers don't need to construct one explicitly.
+async fn register_counted_echo_new(
+    handle: &ahandd::DaemonHandle,
+    name: &str,
+    requires_approval: bool,
+) -> Arc<AtomicUsize> {
+    let counter = Arc::new(AtomicUsize::new(0));
+    register_counted_echo(handle, name, requires_approval, Arc::clone(&counter)).await;
+    counter
+}
+
+/// In-process approve: grant approval via `respond_approval` → handler executes.
+///
+/// Flow: subscribe_approvals → send AppToolRequest → receive ApprovalRequest
+/// in-process → respond_approval(approved=true) → ResultJson arrives.
+#[tokio::test]
+async fn in_process_approve_executes_app_tool() {
+    let (mock, handle, _tmp) = setup_gated_daemon(SessionMode::Strict, 3600).await;
+    let run_count = register_counted_echo_new(&handle, "demo_echo", false).await;
+
+    // Subscribe before registering so no broadcasts are missed.
+    let mut approvals = handle.subscribe_approvals();
+
+    // Wait for the tool snapshot.
+    mock.wait_for_app_tools_updates(2, Duration::from_secs(5))
+        .await
+        .expect("tool snapshot");
+
+    mock.send_app_tool_request("ipa-1", "demo_echo", r#"{}"#, 10_000)
+        .expect("send ok");
+
+    let req = tokio::time::timeout(Duration::from_secs(5), approvals.recv())
+        .await
+        .expect("timeout waiting for ApprovalRequest")
+        .expect("channel closed before receiving ApprovalRequest");
+
+    assert_eq!(
+        req.job_id, "app-tool:ipa-1",
+        "job_id must be namespaced 'app-tool:<tool_call_id>'"
+    );
+
+    // Approve in-process — respond_approval must return true (entry found).
+    assert!(
+        handle.respond_approval(&req.job_id, true, "").await,
+        "respond_approval should return true for a pending request"
+    );
+
+    // Handler should execute and result should arrive at the mock hub.
+    let responses = mock
+        .wait_for_app_tool_responses(1, Duration::from_secs(10))
+        .await
+        .expect("AppToolResponse not received within 10s after in-process approval");
+
+    let resp = &responses[0];
+    assert_eq!(resp.tool_call_id, "ipa-1");
+    assert!(
+        matches!(&resp.result, Some(app_tool_response::Result::ResultJson(_))),
+        "expected ResultJson after in-process approval, got {:?}",
+        resp.result
+    );
+
+    assert_eq!(
+        run_count.load(Ordering::SeqCst),
+        1,
+        "handler ran exactly once"
+    );
+
+    handle.shutdown().await.expect("shutdown clean");
+}
+
+/// In-process deny: deny with reason → APPROVAL_DENIED; second request sees 1
+/// previous_refusal; principal recorded as "local".
+#[tokio::test]
+async fn in_process_deny_records_refusal_once() {
+    let (mock, handle, _tmp) = setup_gated_daemon(SessionMode::Strict, 3600).await;
+    register_counted_echo_new(&handle, "demo_echo", false).await;
+
+    let mut approvals = handle.subscribe_approvals();
+
+    mock.wait_for_app_tools_updates(2, Duration::from_secs(5))
+        .await
+        .expect("tool snapshot");
+
+    // First request — deny with reason "not now".
+    mock.send_app_tool_request("ipd-1", "demo_echo", r#"{}"#, 10_000)
+        .expect("send first ok");
+
+    let req = tokio::time::timeout(Duration::from_secs(5), approvals.recv())
+        .await
+        .expect("timeout waiting for first ApprovalRequest")
+        .expect("channel closed");
+
+    assert_eq!(req.job_id, "app-tool:ipd-1");
+
+    assert!(
+        handle.respond_approval(&req.job_id, false, "not now").await,
+        "deny with reason must return true"
+    );
+
+    // APPROVAL_DENIED should arrive.
+    let first_responses = mock
+        .wait_for_app_tool_responses(1, Duration::from_secs(5))
+        .await
+        .expect("APPROVAL_DENIED not received within 5s");
+
+    assert!(
+        matches!(
+            &first_responses[0].result,
+            Some(app_tool_response::Result::Error(e)) if e.code == "APPROVAL_DENIED"
+        ),
+        "expected APPROVAL_DENIED, got {:?}",
+        first_responses[0].result
+    );
+
+    // Second request (new tool_call_id) of the same tool → previous_refusals.len() == 1.
+    mock.send_app_tool_request("ipd-2", "demo_echo", r#"{}"#, 10_000)
+        .expect("send second ok");
+
+    let second_req = tokio::time::timeout(Duration::from_secs(5), approvals.recv())
+        .await
+        .expect("timeout waiting for second ApprovalRequest")
+        .expect("channel closed");
+
+    assert_eq!(second_req.job_id, "app-tool:ipd-2");
+    assert_eq!(
+        second_req.previous_refusals.len(),
+        1,
+        "second invocation must see exactly 1 previous_refusal from the in-process denial; got {}",
+        second_req.previous_refusals.len()
+    );
+
+    // Clean up — deny the second request too.
+    handle
+        .respond_approval(&second_req.job_id, false, "cleanup")
+        .await;
+    mock.wait_for_app_tool_responses(2, Duration::from_secs(5))
+        .await
+        .expect("second APPROVAL_DENIED not received");
+
+    handle.shutdown().await.expect("shutdown clean");
+}
+
+/// In-process respond to unknown job → returns false (no panic, no hang).
+#[tokio::test]
+async fn in_process_respond_unknown_job_returns_false() {
+    let (_mock, handle, _tmp) = setup_gated_daemon(SessionMode::Strict, 3600).await;
+
+    let result = handle
+        .respond_approval("app-tool:nonexistent", true, "")
+        .await;
+    assert!(
+        !result,
+        "respond_approval for an unknown job_id must return false"
+    );
+
+    // Also test deny-with-reason path for an unknown job.
+    let result_deny = handle
+        .respond_approval("app-tool:also-nonexistent", false, "some reason")
+        .await;
+    assert!(
+        !result_deny,
+        "respond_approval (deny+reason) for an unknown job_id must return false"
+    );
+
+    handle.shutdown().await.expect("shutdown clean");
+}

--- a/crates/ahandd/tests/app_tools.rs
+++ b/crates/ahandd/tests/app_tools.rs
@@ -1779,10 +1779,10 @@ async fn approval_consuming_budget_shrinks_execution_timeout() {
 
 // ── Task 7: in-process approval API ──────────────────────────────────────────
 
-/// Helper: register a counted-echo tool and return the counter.
+/// Helper: register a counted-echo tool and return the counter handle.
 /// Wraps the existing `register_counted_echo` helper, creating the counter
 /// internally so callers don't need to construct one explicitly.
-async fn register_counted_echo_new(
+async fn register_counted_echo_handle(
     handle: &ahandd::DaemonHandle,
     name: &str,
     requires_approval: bool,
@@ -1799,9 +1799,9 @@ async fn register_counted_echo_new(
 #[tokio::test]
 async fn in_process_approve_executes_app_tool() {
     let (mock, handle, _tmp) = setup_gated_daemon(SessionMode::Strict, 3600).await;
-    let run_count = register_counted_echo_new(&handle, "demo_echo", false).await;
+    let run_count = register_counted_echo_handle(&handle, "demo_echo", false).await;
 
-    // Subscribe before registering so no broadcasts are missed.
+    // Subscribe before traffic starts so no broadcasts are missed.
     let mut approvals = handle.subscribe_approvals();
 
     // Wait for the tool snapshot.
@@ -1856,7 +1856,7 @@ async fn in_process_approve_executes_app_tool() {
 #[tokio::test]
 async fn in_process_deny_records_refusal_once() {
     let (mock, handle, _tmp) = setup_gated_daemon(SessionMode::Strict, 3600).await;
-    register_counted_echo_new(&handle, "demo_echo", false).await;
+    register_counted_echo_handle(&handle, "demo_echo", false).await;
 
     let mut approvals = handle.subscribe_approvals();
 
@@ -1946,4 +1946,102 @@ async fn in_process_respond_unknown_job_returns_false() {
     );
 
     handle.shutdown().await.expect("shutdown clean");
+}
+
+/// Deny-without-reason: respond_approval(false, "") resolves the entry
+/// (returns true) and sends APPROVAL_DENIED, but does NOT record a refusal,
+/// so a follow-up request's `previous_refusals` is empty.
+#[tokio::test]
+async fn in_process_deny_without_reason_no_refusal_recorded() {
+    let (mock, handle, _tmp) = setup_gated_daemon(SessionMode::Strict, 3600).await;
+    register_counted_echo_handle(&handle, "demo_echo", false).await;
+
+    // Subscribe before traffic starts so no broadcasts are missed.
+    let mut approvals = handle.subscribe_approvals();
+
+    mock.wait_for_app_tools_updates(2, Duration::from_secs(5))
+        .await
+        .expect("tool snapshot");
+
+    // First request — deny with empty reason.
+    mock.send_app_tool_request("ipnr-1", "demo_echo", r#"{}"#, 10_000)
+        .expect("send first ok");
+
+    let req = tokio::time::timeout(Duration::from_secs(5), approvals.recv())
+        .await
+        .expect("timeout waiting for first ApprovalRequest")
+        .expect("channel closed");
+
+    assert_eq!(req.job_id, "app-tool:ipnr-1");
+
+    // Deny with empty reason — must still return true (entry resolved).
+    assert!(
+        handle.respond_approval(&req.job_id, false, "").await,
+        "deny with empty reason must return true (entry was pending)"
+    );
+
+    // APPROVAL_DENIED should arrive.
+    let first_responses = mock
+        .wait_for_app_tool_responses(1, Duration::from_secs(5))
+        .await
+        .expect("APPROVAL_DENIED not received within 5s");
+
+    assert!(
+        matches!(
+            &first_responses[0].result,
+            Some(app_tool_response::Result::Error(e)) if e.code == "APPROVAL_DENIED"
+        ),
+        "expected APPROVAL_DENIED, got {:?}",
+        first_responses[0].result
+    );
+
+    // Second request of the same tool — previous_refusals must be EMPTY
+    // because the denial carried no reason, so no refusal was recorded.
+    mock.send_app_tool_request("ipnr-2", "demo_echo", r#"{}"#, 10_000)
+        .expect("send second ok");
+
+    let second_req = tokio::time::timeout(Duration::from_secs(5), approvals.recv())
+        .await
+        .expect("timeout waiting for second ApprovalRequest")
+        .expect("channel closed");
+
+    assert_eq!(second_req.job_id, "app-tool:ipnr-2");
+    assert!(
+        second_req.previous_refusals.is_empty(),
+        "deny-without-reason must NOT record a refusal; previous_refusals should be empty, got {}",
+        second_req.previous_refusals.len()
+    );
+
+    // Clean up.
+    handle
+        .respond_approval(&second_req.job_id, false, "cleanup")
+        .await;
+    mock.wait_for_app_tool_responses(2, Duration::from_secs(5))
+        .await
+        .expect("second APPROVAL_DENIED not received");
+
+    handle.shutdown().await.expect("shutdown clean");
+}
+
+/// Shutdown pins channel closed: after handle.shutdown() the approval
+/// subscription recv() returns None (channel closed).
+#[tokio::test]
+async fn approval_subscription_closed_after_shutdown() {
+    let (_mock, handle, _tmp) = setup_gated_daemon(SessionMode::Strict, 3600).await;
+
+    // Subscribe before shutdown so we hold a receiver.
+    let mut approvals = handle.subscribe_approvals();
+
+    // Shut down — this consumes the handle.
+    handle.shutdown().await.expect("shutdown clean");
+
+    // The broadcast channel is now closed; recv() must return None promptly.
+    let result = tokio::time::timeout(Duration::from_secs(2), approvals.recv())
+        .await
+        .expect("recv did not return within 2s after shutdown");
+
+    assert!(
+        result.is_none(),
+        "recv() must return None after the daemon shuts down"
+    );
 }


### PR DESCRIPTION
DaemonHandle::subscribe_approvals + respond_approval — typed wrapper over the existing approval broadcast and the same resolve/refusal path the WS/IPC arms use. Unblocks Coffice's native approval dialogs (sub-project 3).

## Summary

- \`DaemonHandle\` gains three private fields: \`approval_broadcast_tx\`, \`approval_mgr\`, \`session_mgr\` (cloned from \`spawn()\` before task launch)
- New \`ApprovalSubscription\` type wraps the broadcast receiver and yields only \`ApprovalRequest\` payloads, skipping lag and non-approval envelopes
- \`subscribe_approvals()\` creates a new subscriber; \`respond_approval()\` mirrors the WS/IPC ApprovalResponse handling (resolve + refusal recording via principal \`"local"\` on deny-with-reason)
- \`ApprovalRequest\` and \`ApprovalSubscription\` re-exported from crate root
- 3 integration tests in \`tests/app_tools.rs\`: approve executes, deny records refusal (previous_refusals.len()==1 on 2nd request), unknown job returns false

## Test plan

- [x] \`cargo test -p ahandd --test app_tools in_process\` — 3 new tests pass
- [x] Full \`cargo test -p ahandd --test app_tools\` — all 30 tests pass
- [x] \`cargo test -p ahandd --lib public_api\` — 17 unit tests pass
- [x] \`cargo fmt --check\`, \`cargo clippy -D warnings\`, \`cargo check --workspace\` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)