### PR TITLE
Fix audit fallback test race

### DIFF
--- a/crates/ahand-hub/src/audit_writer.rs
+++ b/crates/ahand-hub/src/audit_writer.rs
@@ -359,14 +359,18 @@ mod tests {
             .unwrap();
 
         let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+        let mut last_body = String::new();
         loop {
-            if tokio::fs::metadata(&fallback_path).await.is_ok() {
-                let body = tokio::fs::read_to_string(&fallback_path).await.unwrap();
-                assert!(body.contains("\"action\":\"job.created\""));
-                break;
+            match tokio::fs::read_to_string(&fallback_path).await {
+                Ok(body) if body.contains("\"action\":\"job.created\"") => break,
+                Ok(body) => {
+                    last_body = body;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => panic!("failed to read fallback file: {err}"),
             }
             if tokio::time::Instant::now() >= deadline {
-                panic!("fallback file was not written");
+                panic!("fallback file did not contain expected audit entry: {last_body:?}");
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }


### PR DESCRIPTION
## Summary
- wait for the audit fallback file to contain the expected entry before asserting
- keep timeout diagnostics with the last observed fallback content

## Verification
- cargo fmt --check
- cargo test -p ahand-hub audit_writer::tests::buffered_store_falls_back_to_file_after_store_failure -- --exact --nocapture
- cargo test -p ahand-hub --lib -- --skip output_stream::tests::persistent_subscribe_reader_survives_multiple_live_polls --skip output_stream::tests::persistent_subscribe_does_not_miss_first_live_event_after_empty_history
- cargo clippy -p ahand-hub --all-targets --all-features -- -D warnings

Note: full local cargo test -p ahand-hub --lib hit local Docker disk exhaustion in the two Postgres testcontainer tests; the same run otherwise passed with those two skipped.