### PR TITLE
[codex] Add sandbox mount API

### DIFF
--- a/crates/ahandd/src/lib.rs
+++ b/crates/ahandd/src/lib.rs
@@ -21,7 +21,8 @@ pub use device_identity::DeviceIdentity;
 pub use public_api::{
     AppToolArgsHandler, AppToolDef, AppToolError, AppToolHandler, AppToolInvocation,
     ApprovalSubscription, DaemonConfig, DaemonConfigBuilder, DaemonHandle, DaemonStatus, ErrorKind,
-    SessionMode, args_only_handler, load_or_create_identity, spawn,
+    MountAccess, MountScope, MountSource, MountSourceSnapshot, RegisteredSandboxMount,
+    SandboxMountSpec, SessionMode, args_only_handler, load_or_create_identity, spawn,
 };
 pub use sandbox::{
     FixedSandboxInvocationResolver, SandboxInvocationContext, SandboxInvocationResolver,

--- a/crates/ahandd/src/public_api.rs
+++ b/crates/ahandd/src/public_api.rs
@@ -691,6 +691,7 @@ pub(crate) async fn execute_sandbox_command_with_registry(
     let policy = RuntimeSandboxPolicy {
         writable_root: workspace_root,
         readonly_roots: exec_env.readonly_roots,
+        mounts: exec_env.mounts,
         network,
     };
 

--- a/crates/ahandd/src/public_api.rs
+++ b/crates/ahandd/src/public_api.rs
@@ -39,7 +39,7 @@ use crate::sandbox::{
 };
 pub use crate::sandbox::{
     MountAccess, MountScope, MountSource, MountSourceSnapshot, RegisteredSandboxMount,
-    SandboxInvocationContext, SandboxMountSpec,
+    SandboxMountSpec,
 };
 use crate::session::SessionManager;
 
@@ -628,21 +628,22 @@ pub(crate) async fn execute_sandbox_command_with_registry(
     session_id: &str,
     request: SandboxExecRequest,
 ) -> SandboxResult<SandboxExecResult> {
+    let SandboxExecRequest {
+        command,
+        cwd,
+        env: request_env,
+        timeout: request_timeout,
+        context,
+    } = request;
     let (workspace_root, network, exec_env): (PathBuf, NetworkPolicy, RegisteredExecEnvironment) = {
         let registry = sandbox_registry.lock().await;
         let session = registry.session(session_id)?;
         (
             session.workspace_root.clone(),
             session.network,
-            session.exec_environment(),
+            session.exec_environment_for(context.as_ref())?,
         )
     };
-    let SandboxExecRequest {
-        command,
-        cwd,
-        env: request_env,
-        timeout: request_timeout,
-    } = request;
 
     std::fs::create_dir_all(&workspace_root).map_err(|e| {
         crate::sandbox::SandboxError::unavailable(format!(
@@ -660,9 +661,18 @@ pub(crate) async fn execute_sandbox_command_with_registry(
         })?,
     };
     let command = runner::command_argv_from_sandbox_command(&command)?;
+    let protected_mount_env = exec_env
+        .mounts
+        .iter()
+        .filter_map(|mount| mount.env_var.clone())
+        .collect::<HashSet<_>>();
     let mut env = exec_env.env;
     merge_path_entries(&mut env, &exec_env.path_entries);
-    env.extend(request_env);
+    env.extend(
+        request_env
+            .into_iter()
+            .filter(|(key, _)| !protected_mount_env.contains(key)),
+    );
     let timeout = request_timeout.unwrap_or(exec_env.default_timeout);
     let policy = RuntimeSandboxPolicy {
         writable_root: workspace_root,
@@ -1299,6 +1309,7 @@ mod tests {
                 permission_mode: SandboxPermissionMode::Readonly,
                 workspace_root,
                 network: NetworkPolicy::Enabled,
+                mounts: Vec::new(),
             })
             .await
             .unwrap();
@@ -1313,6 +1324,7 @@ mod tests {
                     cwd: None,
                     env: HashMap::new(),
                     timeout: Some(Duration::from_secs(5)),
+                    context: None,
                 },
             )
             .await;

--- a/crates/ahandd/src/public_api.rs
+++ b/crates/ahandd/src/public_api.rs
@@ -458,6 +458,36 @@ impl DaemonHandle {
         self.sandbox_registry.lock().await.create_session(config)
     }
 
+    pub async fn register_sandbox_mount(
+        &self,
+        session_id: &str,
+        spec: SandboxMountSpec,
+    ) -> SandboxResult<RegisteredSandboxMount> {
+        self.sandbox_registry
+            .lock()
+            .await
+            .register_mount(session_id, spec)
+    }
+
+    pub async fn unregister_sandbox_mount(
+        &self,
+        session_id: &str,
+        mount_id: &str,
+        scope: MountScope,
+    ) -> SandboxResult<()> {
+        self.sandbox_registry
+            .lock()
+            .await
+            .unregister_mount(session_id, mount_id, scope)
+    }
+
+    pub async fn list_sandbox_mounts(
+        &self,
+        session_id: &str,
+    ) -> SandboxResult<Vec<RegisteredSandboxMount>> {
+        self.sandbox_registry.lock().await.list_mounts(session_id)
+    }
+
     pub async fn update_sandbox_permission_mode(
         &self,
         session_id: &str,

--- a/crates/ahandd/src/public_api.rs
+++ b/crates/ahandd/src/public_api.rs
@@ -37,6 +37,10 @@ use crate::sandbox::{
     registry::SandboxRegistry,
     runner::{self, PlatformExecuteRequest, RuntimeSandboxPolicy},
 };
+pub use crate::sandbox::{
+    MountAccess, MountScope, MountSource, MountSourceSnapshot, RegisteredSandboxMount,
+    SandboxInvocationContext, SandboxMountSpec,
+};
 use crate::session::SessionManager;
 
 pub use crate::app_tool_registry::{
@@ -532,6 +536,7 @@ impl DaemonHandle {
                 cwd: request.cwd,
                 env,
                 timeout: request.timeout.or(Some(provider.default_timeout)),
+                context: None,
             },
         )
         .await
@@ -1225,6 +1230,7 @@ mod tests {
                 permission_mode: SandboxPermissionMode::Readonly,
                 workspace_root,
                 network: NetworkPolicy::Enabled,
+                mounts: Vec::new(),
             })
             .await
             .unwrap();
@@ -1237,6 +1243,7 @@ mod tests {
                     cwd: None,
                     env: HashMap::new(),
                     timeout: Some(Duration::from_secs(1)),
+                    context: None,
                 },
             )
             .await

--- a/crates/ahandd/src/public_api.rs
+++ b/crates/ahandd/src/public_api.rs
@@ -635,13 +635,19 @@ pub(crate) async fn execute_sandbox_command_with_registry(
         timeout: request_timeout,
         context,
     } = request;
-    let (workspace_root, network, exec_env): (PathBuf, NetworkPolicy, RegisteredExecEnvironment) = {
+    let (workspace_root, network, exec_env, reserved_mount_env): (
+        PathBuf,
+        NetworkPolicy,
+        RegisteredExecEnvironment,
+        HashSet<String>,
+    ) = {
         let registry = sandbox_registry.lock().await;
         let session = registry.session(session_id)?;
         (
             session.workspace_root.clone(),
             session.network,
-            session.exec_environment_for(context.as_ref())?,
+            session.exec_environment_for(context.as_ref()),
+            session.registered_mount_env_vars().into_iter().collect(),
         )
     };
 
@@ -661,17 +667,25 @@ pub(crate) async fn execute_sandbox_command_with_registry(
         })?,
     };
     let command = runner::command_argv_from_sandbox_command(&command)?;
-    let protected_mount_env = exec_env
+    let active_mount_env = exec_env
         .mounts
         .iter()
         .filter_map(|mount| mount.env_var.clone())
         .collect::<HashSet<_>>();
+    if let Some((key, _)) = request_env
+        .iter()
+        .find(|(key, _)| reserved_mount_env.contains(*key) && !active_mount_env.contains(*key))
+    {
+        return Err(crate::sandbox::SandboxError::mount_scope_mismatch(format!(
+            "sandbox mount env var '{key}' is not active for this invocation context"
+        )));
+    }
     let mut env = exec_env.env;
     merge_path_entries(&mut env, &exec_env.path_entries);
     env.extend(
         request_env
             .into_iter()
-            .filter(|(key, _)| !protected_mount_env.contains(key)),
+            .filter(|(key, _)| !active_mount_env.contains(key)),
     );
     let timeout = request_timeout.unwrap_or(exec_env.default_timeout);
     let policy = RuntimeSandboxPolicy {

--- a/crates/ahandd/src/sandbox/file_lifecycle.rs
+++ b/crates/ahandd/src/sandbox/file_lifecycle.rs
@@ -376,6 +376,7 @@ mod tests {
                 permission_mode: SandboxPermissionMode::Readonly,
                 workspace_root: root.to_path_buf(),
                 network: NetworkPolicy::Enabled,
+                mounts: Vec::new(),
             })
             .unwrap();
         registry

--- a/crates/ahandd/src/sandbox/mod.rs
+++ b/crates/ahandd/src/sandbox/mod.rs
@@ -7,12 +7,14 @@ pub mod tool_provider;
 pub mod types;
 
 pub use tool_provider::{
-    FixedSandboxInvocationResolver, SandboxInvocationContext, SandboxInvocationResolver,
-    SandboxToolProvider, SandboxToolProviderOptions,
+    FixedSandboxInvocationResolver, SandboxInvocationResolver, SandboxToolProvider,
+    SandboxToolProviderOptions,
 };
 pub use types::{
-    CommitResult, FileVersion, FileVersionStatus, HostFileRef, NetworkPolicy, PermissionSnapshot,
-    RegisterVersionRequest, RegisteredExecEnvironment, RuntimeExecuteRequest, RuntimeExecuteResult,
+    CommitResult, FileVersion, FileVersionStatus, HostFileRef, MountAccess, MountScope,
+    MountSource, MountSourceSnapshot, NetworkPolicy, PermissionSnapshot, RegisterVersionRequest,
+    RegisteredExecEnvironment, RegisteredSandboxMount, RuntimeExecuteRequest, RuntimeExecuteResult,
     RuntimeProviderConfig, SandboxCommand, SandboxError, SandboxExecRequest, SandboxExecResult,
-    SandboxFile, SandboxPermissionMode, SandboxResult, SandboxSessionConfig,
+    SandboxFile, SandboxInvocationContext, SandboxMountSpec, SandboxPermissionMode, SandboxResult,
+    SandboxSessionConfig,
 };

--- a/crates/ahandd/src/sandbox/mod.rs
+++ b/crates/ahandd/src/sandbox/mod.rs
@@ -1,4 +1,5 @@
 pub mod file_lifecycle;
+pub mod mounts;
 pub mod path_policy;
 pub mod platform;
 pub mod registry;

--- a/crates/ahandd/src/sandbox/mounts.rs
+++ b/crates/ahandd/src/sandbox/mounts.rs
@@ -22,13 +22,11 @@ pub fn register_mount(
         SandboxError::mount_target_invalid(format!("failed to resolve sandbox workspace root: {e}"))
     })?;
     let mount_namespace = workspace_root.join("workspace").join("mounts");
-    let canonical_namespace = mount_namespace.canonicalize().map_err(|e| {
-        SandboxError::mount_target_invalid(format!("failed to resolve mount namespace: {e}"))
-    })?;
+    let canonical_namespace = validate_mount_namespace(&workspace_root, &mount_namespace)?;
     let (source, source_snapshot) = resolve_source(spec.source)?;
     let target = match spec.target {
         Some(target) => resolve_explicit_target(&workspace_root, &canonical_namespace, &target)?,
-        None => allocate_auto_target(&canonical_namespace, &slug_from_mount_id(&spec.mount_id)),
+        None => allocate_auto_target(&mount_namespace, &slug_from_mount_id(&spec.mount_id)),
     };
 
     Ok(RegisteredSandboxMount {
@@ -66,14 +64,47 @@ fn resolve_source(source: MountSource) -> SandboxResult<(MountSource, MountSourc
             let snapshot = snapshot_for_path(&canonical)?;
             Ok((MountSource::HostPath(canonical), snapshot))
         }
-        other => Ok((
-            other,
-            MountSourceSnapshot {
-                exists: false,
-                is_dir: false,
-            },
-        )),
+        MountSource::SandboxPath(_) | MountSource::RuntimePath(_) => {
+            Err(SandboxError::mount_source_unsupported(
+                "only host path mount sources are currently supported",
+            ))
+        }
     }
+}
+
+fn validate_mount_namespace(
+    workspace_root: &Path,
+    mount_namespace: &Path,
+) -> SandboxResult<PathBuf> {
+    let metadata = fs::symlink_metadata(mount_namespace).map_err(|e| {
+        SandboxError::mount_target_invalid(format!("failed to inspect mount namespace: {e}"))
+    })?;
+    if metadata.file_type().is_symlink() {
+        return Err(SandboxError::mount_target_invalid(
+            "mount namespace must not be a symlink",
+        ));
+    }
+    if !metadata.is_dir() {
+        return Err(SandboxError::mount_target_invalid(
+            "mount namespace must be a directory",
+        ));
+    }
+
+    let canonical_namespace = mount_namespace.canonicalize().map_err(|e| {
+        SandboxError::mount_target_invalid(format!("failed to resolve mount namespace: {e}"))
+    })?;
+    if canonical_namespace != mount_namespace {
+        return Err(SandboxError::mount_target_invalid(
+            "mount namespace must resolve inside workspace/mounts without symlinks",
+        ));
+    }
+    if !canonical_namespace.starts_with(workspace_root) {
+        return Err(SandboxError::mount_target_invalid(
+            "mount namespace escapes the session root",
+        ));
+    }
+
+    Ok(canonical_namespace)
 }
 
 fn snapshot_for_path(path: &Path) -> SandboxResult<MountSourceSnapshot> {
@@ -258,6 +289,29 @@ mod tests {
         register_mount(&session(workspace_root), spec)
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn auto_target_rejects_symlinked_mount_namespace() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        let outside = temp.path().join("outside-mounts");
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(workspace_root.join("workspace")).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        symlink(&outside, workspace_root.join("workspace").join("mounts")).unwrap();
+
+        let err = register_for_test(
+            &workspace_root,
+            readonly_host_spec("selected-folder", source),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, "MOUNT_TARGET_INVALID");
+    }
+
     #[test]
     fn auto_target_uses_mount_id_not_host_path() {
         let temp = tempfile::tempdir().unwrap();
@@ -315,6 +369,30 @@ mod tests {
             ),
         )
         .unwrap_err();
+
+        assert_eq!(err.code, "MOUNT_SOURCE_UNSUPPORTED");
+    }
+
+    #[test]
+    fn sandbox_path_source_returns_unsupported() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let mut spec = readonly_host_spec("session-assets", temp.path().join("unused"));
+        spec.source = MountSource::SandboxPath(PathBuf::from("workspace/assets"));
+
+        let err = register_for_test(&workspace_root, spec).unwrap_err();
+
+        assert_eq!(err.code, "MOUNT_SOURCE_UNSUPPORTED");
+    }
+
+    #[test]
+    fn runtime_path_source_returns_unsupported() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let mut spec = readonly_host_spec("runtime-cache", temp.path().join("unused"));
+        spec.source = MountSource::RuntimePath(PathBuf::from("/runtime/cache"));
+
+        let err = register_for_test(&workspace_root, spec).unwrap_err();
 
         assert_eq!(err.code, "MOUNT_SOURCE_UNSUPPORTED");
     }

--- a/crates/ahandd/src/sandbox/mounts.rs
+++ b/crates/ahandd/src/sandbox/mounts.rs
@@ -1,0 +1,428 @@
+use std::fs;
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+use super::registry::SandboxSessionState;
+use super::types::{
+    MountAccess, MountSource, MountSourceSnapshot, RegisteredSandboxMount, SandboxError,
+    SandboxMountSpec, SandboxResult,
+};
+
+pub fn register_mount(
+    session: &SandboxSessionState,
+    spec: SandboxMountSpec,
+) -> SandboxResult<RegisteredSandboxMount> {
+    if spec.access != MountAccess::ReadOnly {
+        return Err(SandboxError::mount_access_denied(
+            "sandbox mounts currently support read-only access only",
+        ));
+    }
+
+    let workspace_root = session.workspace_root.canonicalize().map_err(|e| {
+        SandboxError::mount_target_invalid(format!("failed to resolve sandbox workspace root: {e}"))
+    })?;
+    let mount_namespace = workspace_root.join("workspace").join("mounts");
+    let canonical_namespace = mount_namespace.canonicalize().map_err(|e| {
+        SandboxError::mount_target_invalid(format!("failed to resolve mount namespace: {e}"))
+    })?;
+    let (source, source_snapshot) = resolve_source(spec.source)?;
+    let target = match spec.target {
+        Some(target) => resolve_explicit_target(&workspace_root, &canonical_namespace, &target)?,
+        None => allocate_auto_target(&canonical_namespace, &slug_from_mount_id(&spec.mount_id)),
+    };
+
+    Ok(RegisteredSandboxMount {
+        mount_id: spec.mount_id,
+        source,
+        access: spec.access,
+        scope: spec.scope,
+        target,
+        env_var: spec.env_var,
+        source_snapshot,
+    })
+}
+
+fn resolve_source(source: MountSource) -> SandboxResult<(MountSource, MountSourceSnapshot)> {
+    match source {
+        MountSource::HostPath(path) => {
+            if is_url_like_path(&path) {
+                return Err(SandboxError::mount_source_unsupported(
+                    "URL-like mount sources are not supported",
+                ));
+            }
+            let canonical = path.canonicalize().map_err(|e| {
+                if e.kind() == io::ErrorKind::NotFound {
+                    SandboxError::mount_source_not_found(format!(
+                        "mount source does not exist: {}",
+                        path.display()
+                    ))
+                } else {
+                    SandboxError::unavailable(format!(
+                        "failed to resolve mount source '{}': {e}",
+                        path.display()
+                    ))
+                }
+            })?;
+            let snapshot = snapshot_for_path(&canonical)?;
+            Ok((MountSource::HostPath(canonical), snapshot))
+        }
+        other => Ok((
+            other,
+            MountSourceSnapshot {
+                exists: false,
+                is_dir: false,
+            },
+        )),
+    }
+}
+
+fn snapshot_for_path(path: &Path) -> SandboxResult<MountSourceSnapshot> {
+    let metadata = fs::metadata(path).map_err(|e| {
+        SandboxError::unavailable(format!(
+            "failed to read mount source metadata '{}': {e}",
+            path.display()
+        ))
+    })?;
+    Ok(MountSourceSnapshot {
+        exists: true,
+        is_dir: metadata.is_dir(),
+    })
+}
+
+fn resolve_explicit_target(
+    workspace_root: &Path,
+    canonical_namespace: &Path,
+    target: &Path,
+) -> SandboxResult<PathBuf> {
+    if target.is_absolute() {
+        return Err(SandboxError::mount_target_invalid(
+            "mount targets must be relative to the session root",
+        ));
+    }
+    for component in target.components() {
+        if matches!(
+            component,
+            Component::ParentDir | Component::Prefix(_) | Component::RootDir
+        ) {
+            return Err(SandboxError::mount_target_invalid(
+                "mount target contains disallowed traversal",
+            ));
+        }
+    }
+
+    let candidate = workspace_root.join(target);
+    if !candidate.starts_with(canonical_namespace) {
+        return Err(SandboxError::mount_target_invalid(
+            "mount target must be under workspace/mounts",
+        ));
+    }
+
+    if path_exists(&candidate) {
+        let canonical_candidate = candidate.canonicalize().map_err(|e| {
+            SandboxError::mount_target_invalid(format!(
+                "failed to resolve mount target '{}': {e}",
+                candidate.display()
+            ))
+        })?;
+        if !canonical_candidate.starts_with(canonical_namespace) {
+            return Err(SandboxError::mount_target_invalid(
+                "mount target escapes workspace/mounts",
+            ));
+        }
+        return Err(SandboxError::mount_target_conflict(format!(
+            "mount target already exists: {}",
+            candidate.display()
+        )));
+    }
+
+    let nearest_existing = nearest_existing_ancestor(&candidate).ok_or_else(|| {
+        SandboxError::mount_target_invalid("mount target has no existing parent namespace")
+    })?;
+    let canonical_existing = nearest_existing.canonicalize().map_err(|e| {
+        SandboxError::mount_target_invalid(format!(
+            "failed to resolve mount target parent '{}': {e}",
+            nearest_existing.display()
+        ))
+    })?;
+    if !canonical_existing.starts_with(canonical_namespace) {
+        return Err(SandboxError::mount_target_invalid(
+            "mount target parent escapes workspace/mounts",
+        ));
+    }
+
+    Ok(candidate)
+}
+
+fn allocate_auto_target(canonical_namespace: &Path, slug: &str) -> PathBuf {
+    let mut suffix = 1;
+    loop {
+        let name = if suffix == 1 {
+            slug.to_string()
+        } else {
+            format!("{slug}-{suffix}")
+        };
+        let candidate = canonical_namespace.join(name);
+        if !path_exists(&candidate) {
+            return candidate;
+        }
+        suffix += 1;
+    }
+}
+
+fn path_exists(path: &Path) -> bool {
+    fs::symlink_metadata(path).is_ok()
+}
+
+fn nearest_existing_ancestor(path: &Path) -> Option<PathBuf> {
+    let mut current = path.parent();
+    while let Some(candidate) = current {
+        if path_exists(candidate) {
+            return Some(candidate.to_path_buf());
+        }
+        current = candidate.parent();
+    }
+    None
+}
+
+fn slug_from_mount_id(mount_id: &str) -> String {
+    let mut slug = String::new();
+    let mut previous_separator = false;
+
+    for ch in mount_id.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch);
+            previous_separator = false;
+        } else if !previous_separator && !slug.is_empty() {
+            slug.push('-');
+            previous_separator = true;
+        }
+    }
+
+    while slug.ends_with('-') {
+        slug.pop();
+    }
+
+    if slug.is_empty() {
+        "mount".to_string()
+    } else {
+        slug
+    }
+}
+
+fn is_url_like_path(path: &Path) -> bool {
+    let raw = path.to_string_lossy();
+    raw.contains("://")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    use super::register_mount;
+    use crate::sandbox::NetworkPolicy;
+    use crate::sandbox::registry::SandboxSessionState;
+    use crate::sandbox::types::{
+        MountAccess, MountScope, MountSource, RegisteredSandboxMount, SandboxMountSpec,
+        SandboxPermissionMode, SandboxSessionConfig,
+    };
+
+    fn session(workspace_root: &Path) -> SandboxSessionState {
+        fs::create_dir_all(workspace_root.join("workspace").join("mounts")).unwrap();
+        SandboxSessionState::from_config(SandboxSessionConfig {
+            session_id: "session-1".to_string(),
+            permission_mode: SandboxPermissionMode::Readonly,
+            workspace_root: workspace_root.to_path_buf(),
+            network: NetworkPolicy::Enabled,
+            mounts: Vec::new(),
+        })
+    }
+
+    fn readonly_host_spec(mount_id: &str, source: PathBuf) -> SandboxMountSpec {
+        SandboxMountSpec {
+            mount_id: mount_id.to_string(),
+            source: MountSource::HostPath(source),
+            access: MountAccess::ReadOnly,
+            scope: MountScope::Run {
+                run_id: "run-1".to_string(),
+            },
+            target: None,
+            env_var: Some("COFFICE_SELECTED_FOLDER_DIR".to_string()),
+        }
+    }
+
+    fn register_for_test(
+        workspace_root: &Path,
+        spec: SandboxMountSpec,
+    ) -> crate::sandbox::SandboxResult<RegisteredSandboxMount> {
+        register_mount(&session(workspace_root), spec)
+    }
+
+    #[test]
+    fn auto_target_uses_mount_id_not_host_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host").join("Private Client");
+        fs::create_dir_all(&source).unwrap();
+        let source_with_parent = source.join("..").join("Private Client");
+
+        let mount = register_for_test(
+            &workspace_root,
+            readonly_host_spec("selected-folder", source_with_parent),
+        )
+        .unwrap();
+
+        assert_eq!(
+            mount.target,
+            workspace_root
+                .canonicalize()
+                .unwrap()
+                .join("workspace/mounts/selected-folder")
+        );
+        assert!(!mount.target.to_string_lossy().contains("Private Client"));
+        assert_eq!(
+            mount.source,
+            MountSource::HostPath(source.canonicalize().unwrap())
+        );
+        assert!(mount.source_snapshot.exists);
+        assert!(mount.source_snapshot.is_dir);
+    }
+
+    #[test]
+    fn missing_host_source_returns_not_found() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+
+        let err = register_for_test(
+            &workspace_root,
+            readonly_host_spec("selected-folder", temp.path().join("missing")),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, "MOUNT_SOURCE_NOT_FOUND");
+    }
+
+    #[test]
+    fn url_like_host_source_returns_unsupported() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+
+        let err = register_for_test(
+            &workspace_root,
+            readonly_host_spec(
+                "selected-folder",
+                PathBuf::from("https://example.test/private-client"),
+            ),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, "MOUNT_SOURCE_UNSUPPORTED");
+    }
+
+    #[test]
+    fn non_read_only_access_returns_access_denied() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        fs::create_dir_all(&source).unwrap();
+
+        for access in [
+            MountAccess::WriteOnly,
+            MountAccess::ReadWrite,
+            MountAccess::CopyOnWrite,
+        ] {
+            let mut spec = readonly_host_spec("selected-folder", source.clone());
+            spec.access = access;
+
+            let err = register_for_test(&workspace_root, spec).unwrap_err();
+
+            assert_eq!(err.code, "MOUNT_ACCESS_DENIED");
+        }
+    }
+
+    #[test]
+    fn explicit_target_outside_mount_namespace_returns_invalid() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        fs::create_dir_all(&source).unwrap();
+
+        let mut spec = readonly_host_spec("selected-folder", source.clone());
+        spec.target = Some(workspace_root.join("workspace").join("outside"));
+        let err = register_for_test(&workspace_root, spec).unwrap_err();
+        assert_eq!(err.code, "MOUNT_TARGET_INVALID");
+
+        let mut spec = readonly_host_spec("selected-folder", source);
+        spec.target = Some(PathBuf::from("workspace/mounts/../escape"));
+        let err = register_for_test(&workspace_root, spec).unwrap_err();
+        assert_eq!(err.code, "MOUNT_TARGET_INVALID");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explicit_target_symlink_escape_returns_invalid() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let namespace = workspace_root.join("workspace").join("mounts");
+        let source = temp.path().join("host");
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        fs::create_dir_all(&namespace).unwrap();
+        symlink(&outside, namespace.join("link")).unwrap();
+
+        let mut spec = readonly_host_spec("selected-folder", source);
+        spec.target = Some(PathBuf::from("workspace/mounts/link/selected-folder"));
+
+        let err = register_for_test(&workspace_root, spec).unwrap_err();
+
+        assert_eq!(err.code, "MOUNT_TARGET_INVALID");
+    }
+
+    #[test]
+    fn explicit_target_conflict_returns_conflict() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        let target = workspace_root
+            .join("workspace")
+            .join("mounts")
+            .join("selected-folder");
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&target).unwrap();
+
+        let mut spec = readonly_host_spec("selected-folder", source);
+        spec.target = Some(PathBuf::from("workspace/mounts/selected-folder"));
+
+        let err = register_for_test(&workspace_root, spec).unwrap_err();
+
+        assert_eq!(err.code, "MOUNT_TARGET_CONFLICT");
+    }
+
+    #[test]
+    fn auto_target_uses_deterministic_suffixes_for_existing_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let namespace = workspace_root.join("workspace").join("mounts");
+        let source = temp.path().join("host");
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(namespace.join("selected-folder")).unwrap();
+        fs::create_dir_all(namespace.join("selected-folder-2")).unwrap();
+
+        let mount = register_for_test(
+            &workspace_root,
+            readonly_host_spec("selected-folder", source),
+        )
+        .unwrap();
+
+        assert_eq!(
+            mount.target,
+            workspace_root
+                .canonicalize()
+                .unwrap()
+                .join("workspace/mounts/selected-folder-3")
+        );
+    }
+}

--- a/crates/ahandd/src/sandbox/mounts.rs
+++ b/crates/ahandd/src/sandbox/mounts.rs
@@ -12,6 +12,14 @@ pub fn register_mount(
     session: &SandboxSessionState,
     spec: SandboxMountSpec,
 ) -> SandboxResult<RegisteredSandboxMount> {
+    register_mount_with_existing_targets(session, spec, std::iter::empty::<&Path>())
+}
+
+pub(crate) fn register_mount_with_existing_targets<'a>(
+    session: &SandboxSessionState,
+    spec: SandboxMountSpec,
+    existing_targets: impl IntoIterator<Item = &'a Path>,
+) -> SandboxResult<RegisteredSandboxMount> {
     if spec.access != MountAccess::ReadOnly {
         return Err(SandboxError::mount_access_denied(
             "sandbox mounts currently support read-only access only",
@@ -22,11 +30,25 @@ pub fn register_mount(
         SandboxError::mount_target_invalid(format!("failed to resolve sandbox workspace root: {e}"))
     })?;
     let mount_namespace = workspace_root.join("workspace").join("mounts");
+    ensure_mount_namespace(&workspace_root, &mount_namespace)?;
     let canonical_namespace = validate_mount_namespace(&workspace_root, &mount_namespace)?;
+    let existing_targets = existing_targets
+        .into_iter()
+        .map(Path::to_path_buf)
+        .collect::<Vec<_>>();
     let (source, source_snapshot) = resolve_source(spec.source)?;
     let target = match spec.target {
-        Some(target) => resolve_explicit_target(&workspace_root, &canonical_namespace, &target)?,
-        None => allocate_auto_target(&mount_namespace, &slug_from_mount_id(&spec.mount_id)),
+        Some(target) => resolve_explicit_target(
+            &workspace_root,
+            &canonical_namespace,
+            &target,
+            &existing_targets,
+        )?,
+        None => allocate_auto_target(
+            &mount_namespace,
+            &slug_from_mount_id(&spec.mount_id),
+            &existing_targets,
+        ),
     };
 
     Ok(RegisteredSandboxMount {
@@ -38,6 +60,39 @@ pub fn register_mount(
         env_var: spec.env_var,
         source_snapshot,
     })
+}
+
+fn ensure_mount_namespace(workspace_root: &Path, mount_namespace: &Path) -> SandboxResult<()> {
+    let workspace_dir = workspace_root.join("workspace");
+    ensure_plain_directory(&workspace_dir, "workspace directory")?;
+    ensure_plain_directory(mount_namespace, "mount namespace")
+}
+
+fn ensure_plain_directory(path: &Path, label: &str) -> SandboxResult<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() {
+                return Err(SandboxError::mount_target_invalid(format!(
+                    "{label} must not be a symlink"
+                )));
+            }
+            if !metadata.is_dir() {
+                return Err(SandboxError::mount_target_invalid(format!(
+                    "{label} must be a directory"
+                )));
+            }
+            Ok(())
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            fs::create_dir(path).map_err(|e| {
+                SandboxError::mount_target_invalid(format!("failed to create {label}: {e}"))
+            })?;
+            Ok(())
+        }
+        Err(e) => Err(SandboxError::mount_target_invalid(format!(
+            "failed to inspect {label}: {e}"
+        ))),
+    }
 }
 
 fn resolve_source(source: MountSource) -> SandboxResult<(MountSource, MountSourceSnapshot)> {
@@ -124,6 +179,7 @@ fn resolve_explicit_target(
     workspace_root: &Path,
     canonical_namespace: &Path,
     target: &Path,
+    existing_targets: &[PathBuf],
 ) -> SandboxResult<PathBuf> {
     if target.is_absolute() {
         return Err(SandboxError::mount_target_invalid(
@@ -146,6 +202,12 @@ fn resolve_explicit_target(
         return Err(SandboxError::mount_target_invalid(
             "mount target must be under workspace/mounts",
         ));
+    }
+    if target_conflicts(&candidate, existing_targets) {
+        return Err(SandboxError::mount_target_conflict(format!(
+            "mount target already registered: {}",
+            candidate.display()
+        )));
     }
 
     if path_exists(&candidate) {
@@ -184,7 +246,11 @@ fn resolve_explicit_target(
     Ok(candidate)
 }
 
-fn allocate_auto_target(canonical_namespace: &Path, slug: &str) -> PathBuf {
+fn allocate_auto_target(
+    canonical_namespace: &Path,
+    slug: &str,
+    existing_targets: &[PathBuf],
+) -> PathBuf {
     let mut suffix = 1;
     loop {
         let name = if suffix == 1 {
@@ -193,11 +259,17 @@ fn allocate_auto_target(canonical_namespace: &Path, slug: &str) -> PathBuf {
             format!("{slug}-{suffix}")
         };
         let candidate = canonical_namespace.join(name);
-        if !path_exists(&candidate) {
+        if !path_exists(&candidate) && !target_conflicts(&candidate, existing_targets) {
             return candidate;
         }
         suffix += 1;
     }
+}
+
+fn target_conflicts(candidate: &Path, existing_targets: &[PathBuf]) -> bool {
+    existing_targets
+        .iter()
+        .any(|existing| existing == candidate)
 }
 
 fn path_exists(path: &Path) -> bool {

--- a/crates/ahandd/src/sandbox/platform/macos.rs
+++ b/crates/ahandd/src/sandbox/platform/macos.rs
@@ -175,6 +175,7 @@ mod tests {
         let policy = RuntimeSandboxPolicy {
             writable_root: PathBuf::from("/sessions/s1"),
             readonly_roots: vec![PathBuf::from("/runtimes/python")],
+            mounts: Vec::new(),
             network: NetworkPolicy::Enabled,
         };
 
@@ -195,6 +196,7 @@ mod tests {
         let policy = RuntimeSandboxPolicy {
             writable_root: PathBuf::from("/sessions/s1"),
             readonly_roots: vec![PathBuf::from("/runtime/python")],
+            mounts: Vec::new(),
             network: NetworkPolicy::Enabled,
         };
 
@@ -242,6 +244,7 @@ mod tests {
             policy: RuntimeSandboxPolicy {
                 writable_root: temp.path().to_path_buf(),
                 readonly_roots: vec![PathBuf::from("/bin")],
+                mounts: Vec::new(),
                 network: NetworkPolicy::Enabled,
             },
         })

--- a/crates/ahandd/src/sandbox/platform/windows.rs
+++ b/crates/ahandd/src/sandbox/platform/windows.rs
@@ -37,6 +37,7 @@ mod tests {
         let policy = WindowsRuntimePolicy::from_runtime_policy(RuntimeSandboxPolicy {
             writable_root: PathBuf::from(r"C:\sessions\s1"),
             readonly_roots: vec![PathBuf::from(r"C:\runtimes\python")],
+            mounts: Vec::new(),
             network: NetworkPolicy::Enabled,
         });
 

--- a/crates/ahandd/src/sandbox/registry.rs
+++ b/crates/ahandd/src/sandbox/registry.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -65,13 +65,12 @@ impl SandboxSessionState {
 
     pub fn exec_environment(&self) -> RegisteredExecEnvironment {
         self.exec_environment_for(None)
-            .expect("sandbox exec environment without context should not fail")
     }
 
     pub fn exec_environment_for(
         &self,
         context: Option<&SandboxInvocationContext>,
-    ) -> SandboxResult<RegisteredExecEnvironment> {
+    ) -> RegisteredExecEnvironment {
         let mut path_entries = Vec::new();
         let mut readonly_roots = Vec::new();
         let mut env = HashMap::new();
@@ -96,24 +95,26 @@ impl SandboxSessionState {
                     env.insert(env_var.clone(), mount.target.to_string_lossy().to_string());
                 }
                 active_mounts.push(mount.clone());
-            } else if mount.env_var.is_some() && mount_scope_requires_context(&mount.scope) {
-                return Err(SandboxError::mount_scope_mismatch(format!(
-                    "sandbox mount '{}' is scoped to a different invocation context",
-                    mount.mount_id
-                )));
             }
         }
 
         path_entries.sort();
         readonly_roots.sort();
 
-        Ok(RegisteredExecEnvironment {
+        RegisteredExecEnvironment {
             path_entries,
             readonly_roots,
             env,
             mounts: active_mounts,
             default_timeout: Duration::from_secs(30),
-        })
+        }
+    }
+
+    pub fn registered_mount_env_vars(&self) -> BTreeSet<String> {
+        self.mounts
+            .values()
+            .filter_map(|mount| mount.env_var.clone())
+            .collect()
     }
 }
 
@@ -130,10 +131,6 @@ fn mount_scope_active(scope: &MountScope, context: Option<&SandboxInvocationCont
                 == Some(invocation_id.as_str())
         }
     }
-}
-
-fn mount_scope_requires_context(scope: &MountScope) -> bool {
-    !matches!(scope, MountScope::Session)
 }
 
 fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
@@ -228,6 +225,17 @@ impl SandboxRegistry {
                 "sandbox mount '{}' is already registered for the requested scope",
                 spec.mount_id
             )));
+        }
+        if let Some(env_var) = &spec.env_var {
+            if session
+                .mounts
+                .values()
+                .any(|mount| mount.env_var.as_deref() == Some(env_var.as_str()))
+            {
+                return Err(SandboxError::mount_env_conflict(format!(
+                    "sandbox mount env var '{env_var}' is already registered"
+                )));
+            }
         }
         let existing_targets = session
             .mounts
@@ -515,6 +523,80 @@ mod tests {
     }
 
     #[test]
+    fn sandbox_registry_duplicate_mount_env_var_is_rejected() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        fs::create_dir_all(&workspace_root).unwrap();
+        fs::create_dir_all(&source).unwrap();
+        let mut registry = SandboxRegistry::default();
+        registry.create_session(config(workspace_root)).unwrap();
+        registry
+            .register_mount(
+                "session-1",
+                readonly_mount_with_env(
+                    "selected-folder",
+                    source.clone(),
+                    MountScope::Run {
+                        run_id: "run-1".to_string(),
+                    },
+                    "COFFICE_SELECTED_FOLDER_DIR",
+                ),
+            )
+            .unwrap();
+
+        let err = registry
+            .register_mount(
+                "session-1",
+                readonly_mount_with_env(
+                    "selected-folder-2",
+                    source,
+                    MountScope::Run {
+                        run_id: "run-2".to_string(),
+                    },
+                    "COFFICE_SELECTED_FOLDER_DIR",
+                ),
+            )
+            .unwrap_err();
+
+        assert_eq!(err.code, "MOUNT_ENV_CONFLICT");
+    }
+
+    #[test]
+    fn sandbox_registry_create_session_rejects_initial_duplicate_mount_env_var() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        fs::create_dir_all(&workspace_root).unwrap();
+        fs::create_dir_all(&source).unwrap();
+        let mut config = config(workspace_root);
+        config.mounts = vec![
+            readonly_mount_with_env(
+                "selected-folder",
+                source.clone(),
+                MountScope::Run {
+                    run_id: "run-1".to_string(),
+                },
+                "COFFICE_SELECTED_FOLDER_DIR",
+            ),
+            readonly_mount_with_env(
+                "selected-folder-2",
+                source,
+                MountScope::Run {
+                    run_id: "run-2".to_string(),
+                },
+                "COFFICE_SELECTED_FOLDER_DIR",
+            ),
+        ];
+        let mut registry = SandboxRegistry::default();
+
+        let err = registry.create_session(config).unwrap_err();
+
+        assert_eq!(err.code, "MOUNT_ENV_CONFLICT");
+        assert!(registry.session("session-1").is_err());
+    }
+
+    #[test]
     fn permission_update_increments_only_on_change() {
         let temp = tempfile::tempdir().unwrap();
         let mut registry = SandboxRegistry::default();
@@ -651,8 +733,7 @@ mod tests {
         let env = registry
             .session("session-1")
             .unwrap()
-            .exec_environment_for(None)
-            .unwrap();
+            .exec_environment_for(None);
 
         let target = workspace_root
             .canonicalize()
@@ -699,8 +780,7 @@ mod tests {
                 run_id: Some("run-1".to_string()),
                 scope_id: None,
                 invocation_id: None,
-            }))
-            .unwrap();
+            }));
         let mismatched = registry
             .session("session-1")
             .unwrap()
@@ -709,8 +789,11 @@ mod tests {
                 run_id: Some("run-2".to_string()),
                 scope_id: None,
                 invocation_id: None,
-            }))
-            .unwrap_err();
+            }));
+        let no_context = registry
+            .session("session-1")
+            .unwrap()
+            .exec_environment_for(None);
 
         let target = workspace_root
             .canonicalize()
@@ -721,7 +804,10 @@ mod tests {
             target.to_string_lossy()
         );
         assert_eq!(matching.mounts.len(), 1);
-        assert_eq!(mismatched.code, "MOUNT_SCOPE_MISMATCH");
+        assert!(mismatched.mounts.is_empty());
+        assert!(!mismatched.env.contains_key("COFFICE_SELECTED_FOLDER_DIR"));
+        assert!(no_context.mounts.is_empty());
+        assert!(!no_context.env.contains_key("COFFICE_SELECTED_FOLDER_DIR"));
     }
 
     #[test]
@@ -757,8 +843,7 @@ mod tests {
                 run_id: None,
                 scope_id: None,
                 invocation_id: Some("inv-1".to_string()),
-            }))
-            .unwrap();
+            }));
         let mismatched = registry
             .session("session-1")
             .unwrap()
@@ -767,8 +852,11 @@ mod tests {
                 run_id: None,
                 scope_id: None,
                 invocation_id: Some("inv-2".to_string()),
-            }))
-            .unwrap_err();
+            }));
+        let no_context = registry
+            .session("session-1")
+            .unwrap()
+            .exec_environment_for(None);
 
         let target = workspace_root
             .canonicalize()
@@ -779,11 +867,14 @@ mod tests {
             target.to_string_lossy()
         );
         assert_eq!(matching.mounts.len(), 1);
-        assert_eq!(mismatched.code, "MOUNT_SCOPE_MISMATCH");
+        assert!(mismatched.mounts.is_empty());
+        assert!(!mismatched.env.contains_key("COFFICE_SELECTED_FOLDER_DIR"));
+        assert!(no_context.mounts.is_empty());
+        assert!(!no_context.env.contains_key("COFFICE_SELECTED_FOLDER_DIR"));
     }
 
     #[test]
-    fn sandbox_exec_environment_run_mount_env_var_fails_closed_without_context() {
+    fn sandbox_exec_environment_inactive_run_mount_env_var_is_omitted_without_context() {
         let temp = tempfile::tempdir().unwrap();
         let workspace_root = temp.path().join("sandbox");
         let source = temp.path().join("host");
@@ -805,13 +896,16 @@ mod tests {
             )
             .unwrap();
 
-        let err = registry
+        let env = registry
             .session("session-1")
             .unwrap()
-            .exec_environment_for(None)
-            .unwrap_err();
+            .exec_environment_for(None);
+        let legacy_env = registry.session("session-1").unwrap().exec_environment();
 
-        assert_eq!(err.code, "MOUNT_SCOPE_MISMATCH");
+        assert!(env.mounts.is_empty());
+        assert!(!env.env.contains_key("COFFICE_SELECTED_FOLDER_DIR"));
+        assert!(legacy_env.mounts.is_empty());
+        assert!(!legacy_env.env.contains_key("COFFICE_SELECTED_FOLDER_DIR"));
     }
 
     #[test]
@@ -839,8 +933,7 @@ mod tests {
         let env = registry
             .session("session-1")
             .unwrap()
-            .exec_environment_for(None)
-            .unwrap();
+            .exec_environment_for(None);
 
         assert!(env.mounts.is_empty());
     }

--- a/crates/ahandd/src/sandbox/registry.rs
+++ b/crates/ahandd/src/sandbox/registry.rs
@@ -179,7 +179,7 @@ impl SandboxRegistry {
     ) -> SandboxResult<RegisteredSandboxMount> {
         let key = (spec.mount_id.clone(), spec.scope.clone());
         if session.mounts.contains_key(&key) {
-            return Err(SandboxError::mount_target_conflict(format!(
+            return Err(SandboxError::mount_already_registered(format!(
                 "sandbox mount '{}' is already registered for the requested scope",
                 spec.mount_id
             )));
@@ -376,7 +376,7 @@ mod tests {
             )
             .unwrap_err();
 
-        assert_eq!(err.code, "MOUNT_TARGET_CONFLICT");
+        assert_eq!(err.code, "MOUNT_ALREADY_REGISTERED");
     }
 
     #[test]

--- a/crates/ahandd/src/sandbox/registry.rs
+++ b/crates/ahandd/src/sandbox/registry.rs
@@ -225,16 +225,15 @@ impl SandboxRegistry {
                 spec.mount_id
             )));
         }
-        if let Some(env_var) = &spec.env_var {
-            if session
+        if let Some(env_var) = &spec.env_var
+            && session
                 .mounts
                 .values()
                 .any(|mount| mount.env_var.as_deref() == Some(env_var.as_str()))
-            {
-                return Err(SandboxError::mount_env_conflict(format!(
-                    "sandbox mount env var '{env_var}' is already registered"
-                )));
-            }
+        {
+            return Err(SandboxError::mount_env_conflict(format!(
+                "sandbox mount env var '{env_var}' is already registered"
+            )));
         }
         let existing_targets = session
             .mounts

--- a/crates/ahandd/src/sandbox/registry.rs
+++ b/crates/ahandd/src/sandbox/registry.rs
@@ -122,8 +122,7 @@ fn mount_scope_active(scope: &MountScope, context: Option<&SandboxInvocationCont
     match scope {
         MountScope::Session => true,
         MountScope::Run { run_id } => {
-            context
-                .and_then(|context| context.run_id.as_deref().or(context.scope_id.as_deref()))
+            context.and_then(|context| context.run_id.as_deref().or(context.scope_id.as_deref()))
                 == Some(run_id.as_str())
         }
         MountScope::Invocation { invocation_id } => {

--- a/crates/ahandd/src/sandbox/registry.rs
+++ b/crates/ahandd/src/sandbox/registry.rs
@@ -144,6 +144,7 @@ mod tests {
             permission_mode: SandboxPermissionMode::Readonly,
             workspace_root,
             network: NetworkPolicy::Enabled,
+            mounts: Vec::new(),
         }
     }
 

--- a/crates/ahandd/src/sandbox/registry.rs
+++ b/crates/ahandd/src/sandbox/registry.rs
@@ -6,7 +6,8 @@ use super::mounts;
 use super::types::{
     FileVersion, HostFileRef, MountScope, NetworkPolicy, PermissionSnapshot,
     RegisteredExecEnvironment, RegisteredSandboxMount, RuntimeProviderConfig, SandboxError,
-    SandboxFile, SandboxMountSpec, SandboxPermissionMode, SandboxResult, SandboxSessionConfig,
+    SandboxFile, SandboxInvocationContext, SandboxMountSpec, SandboxPermissionMode, SandboxResult,
+    SandboxSessionConfig,
 };
 
 #[derive(Debug, Clone)]
@@ -63,9 +64,18 @@ impl SandboxSessionState {
     }
 
     pub fn exec_environment(&self) -> RegisteredExecEnvironment {
+        self.exec_environment_for(None)
+            .expect("sandbox exec environment without context should not fail")
+    }
+
+    pub fn exec_environment_for(
+        &self,
+        context: Option<&SandboxInvocationContext>,
+    ) -> SandboxResult<RegisteredExecEnvironment> {
         let mut path_entries = Vec::new();
         let mut readonly_roots = Vec::new();
         let mut env = HashMap::new();
+        let mut active_mounts = Vec::new();
 
         for provider in self.runtimes.values() {
             if let Some(parent) = provider.executable.parent() {
@@ -79,16 +89,51 @@ impl SandboxSessionState {
             }
         }
 
+        for mount in self.mounts.values() {
+            let active = mount_scope_active(&mount.scope, context);
+            if active {
+                if let Some(env_var) = &mount.env_var {
+                    env.insert(env_var.clone(), mount.target.to_string_lossy().to_string());
+                }
+                active_mounts.push(mount.clone());
+            } else if mount.env_var.is_some() && mount_scope_requires_context(&mount.scope) {
+                return Err(SandboxError::mount_scope_mismatch(format!(
+                    "sandbox mount '{}' is scoped to a different invocation context",
+                    mount.mount_id
+                )));
+            }
+        }
+
         path_entries.sort();
         readonly_roots.sort();
 
-        RegisteredExecEnvironment {
+        Ok(RegisteredExecEnvironment {
             path_entries,
             readonly_roots,
             env,
+            mounts: active_mounts,
             default_timeout: Duration::from_secs(30),
+        })
+    }
+}
+
+fn mount_scope_active(scope: &MountScope, context: Option<&SandboxInvocationContext>) -> bool {
+    match scope {
+        MountScope::Session => true,
+        MountScope::Run { run_id } => {
+            context
+                .and_then(|context| context.run_id.as_deref().or(context.scope_id.as_deref()))
+                == Some(run_id.as_str())
+        }
+        MountScope::Invocation { invocation_id } => {
+            context.and_then(|context| context.invocation_id.as_deref())
+                == Some(invocation_id.as_str())
         }
     }
+}
+
+fn mount_scope_requires_context(scope: &MountScope) -> bool {
+    !matches!(scope, MountScope::Session)
 }
 
 fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
@@ -200,8 +245,8 @@ impl SandboxRegistry {
 mod tests {
     use super::*;
     use crate::sandbox::types::{
-        MountAccess, MountScope, MountSource, NetworkPolicy, SandboxMountSpec,
-        SandboxPermissionMode, SandboxSessionConfig,
+        MountAccess, MountScope, MountSource, NetworkPolicy, SandboxInvocationContext,
+        SandboxMountSpec, SandboxPermissionMode, SandboxSessionConfig,
     };
     use std::fs;
     use std::path::PathBuf;
@@ -224,6 +269,18 @@ mod tests {
             scope,
             target: None,
             env_var: None,
+        }
+    }
+
+    fn readonly_mount_with_env(
+        mount_id: &str,
+        source: PathBuf,
+        scope: MountScope,
+        env_var: &str,
+    ) -> SandboxMountSpec {
+        SandboxMountSpec {
+            env_var: Some(env_var.to_string()),
+            ..readonly_mount(mount_id, source, scope)
         }
     }
 
@@ -566,5 +623,225 @@ mod tests {
             env.readonly_roots,
             vec![runtime_root.canonicalize().unwrap()]
         );
+    }
+
+    #[test]
+    fn sandbox_exec_environment_session_mount_is_active_without_context() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        fs::create_dir_all(&workspace_root).unwrap();
+        fs::create_dir_all(&source).unwrap();
+        let mut registry = SandboxRegistry::default();
+        registry
+            .create_session(config(workspace_root.clone()))
+            .unwrap();
+        registry
+            .register_mount(
+                "session-1",
+                readonly_mount_with_env(
+                    "selected-folder",
+                    source,
+                    MountScope::Session,
+                    "COFFICE_SELECTED_FOLDER_DIR",
+                ),
+            )
+            .unwrap();
+
+        let env = registry
+            .session("session-1")
+            .unwrap()
+            .exec_environment_for(None)
+            .unwrap();
+
+        let target = workspace_root
+            .canonicalize()
+            .unwrap()
+            .join("workspace/mounts/selected-folder");
+        assert_eq!(env.mounts.len(), 1);
+        assert_eq!(env.mounts[0].target, target);
+        assert_eq!(
+            env.env["COFFICE_SELECTED_FOLDER_DIR"],
+            target.to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn sandbox_exec_environment_run_mount_requires_matching_run_id() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        fs::create_dir_all(&workspace_root).unwrap();
+        fs::create_dir_all(&source).unwrap();
+        let mut registry = SandboxRegistry::default();
+        registry
+            .create_session(config(workspace_root.clone()))
+            .unwrap();
+        registry
+            .register_mount(
+                "session-1",
+                readonly_mount_with_env(
+                    "selected-folder",
+                    source,
+                    MountScope::Run {
+                        run_id: "run-1".to_string(),
+                    },
+                    "COFFICE_SELECTED_FOLDER_DIR",
+                ),
+            )
+            .unwrap();
+
+        let matching = registry
+            .session("session-1")
+            .unwrap()
+            .exec_environment_for(Some(&SandboxInvocationContext {
+                session_id: "session-1".to_string(),
+                run_id: Some("run-1".to_string()),
+                scope_id: None,
+                invocation_id: None,
+            }))
+            .unwrap();
+        let mismatched = registry
+            .session("session-1")
+            .unwrap()
+            .exec_environment_for(Some(&SandboxInvocationContext {
+                session_id: "session-1".to_string(),
+                run_id: Some("run-2".to_string()),
+                scope_id: None,
+                invocation_id: None,
+            }))
+            .unwrap_err();
+
+        let target = workspace_root
+            .canonicalize()
+            .unwrap()
+            .join("workspace/mounts/selected-folder");
+        assert_eq!(
+            matching.env["COFFICE_SELECTED_FOLDER_DIR"],
+            target.to_string_lossy()
+        );
+        assert_eq!(matching.mounts.len(), 1);
+        assert_eq!(mismatched.code, "MOUNT_SCOPE_MISMATCH");
+    }
+
+    #[test]
+    fn sandbox_exec_environment_invocation_mount_requires_matching_invocation_id() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        fs::create_dir_all(&workspace_root).unwrap();
+        fs::create_dir_all(&source).unwrap();
+        let mut registry = SandboxRegistry::default();
+        registry
+            .create_session(config(workspace_root.clone()))
+            .unwrap();
+        registry
+            .register_mount(
+                "session-1",
+                readonly_mount_with_env(
+                    "selected-folder",
+                    source,
+                    MountScope::Invocation {
+                        invocation_id: "inv-1".to_string(),
+                    },
+                    "COFFICE_SELECTED_FOLDER_DIR",
+                ),
+            )
+            .unwrap();
+
+        let matching = registry
+            .session("session-1")
+            .unwrap()
+            .exec_environment_for(Some(&SandboxInvocationContext {
+                session_id: "session-1".to_string(),
+                run_id: None,
+                scope_id: None,
+                invocation_id: Some("inv-1".to_string()),
+            }))
+            .unwrap();
+        let mismatched = registry
+            .session("session-1")
+            .unwrap()
+            .exec_environment_for(Some(&SandboxInvocationContext {
+                session_id: "session-1".to_string(),
+                run_id: None,
+                scope_id: None,
+                invocation_id: Some("inv-2".to_string()),
+            }))
+            .unwrap_err();
+
+        let target = workspace_root
+            .canonicalize()
+            .unwrap()
+            .join("workspace/mounts/selected-folder");
+        assert_eq!(
+            matching.env["COFFICE_SELECTED_FOLDER_DIR"],
+            target.to_string_lossy()
+        );
+        assert_eq!(matching.mounts.len(), 1);
+        assert_eq!(mismatched.code, "MOUNT_SCOPE_MISMATCH");
+    }
+
+    #[test]
+    fn sandbox_exec_environment_run_mount_env_var_fails_closed_without_context() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        fs::create_dir_all(&workspace_root).unwrap();
+        fs::create_dir_all(&source).unwrap();
+        let mut registry = SandboxRegistry::default();
+        registry.create_session(config(workspace_root)).unwrap();
+        registry
+            .register_mount(
+                "session-1",
+                readonly_mount_with_env(
+                    "selected-folder",
+                    source,
+                    MountScope::Run {
+                        run_id: "run-1".to_string(),
+                    },
+                    "COFFICE_SELECTED_FOLDER_DIR",
+                ),
+            )
+            .unwrap();
+
+        let err = registry
+            .session("session-1")
+            .unwrap()
+            .exec_environment_for(None)
+            .unwrap_err();
+
+        assert_eq!(err.code, "MOUNT_SCOPE_MISMATCH");
+    }
+
+    #[test]
+    fn sandbox_exec_environment_scoped_mount_without_env_var_can_be_inactive() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        fs::create_dir_all(&workspace_root).unwrap();
+        fs::create_dir_all(&source).unwrap();
+        let mut registry = SandboxRegistry::default();
+        registry.create_session(config(workspace_root)).unwrap();
+        registry
+            .register_mount(
+                "session-1",
+                readonly_mount(
+                    "selected-folder",
+                    source,
+                    MountScope::Run {
+                        run_id: "run-1".to_string(),
+                    },
+                ),
+            )
+            .unwrap();
+
+        let env = registry
+            .session("session-1")
+            .unwrap()
+            .exec_environment_for(None)
+            .unwrap();
+
+        assert!(env.mounts.is_empty());
     }
 }

--- a/crates/ahandd/src/sandbox/registry.rs
+++ b/crates/ahandd/src/sandbox/registry.rs
@@ -2,10 +2,11 @@ use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::time::Duration;
 
+use super::mounts;
 use super::types::{
-    FileVersion, HostFileRef, NetworkPolicy, PermissionSnapshot, RegisteredExecEnvironment,
-    RuntimeProviderConfig, SandboxError, SandboxFile, SandboxPermissionMode, SandboxResult,
-    SandboxSessionConfig,
+    FileVersion, HostFileRef, MountScope, NetworkPolicy, PermissionSnapshot,
+    RegisteredExecEnvironment, RegisteredSandboxMount, RuntimeProviderConfig, SandboxError,
+    SandboxFile, SandboxMountSpec, SandboxPermissionMode, SandboxResult, SandboxSessionConfig,
 };
 
 #[derive(Debug, Clone)]
@@ -17,21 +18,31 @@ pub struct SandboxSessionState {
     pub host_file_refs: BTreeMap<String, HostFileRef>,
     pub imported_files: BTreeMap<String, SandboxFile>,
     pub file_versions: BTreeMap<String, FileVersion>,
+    pub mounts: BTreeMap<(String, MountScope), RegisteredSandboxMount>,
     permission: PermissionSnapshot,
 }
 
 impl SandboxSessionState {
     pub fn from_config(config: SandboxSessionConfig) -> Self {
+        let SandboxSessionConfig {
+            session_id,
+            permission_mode,
+            workspace_root,
+            network,
+            mounts: _,
+        } = config;
+
         Self {
-            session_id: config.session_id,
-            workspace_root: config.workspace_root,
-            network: config.network,
+            session_id,
+            workspace_root,
+            network,
             runtimes: BTreeMap::new(),
             host_file_refs: BTreeMap::new(),
             imported_files: BTreeMap::new(),
             file_versions: BTreeMap::new(),
+            mounts: BTreeMap::new(),
             permission: PermissionSnapshot {
-                mode: config.permission_mode,
+                mode: permission_mode,
                 version: 1,
             },
         }
@@ -97,12 +108,16 @@ impl SandboxRegistry {
             SandboxError::unavailable(format!("failed to resolve sandbox workspace root: {e}"))
         })?;
         let session_id = config.session_id.clone();
-        let config = SandboxSessionConfig {
+        let mut config = SandboxSessionConfig {
             workspace_root,
             ..config
         };
-        self.sessions
-            .insert(session_id, SandboxSessionState::from_config(config));
+        let initial_mounts = std::mem::take(&mut config.mounts);
+        let mut session = SandboxSessionState::from_config(config);
+        for spec in initial_mounts {
+            Self::register_mount_for_session(&mut session, spec)?;
+        }
+        self.sessions.insert(session_id, session);
         Ok(())
     }
 
@@ -129,12 +144,65 @@ impl SandboxRegistry {
     ) -> SandboxResult<PermissionSnapshot> {
         Ok(self.session_mut(session_id)?.update_permission(mode))
     }
+
+    pub fn register_mount(
+        &mut self,
+        session_id: &str,
+        spec: SandboxMountSpec,
+    ) -> SandboxResult<RegisteredSandboxMount> {
+        let session = self.session_mut(session_id)?;
+        Self::register_mount_for_session(session, spec)
+    }
+
+    pub fn unregister_mount(
+        &mut self,
+        session_id: &str,
+        mount_id: &str,
+        scope: MountScope,
+    ) -> SandboxResult<()> {
+        let session = self.session_mut(session_id)?;
+        let key = (mount_id.to_string(), scope);
+        session.mounts.remove(&key).map(|_| ()).ok_or_else(|| {
+            SandboxError::mount_not_registered(format!(
+                "sandbox mount '{mount_id}' is not registered for the requested scope"
+            ))
+        })
+    }
+
+    pub fn list_mounts(&self, session_id: &str) -> SandboxResult<Vec<RegisteredSandboxMount>> {
+        Ok(self.session(session_id)?.mounts.values().cloned().collect())
+    }
+
+    fn register_mount_for_session(
+        session: &mut SandboxSessionState,
+        spec: SandboxMountSpec,
+    ) -> SandboxResult<RegisteredSandboxMount> {
+        let key = (spec.mount_id.clone(), spec.scope.clone());
+        if session.mounts.contains_key(&key) {
+            return Err(SandboxError::mount_target_conflict(format!(
+                "sandbox mount '{}' is already registered for the requested scope",
+                spec.mount_id
+            )));
+        }
+        let existing_targets = session
+            .mounts
+            .values()
+            .map(|mount| mount.target.as_path())
+            .collect::<Vec<_>>();
+        let registered =
+            mounts::register_mount_with_existing_targets(session, spec, existing_targets)?;
+        session.mounts.insert(key, registered.clone());
+        Ok(registered)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sandbox::types::{NetworkPolicy, SandboxPermissionMode, SandboxSessionConfig};
+    use crate::sandbox::types::{
+        MountAccess, MountScope, MountSource, NetworkPolicy, SandboxMountSpec,
+        SandboxPermissionMode, SandboxSessionConfig,
+    };
     use std::fs;
     use std::path::PathBuf;
 
@@ -145,6 +213,17 @@ mod tests {
             workspace_root,
             network: NetworkPolicy::Enabled,
             mounts: Vec::new(),
+        }
+    }
+
+    fn readonly_mount(mount_id: &str, source: PathBuf, scope: MountScope) -> SandboxMountSpec {
+        SandboxMountSpec {
+            mount_id: mount_id.to_string(),
+            source: MountSource::HostPath(source),
+            access: MountAccess::ReadOnly,
+            scope,
+            target: None,
+            env_var: None,
         }
     }
 
@@ -176,6 +255,206 @@ mod tests {
             registry.session("session-1").unwrap().workspace_root,
             workspace_root.canonicalize().unwrap()
         );
+    }
+
+    #[test]
+    fn sandbox_registry_create_session_registers_initial_config_mounts() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        fs::create_dir_all(&workspace_root).unwrap();
+        fs::create_dir_all(&source).unwrap();
+        let mut config = config(workspace_root.clone());
+        config.mounts = vec![readonly_mount(
+            "selected-folder",
+            source.clone(),
+            MountScope::Session,
+        )];
+        let mut registry = SandboxRegistry::default();
+
+        registry.create_session(config).unwrap();
+        let mounts = registry.list_mounts("session-1").unwrap();
+
+        assert_eq!(mounts.len(), 1);
+        assert_eq!(mounts[0].mount_id, "selected-folder");
+        assert_eq!(
+            mounts[0].source,
+            MountSource::HostPath(source.canonicalize().unwrap())
+        );
+        assert_eq!(
+            mounts[0].target,
+            workspace_root
+                .canonicalize()
+                .unwrap()
+                .join("workspace/mounts/selected-folder")
+        );
+    }
+
+    #[test]
+    fn sandbox_registry_create_session_fails_when_initial_mount_invalid() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        fs::create_dir_all(&workspace_root).unwrap();
+        let mut config = config(workspace_root);
+        config.mounts = vec![readonly_mount(
+            "selected-folder",
+            temp.path().join("missing"),
+            MountScope::Session,
+        )];
+        let mut registry = SandboxRegistry::default();
+
+        let err = registry.create_session(config).unwrap_err();
+
+        assert_eq!(err.code, "MOUNT_SOURCE_NOT_FOUND");
+        assert!(registry.session("session-1").is_err());
+    }
+
+    #[test]
+    fn sandbox_registry_register_list_unregister_mount_round_trip() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        fs::create_dir_all(&workspace_root).unwrap();
+        fs::create_dir_all(&source).unwrap();
+        let mut registry = SandboxRegistry::default();
+        registry.create_session(config(workspace_root)).unwrap();
+
+        let registered = registry
+            .register_mount(
+                "session-1",
+                readonly_mount(
+                    "selected-folder",
+                    source,
+                    MountScope::Run {
+                        run_id: "run-1".to_string(),
+                    },
+                ),
+            )
+            .unwrap();
+        assert_eq!(registry.list_mounts("session-1").unwrap(), vec![registered]);
+
+        registry
+            .unregister_mount(
+                "session-1",
+                "selected-folder",
+                MountScope::Run {
+                    run_id: "run-1".to_string(),
+                },
+            )
+            .unwrap();
+
+        assert!(registry.list_mounts("session-1").unwrap().is_empty());
+        let err = registry
+            .unregister_mount("session-1", "selected-folder", MountScope::Session)
+            .unwrap_err();
+        assert_eq!(err.code, "MOUNT_NOT_REGISTERED");
+    }
+
+    #[test]
+    fn sandbox_registry_duplicate_mount_id_same_scope_is_rejected() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        fs::create_dir_all(&workspace_root).unwrap();
+        fs::create_dir_all(&source).unwrap();
+        let mut registry = SandboxRegistry::default();
+        registry.create_session(config(workspace_root)).unwrap();
+        let scope = MountScope::Run {
+            run_id: "run-1".to_string(),
+        };
+        registry
+            .register_mount(
+                "session-1",
+                readonly_mount("selected-folder", source.clone(), scope.clone()),
+            )
+            .unwrap();
+
+        let err = registry
+            .register_mount(
+                "session-1",
+                readonly_mount("selected-folder", source, scope),
+            )
+            .unwrap_err();
+
+        assert_eq!(err.code, "MOUNT_TARGET_CONFLICT");
+    }
+
+    #[test]
+    fn sandbox_registry_duplicate_mount_id_different_scope_is_allowed_with_auto_suffixes() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        fs::create_dir_all(&workspace_root).unwrap();
+        fs::create_dir_all(&source).unwrap();
+        let mut registry = SandboxRegistry::default();
+        registry
+            .create_session(config(workspace_root.clone()))
+            .unwrap();
+
+        let first = registry
+            .register_mount(
+                "session-1",
+                readonly_mount(
+                    "selected-folder",
+                    source.clone(),
+                    MountScope::Run {
+                        run_id: "run-1".to_string(),
+                    },
+                ),
+            )
+            .unwrap();
+        let second = registry
+            .register_mount(
+                "session-1",
+                readonly_mount(
+                    "selected-folder",
+                    source,
+                    MountScope::Run {
+                        run_id: "run-2".to_string(),
+                    },
+                ),
+            )
+            .unwrap();
+
+        let namespace = workspace_root
+            .canonicalize()
+            .unwrap()
+            .join("workspace/mounts");
+        assert_eq!(first.target, namespace.join("selected-folder"));
+        assert_eq!(second.target, namespace.join("selected-folder-2"));
+        assert_eq!(
+            registry.list_mounts("session-1").unwrap(),
+            vec![first, second]
+        );
+    }
+
+    #[test]
+    fn sandbox_registry_explicit_target_conflicts_with_registered_mount() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        fs::create_dir_all(&workspace_root).unwrap();
+        fs::create_dir_all(&source).unwrap();
+        let mut registry = SandboxRegistry::default();
+        registry.create_session(config(workspace_root)).unwrap();
+        registry
+            .register_mount(
+                "session-1",
+                readonly_mount("selected-folder", source.clone(), MountScope::Session),
+            )
+            .unwrap();
+        let mut spec = readonly_mount(
+            "other-folder",
+            source,
+            MountScope::Run {
+                run_id: "run-1".to_string(),
+            },
+        );
+        spec.target = Some(PathBuf::from("workspace/mounts/selected-folder"));
+
+        let err = registry.register_mount("session-1", spec).unwrap_err();
+
+        assert_eq!(err.code, "MOUNT_TARGET_CONFLICT");
     }
 
     #[test]

--- a/crates/ahandd/src/sandbox/runner.rs
+++ b/crates/ahandd/src/sandbox/runner.rs
@@ -158,49 +158,13 @@ fn materialize_mount_target_symlink(
     let canonical_workspace = workspace_root.canonicalize().map_err(|e| {
         SandboxError::mount_target_invalid(format!("failed to resolve sandbox workspace root: {e}"))
     })?;
-    let mount_namespace = canonical_workspace.join("workspace").join("mounts");
-    fs::create_dir_all(&mount_namespace).map_err(|e| {
-        SandboxError::mount_target_invalid(format!("failed to create mount namespace: {e}"))
-    })?;
-    let namespace_metadata = fs::symlink_metadata(&mount_namespace).map_err(|e| {
-        SandboxError::mount_target_invalid(format!("failed to inspect mount namespace: {e}"))
-    })?;
-    if namespace_metadata.file_type().is_symlink() || !namespace_metadata.is_dir() {
-        return Err(SandboxError::mount_target_invalid(
-            "mount namespace must be a plain directory",
-        ));
-    }
-    let canonical_namespace = mount_namespace.canonicalize().map_err(|e| {
-        SandboxError::mount_target_invalid(format!("failed to resolve mount namespace: {e}"))
-    })?;
-    if canonical_namespace != mount_namespace {
-        return Err(SandboxError::mount_target_invalid(
-            "mount namespace must resolve without symlinks",
-        ));
-    }
+    let canonical_namespace = prepare_mount_namespace(&canonical_workspace)?;
     if !target.is_absolute() || contains_parent_component(target) {
         return Err(SandboxError::mount_target_invalid(
             "resolved mount target must be an absolute path without traversal",
         ));
     }
-    let parent = target.parent().ok_or_else(|| {
-        SandboxError::mount_target_invalid("mount target has no parent namespace")
-    })?;
-    let file_name = target.file_name().ok_or_else(|| {
-        SandboxError::mount_target_invalid("mount target must include a final path component")
-    })?;
-    let canonical_parent = parent.canonicalize().map_err(|e| {
-        SandboxError::mount_target_invalid(format!(
-            "failed to resolve mount target parent '{}': {e}",
-            parent.display()
-        ))
-    })?;
-    let canonical_target_path = canonical_parent.join(file_name);
-    if !canonical_target_path.starts_with(&canonical_namespace) {
-        return Err(SandboxError::mount_target_invalid(
-            "mount target parent escapes workspace/mounts",
-        ));
-    }
+    let parent = validate_mount_target_parent(&canonical_namespace, target)?;
 
     match fs::symlink_metadata(target) {
         Ok(metadata) if metadata.file_type().is_symlink() => {
@@ -245,7 +209,95 @@ fn materialize_mount_target_symlink(
         }
     }
 
+    validate_mount_target_parent(&canonical_namespace, target)?;
     create_symlink(canonical_source, target)
+}
+
+fn prepare_mount_namespace(canonical_workspace: &Path) -> SandboxResult<PathBuf> {
+    ensure_existing_plain_directory(canonical_workspace, "sandbox workspace root")?;
+    let workspace_dir =
+        ensure_plain_child_directory(canonical_workspace, "workspace", "sandbox workspace")?;
+    let mount_namespace =
+        ensure_plain_child_directory(&workspace_dir, "mounts", "mount namespace")?;
+    let canonical_namespace = mount_namespace.canonicalize().map_err(|e| {
+        SandboxError::mount_target_invalid(format!("failed to resolve mount namespace: {e}"))
+    })?;
+    if canonical_namespace != mount_namespace {
+        return Err(SandboxError::mount_target_invalid(
+            "mount namespace must resolve without symlinks",
+        ));
+    }
+    Ok(canonical_namespace)
+}
+
+fn ensure_plain_child_directory(parent: &Path, child: &str, label: &str) -> SandboxResult<PathBuf> {
+    ensure_existing_plain_directory(parent, &format!("{label} parent"))?;
+    let path = parent.join(child);
+    match fs::symlink_metadata(&path) {
+        Ok(_) => ensure_existing_plain_directory(&path, label)?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            ensure_existing_plain_directory(parent, &format!("{label} parent"))?;
+            match fs::create_dir(&path) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(e) => {
+                    return Err(SandboxError::mount_target_invalid(format!(
+                        "failed to create {label}: {e}"
+                    )));
+                }
+            }
+            ensure_existing_plain_directory(&path, label)?;
+        }
+        Err(e) => {
+            return Err(SandboxError::mount_target_invalid(format!(
+                "failed to inspect {label}: {e}"
+            )));
+        }
+    }
+    Ok(path)
+}
+
+fn ensure_existing_plain_directory(path: &Path, label: &str) -> SandboxResult<()> {
+    let metadata = fs::symlink_metadata(path).map_err(|e| {
+        SandboxError::mount_target_invalid(format!("failed to inspect {label}: {e}"))
+    })?;
+    if metadata.file_type().is_symlink() {
+        return Err(SandboxError::mount_target_invalid(format!(
+            "{label} must not be a symlink"
+        )));
+    }
+    if !metadata.is_dir() {
+        return Err(SandboxError::mount_target_invalid(format!(
+            "{label} must be a directory"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_mount_target_parent(
+    canonical_namespace: &Path,
+    target: &Path,
+) -> SandboxResult<PathBuf> {
+    let parent = target.parent().ok_or_else(|| {
+        SandboxError::mount_target_invalid("mount target has no parent namespace")
+    })?;
+    ensure_existing_plain_directory(parent, "mount target parent")?;
+    let file_name = target.file_name().ok_or_else(|| {
+        SandboxError::mount_target_invalid("mount target must include a final path component")
+    })?;
+    let canonical_parent = parent.canonicalize().map_err(|e| {
+        SandboxError::mount_target_invalid(format!(
+            "failed to resolve mount target parent '{}': {e}",
+            parent.display()
+        ))
+    })?;
+    let canonical_target_path = canonical_parent.join(file_name);
+    if !canonical_target_path.starts_with(canonical_namespace) {
+        return Err(SandboxError::mount_target_invalid(
+            "mount target parent escapes workspace/mounts",
+        ));
+    }
+    Ok(parent.to_path_buf())
 }
 
 #[cfg(unix)]
@@ -579,6 +631,29 @@ mod tests {
         let err = materialize_active_mounts_with_platform_support(&mut policy, true).unwrap_err();
 
         assert_eq!(err.code, "MOUNT_TARGET_CONFLICT");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sandbox_mount_materialization_rejects_symlinked_workspace_without_creating_outside_mounts() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        let outside = temp.path().join("outside");
+        let target = workspace_root.join("workspace/mounts/selected-folder");
+        std::fs::create_dir_all(&workspace_root).unwrap();
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        symlink(&outside, workspace_root.join("workspace")).unwrap();
+        let canonical_source = source.canonicalize().unwrap();
+        let mut policy = policy_with_mount(workspace_root, canonical_source, target);
+
+        let err = materialize_active_mounts_with_platform_support(&mut policy, true).unwrap_err();
+
+        assert_eq!(err.code, "MOUNT_TARGET_INVALID");
+        assert!(!outside.join("mounts").exists());
     }
 
     #[test]

--- a/crates/ahandd/src/sandbox/runner.rs
+++ b/crates/ahandd/src/sandbox/runner.rs
@@ -1,19 +1,21 @@
 use std::collections::HashMap;
+use std::fs;
 #[cfg(unix)]
-use std::path::Path;
-use std::path::PathBuf;
+use std::os::unix::fs::symlink;
+use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
 use super::platform;
 use super::types::{
-    NetworkPolicy, RuntimeExecuteResult, RuntimeProviderConfig, SandboxCommand, SandboxError,
-    SandboxResult,
+    MountAccess, MountSource, NetworkPolicy, RegisteredSandboxMount, RuntimeExecuteResult,
+    RuntimeProviderConfig, SandboxCommand, SandboxError, SandboxResult,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeSandboxPolicy {
     pub writable_root: PathBuf,
     pub readonly_roots: Vec<PathBuf>,
+    pub mounts: Vec<RegisteredSandboxMount>,
     pub network: NetworkPolicy,
 }
 
@@ -26,6 +28,7 @@ impl RuntimeSandboxPolicy {
         Self {
             writable_root,
             readonly_roots: provider.readonly_roots,
+            mounts: Vec::new(),
             network,
         }
     }
@@ -40,7 +43,8 @@ pub struct PlatformExecuteRequest {
     pub policy: RuntimeSandboxPolicy,
 }
 
-pub async fn execute(request: PlatformExecuteRequest) -> SandboxResult<RuntimeExecuteResult> {
+pub async fn execute(mut request: PlatformExecuteRequest) -> SandboxResult<RuntimeExecuteResult> {
+    materialize_active_mounts(&mut request.policy)?;
     platform::execute(request).await
 }
 
@@ -60,6 +64,276 @@ pub fn command_argv_from_sandbox_command(command: &SandboxCommand) -> SandboxRes
             Ok(command.clone())
         }
     }
+}
+
+fn materialize_active_mounts(policy: &mut RuntimeSandboxPolicy) -> SandboxResult<()> {
+    materialize_active_mounts_with_platform_support(
+        policy,
+        platform_supports_readonly_host_directory_mounts(),
+    )
+}
+
+fn platform_supports_readonly_host_directory_mounts() -> bool {
+    cfg!(target_os = "macos")
+}
+
+fn materialize_active_mounts_with_platform_support(
+    policy: &mut RuntimeSandboxPolicy,
+    platform_supported: bool,
+) -> SandboxResult<()> {
+    if policy.mounts.is_empty() {
+        return Ok(());
+    }
+    if !platform_supported {
+        return Err(SandboxError::mount_platform_unsupported(
+            "read-only host directory mounts are not supported on this platform",
+        ));
+    }
+
+    for mount in policy.mounts.clone() {
+        let canonical_source = materialize_readonly_host_directory_mount(policy, &mount)?;
+        push_unique_path(&mut policy.readonly_roots, canonical_source);
+    }
+    policy.readonly_roots.sort();
+    policy.readonly_roots.dedup();
+    Ok(())
+}
+
+fn materialize_readonly_host_directory_mount(
+    policy: &RuntimeSandboxPolicy,
+    mount: &RegisteredSandboxMount,
+) -> SandboxResult<PathBuf> {
+    if mount.access != MountAccess::ReadOnly {
+        return Err(SandboxError::mount_platform_unsupported(
+            "only read-only host directory mounts can be materialized",
+        ));
+    }
+    if !mount.source_snapshot.exists {
+        return Err(SandboxError::mount_source_not_found(format!(
+            "mount source no longer exists for '{}'",
+            mount.mount_id
+        )));
+    }
+    if !mount.source_snapshot.is_dir {
+        return Err(SandboxError::mount_source_unsupported(
+            "only host directory mounts can be materialized",
+        ));
+    }
+
+    let source = match &mount.source {
+        MountSource::HostPath(path) => path,
+        MountSource::SandboxPath(_) | MountSource::RuntimePath(_) => {
+            return Err(SandboxError::mount_platform_unsupported(
+                "only host path mounts can be materialized",
+            ));
+        }
+    };
+    let canonical_source = source.canonicalize().map_err(|e| {
+        SandboxError::mount_source_not_found(format!(
+            "failed to resolve mount source '{}': {e}",
+            source.display()
+        ))
+    })?;
+    let metadata = fs::metadata(&canonical_source).map_err(|e| {
+        SandboxError::mount_source_not_found(format!(
+            "failed to inspect mount source '{}': {e}",
+            canonical_source.display()
+        ))
+    })?;
+    if !metadata.is_dir() {
+        return Err(SandboxError::mount_source_unsupported(
+            "only host directory mounts can be materialized",
+        ));
+    }
+
+    materialize_mount_target_symlink(&policy.writable_root, &mount.target, &canonical_source)?;
+    Ok(canonical_source)
+}
+
+fn materialize_mount_target_symlink(
+    workspace_root: &Path,
+    target: &Path,
+    canonical_source: &Path,
+) -> SandboxResult<()> {
+    let canonical_workspace = workspace_root.canonicalize().map_err(|e| {
+        SandboxError::mount_target_invalid(format!("failed to resolve sandbox workspace root: {e}"))
+    })?;
+    let mount_namespace = canonical_workspace.join("workspace").join("mounts");
+    fs::create_dir_all(&mount_namespace).map_err(|e| {
+        SandboxError::mount_target_invalid(format!("failed to create mount namespace: {e}"))
+    })?;
+    let namespace_metadata = fs::symlink_metadata(&mount_namespace).map_err(|e| {
+        SandboxError::mount_target_invalid(format!("failed to inspect mount namespace: {e}"))
+    })?;
+    if namespace_metadata.file_type().is_symlink() || !namespace_metadata.is_dir() {
+        return Err(SandboxError::mount_target_invalid(
+            "mount namespace must be a plain directory",
+        ));
+    }
+    let canonical_namespace = mount_namespace.canonicalize().map_err(|e| {
+        SandboxError::mount_target_invalid(format!("failed to resolve mount namespace: {e}"))
+    })?;
+    if canonical_namespace != mount_namespace {
+        return Err(SandboxError::mount_target_invalid(
+            "mount namespace must resolve without symlinks",
+        ));
+    }
+    if !target.is_absolute() || contains_parent_component(target) {
+        return Err(SandboxError::mount_target_invalid(
+            "resolved mount target must be an absolute path without traversal",
+        ));
+    }
+    let parent = target.parent().ok_or_else(|| {
+        SandboxError::mount_target_invalid("mount target has no parent namespace")
+    })?;
+    let file_name = target.file_name().ok_or_else(|| {
+        SandboxError::mount_target_invalid("mount target must include a final path component")
+    })?;
+    let canonical_parent = parent.canonicalize().map_err(|e| {
+        SandboxError::mount_target_invalid(format!(
+            "failed to resolve mount target parent '{}': {e}",
+            parent.display()
+        ))
+    })?;
+    let canonical_target_path = canonical_parent.join(file_name);
+    if !canonical_target_path.starts_with(&canonical_namespace) {
+        return Err(SandboxError::mount_target_invalid(
+            "mount target parent escapes workspace/mounts",
+        ));
+    }
+
+    match fs::symlink_metadata(target) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            let link_target = fs::read_link(target).map_err(|e| {
+                SandboxError::mount_target_invalid(format!(
+                    "failed to read mount target symlink '{}': {e}",
+                    target.display()
+                ))
+            })?;
+            let resolved_link = if link_target.is_absolute() {
+                link_target
+            } else {
+                parent.join(link_target)
+            }
+            .canonicalize()
+            .map_err(|e| {
+                SandboxError::mount_target_invalid(format!(
+                    "failed to resolve mount target symlink '{}': {e}",
+                    target.display()
+                ))
+            })?;
+            if resolved_link == canonical_source {
+                return Ok(());
+            }
+            return Err(SandboxError::mount_target_conflict(format!(
+                "mount target already points elsewhere: {}",
+                target.display()
+            )));
+        }
+        Ok(_) => {
+            return Err(SandboxError::mount_target_conflict(format!(
+                "mount target already exists: {}",
+                target.display()
+            )));
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(SandboxError::mount_target_invalid(format!(
+                "failed to inspect mount target '{}': {e}",
+                target.display()
+            )));
+        }
+    }
+
+    create_symlink(canonical_source, target)
+}
+
+#[cfg(unix)]
+fn create_symlink(source: &Path, target: &Path) -> SandboxResult<()> {
+    symlink(source, target).map_err(|e| {
+        SandboxError::mount_target_invalid(format!(
+            "failed to create mount target symlink '{}': {e}",
+            target.display()
+        ))
+    })
+}
+
+#[cfg(not(unix))]
+fn create_symlink(_source: &Path, _target: &Path) -> SandboxResult<()> {
+    Err(SandboxError::mount_platform_unsupported(
+        "read-only host directory mounts require symlink support",
+    ))
+}
+
+fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if !paths.iter().any(|existing| existing == &path) {
+        paths.push(path);
+    }
+}
+
+pub fn resolve_executable(program: &str, path_entries: &[PathBuf]) -> SandboxResult<PathBuf> {
+    if program.trim().is_empty() {
+        return Err(SandboxError::invalid_command(
+            "command program must not be empty",
+        ));
+    }
+
+    let program_path = PathBuf::from(program);
+    if program_path.is_absolute() {
+        if contains_parent_component(&program_path) {
+            return Err(SandboxError::invalid_command(format!(
+                "absolute sandbox command '{}' must not contain parent components",
+                program
+            )));
+        }
+        let is_registered_entry_path = path_entries
+            .iter()
+            .any(|entry| program_path.starts_with(entry));
+        let resolved = program_path.canonicalize().map_err(|e| {
+            SandboxError::command_not_found(format!(
+                "failed to resolve sandbox command '{}': {e}",
+                program
+            ))
+        })?;
+        if is_registered_entry_path {
+            return Ok(program_path);
+        }
+        if path_entries.iter().any(|entry| resolved.starts_with(entry)) {
+            return Ok(resolved);
+        }
+        return Err(SandboxError::invalid_command(format!(
+            "absolute sandbox command '{}' is outside registered runtime PATH",
+            program
+        )));
+    }
+
+    if program.contains('/') || program.contains('\\') {
+        return Err(SandboxError::invalid_command(format!(
+            "relative command paths are not allowed: {program}"
+        )));
+    }
+
+    for entry in path_entries {
+        let candidate = entry.join(program);
+        if candidate.exists() {
+            candidate.canonicalize().map_err(|e| {
+                SandboxError::command_not_found(format!(
+                    "failed to resolve sandbox command '{}': {e}",
+                    candidate.display()
+                ))
+            })?;
+            return Ok(candidate);
+        }
+    }
+
+    Err(SandboxError::command_not_found(format!(
+        "sandbox command '{program}' was not found in registered runtime PATH"
+    )))
+}
+
+fn contains_parent_component(path: &Path) -> bool {
+    path.components()
+        .any(|component| matches!(component, Component::ParentDir))
 }
 
 #[cfg(unix)]
@@ -115,7 +389,10 @@ fn find_windows_shell(name: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sandbox::types::{NetworkPolicy, RuntimeProviderConfig};
+    use crate::sandbox::types::{
+        MountAccess, MountScope, MountSource, MountSourceSnapshot, NetworkPolicy,
+        RegisteredSandboxMount, RuntimeProviderConfig,
+    };
     use std::collections::HashMap;
     use std::path::PathBuf;
     use std::time::Duration;
@@ -203,6 +480,7 @@ mod tests {
             policy: RuntimeSandboxPolicy {
                 writable_root: PathBuf::from("/tmp"),
                 readonly_roots: vec![],
+                mounts: Vec::new(),
                 network: NetworkPolicy::Enabled,
             },
         };
@@ -210,5 +488,112 @@ mod tests {
         let err = platform::unsupported::execute(request).await.unwrap_err();
 
         assert_eq!(err.code, "SANDBOX_UNAVAILABLE");
+    }
+
+    fn readonly_host_dir_mount(
+        mount_id: &str,
+        source: PathBuf,
+        target: PathBuf,
+    ) -> RegisteredSandboxMount {
+        RegisteredSandboxMount {
+            mount_id: mount_id.to_string(),
+            source: MountSource::HostPath(source),
+            access: MountAccess::ReadOnly,
+            scope: MountScope::Session,
+            target,
+            env_var: None,
+            source_snapshot: MountSourceSnapshot {
+                exists: true,
+                is_dir: true,
+            },
+        }
+    }
+
+    fn policy_with_mount(
+        workspace_root: PathBuf,
+        source: PathBuf,
+        target: PathBuf,
+    ) -> RuntimeSandboxPolicy {
+        RuntimeSandboxPolicy {
+            writable_root: workspace_root,
+            readonly_roots: Vec::new(),
+            mounts: vec![readonly_host_dir_mount("selected-folder", source, target)],
+            network: NetworkPolicy::Enabled,
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn sandbox_mount_materialization_creates_symlink_and_adds_readonly_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        let target = workspace_root.join("workspace/mounts/selected-folder");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        let canonical_source = source.canonicalize().unwrap();
+        let mut policy =
+            policy_with_mount(workspace_root, canonical_source.clone(), target.clone());
+
+        materialize_active_mounts_with_platform_support(&mut policy, true).unwrap();
+
+        assert_eq!(std::fs::read_link(&target).unwrap(), canonical_source);
+        assert_eq!(policy.readonly_roots, vec![source.canonicalize().unwrap()]);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn sandbox_mount_materialization_accepts_existing_correct_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        let target = workspace_root.join("workspace/mounts/selected-folder");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        let canonical_source = source.canonicalize().unwrap();
+        symlink(&canonical_source, &target).unwrap();
+        let mut policy =
+            policy_with_mount(workspace_root, canonical_source.clone(), target.clone());
+
+        materialize_active_mounts_with_platform_support(&mut policy, true).unwrap();
+
+        assert_eq!(std::fs::read_link(&target).unwrap(), canonical_source);
+        assert_eq!(policy.readonly_roots, vec![source.canonicalize().unwrap()]);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn sandbox_mount_materialization_rejects_existing_conflicting_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        let target = workspace_root.join("workspace/mounts/selected-folder");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        std::fs::write(&target, "conflict").unwrap();
+        let canonical_source = source.canonicalize().unwrap();
+        let mut policy = policy_with_mount(workspace_root, canonical_source, target);
+
+        let err = materialize_active_mounts_with_platform_support(&mut policy, true).unwrap_err();
+
+        assert_eq!(err.code, "MOUNT_TARGET_CONFLICT");
+    }
+
+    #[test]
+    fn sandbox_mount_materialization_unsupported_platform_active_mounts_fail() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let source = temp.path().join("host");
+        let target = workspace_root.join("workspace/mounts/selected-folder");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        let canonical_source = source.canonicalize().unwrap();
+        let mut policy = policy_with_mount(workspace_root, canonical_source, target);
+
+        let err = materialize_active_mounts_with_platform_support(&mut policy, false).unwrap_err();
+
+        assert_eq!(err.code, "MOUNT_PLATFORM_UNSUPPORTED");
     }
 }

--- a/crates/ahandd/src/sandbox/tool_provider.rs
+++ b/crates/ahandd/src/sandbox/tool_provider.rs
@@ -14,7 +14,7 @@ use crate::sandbox::{
     types::{
         CommitResult, FileVersion, HostFileRef, RegisterVersionRequest, RuntimeExecuteResult,
         SandboxCommand, SandboxError, SandboxExecRequest, SandboxExecResult, SandboxFile,
-        SandboxResult,
+        SandboxInvocationContext, SandboxResult,
     },
 };
 
@@ -23,13 +23,6 @@ pub const CODE_SANDBOX_CONTEXT_REQUIRED: &str = "SANDBOX_CONTEXT_REQUIRED";
 #[derive(Debug, Clone, Copy)]
 pub struct SandboxToolProviderOptions {
     pub include_compat_aliases: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SandboxInvocationContext {
-    pub session_id: String,
-    pub run_id: Option<String>,
-    pub scope_id: Option<String>,
 }
 
 pub trait SandboxInvocationResolver: Send + Sync {
@@ -80,6 +73,7 @@ impl SandboxInvocationResolver for FixedSandboxInvocationResolver {
             session_id,
             run_id: trusted_string(context, "runId"),
             scope_id: trusted_string(context, "scopeId"),
+            invocation_id: trusted_string(context, "invocationId"),
         })
     }
 }
@@ -711,6 +705,7 @@ mod tests {
                 permission_mode,
                 workspace_root,
                 network: NetworkPolicy::Enabled,
+                mounts: Vec::new(),
             })
             .unwrap();
         Arc::new(AsyncMutex::new(registry))

--- a/crates/ahandd/src/sandbox/tool_provider.rs
+++ b/crates/ahandd/src/sandbox/tool_provider.rs
@@ -227,14 +227,16 @@ impl SandboxToolProvider {
         let cwd = optional_string_arg(&invocation.args, "cwd")?.map(PathBuf::from);
         let env = optional_string_map_arg(&invocation.args, "env")?;
         let timeout = optional_timeout_arg(&invocation.args, "timeoutSeconds")?;
+        let session_id = context.session_id.clone();
         let result = self
             .execute_command(
-                &context.session_id,
+                &session_id,
                 SandboxExecRequest {
                     command,
                     cwd,
                     env,
                     timeout,
+                    context: Some(context),
                 },
             )
             .await
@@ -254,14 +256,16 @@ impl SandboxToolProvider {
         let command = SandboxCommand::Argv {
             command: std::iter::once("node".to_string()).chain(args).collect(),
         };
+        let session_id = context.session_id.clone();
         let result = self
             .execute_command(
-                &context.session_id,
+                &session_id,
                 SandboxExecRequest {
                     command,
                     cwd,
                     env: HashMap::new(),
                     timeout,
+                    context: Some(context),
                 },
             )
             .await

--- a/crates/ahandd/src/sandbox/types.rs
+++ b/crates/ahandd/src/sandbox/types.rs
@@ -20,6 +20,7 @@ pub const CODE_MOUNT_ACCESS_DENIED: &str = "MOUNT_ACCESS_DENIED";
 pub const CODE_MOUNT_ALREADY_REGISTERED: &str = "MOUNT_ALREADY_REGISTERED";
 pub const CODE_MOUNT_NOT_REGISTERED: &str = "MOUNT_NOT_REGISTERED";
 pub const CODE_MOUNT_SCOPE_MISMATCH: &str = "MOUNT_SCOPE_MISMATCH";
+pub const CODE_MOUNT_ENV_CONFLICT: &str = "MOUNT_ENV_CONFLICT";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -295,6 +296,10 @@ impl SandboxError {
     pub fn mount_scope_mismatch(message: impl Into<String>) -> Self {
         Self::new(CODE_MOUNT_SCOPE_MISMATCH, message)
     }
+
+    pub fn mount_env_conflict(message: impl Into<String>) -> Self {
+        Self::new(CODE_MOUNT_ENV_CONFLICT, message)
+    }
 }
 
 #[cfg(test)]
@@ -436,6 +441,13 @@ mod tests {
         let err = SandboxError::mount_scope_mismatch("mount scope does not match invocation");
 
         assert_eq!(err.code, "MOUNT_SCOPE_MISMATCH");
+    }
+
+    #[test]
+    fn mount_env_conflict_constructor_preserves_code() {
+        let err = SandboxError::mount_env_conflict("mount env var is already registered");
+
+        assert_eq!(err.code, "MOUNT_ENV_CONFLICT");
     }
 
     #[test]

--- a/crates/ahandd/src/sandbox/types.rs
+++ b/crates/ahandd/src/sandbox/types.rs
@@ -17,6 +17,7 @@ pub const CODE_MOUNT_SOURCE_UNSUPPORTED: &str = "MOUNT_SOURCE_UNSUPPORTED";
 pub const CODE_MOUNT_TARGET_INVALID: &str = "MOUNT_TARGET_INVALID";
 pub const CODE_MOUNT_TARGET_CONFLICT: &str = "MOUNT_TARGET_CONFLICT";
 pub const CODE_MOUNT_ACCESS_DENIED: &str = "MOUNT_ACCESS_DENIED";
+pub const CODE_MOUNT_ALREADY_REGISTERED: &str = "MOUNT_ALREADY_REGISTERED";
 pub const CODE_MOUNT_NOT_REGISTERED: &str = "MOUNT_NOT_REGISTERED";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -279,6 +280,10 @@ impl SandboxError {
 
     pub fn mount_access_denied(message: impl Into<String>) -> Self {
         Self::new(CODE_MOUNT_ACCESS_DENIED, message)
+    }
+
+    pub fn mount_already_registered(message: impl Into<String>) -> Self {
+        Self::new(CODE_MOUNT_ALREADY_REGISTERED, message)
     }
 
     pub fn mount_not_registered(message: impl Into<String>) -> Self {

--- a/crates/ahandd/src/sandbox/types.rs
+++ b/crates/ahandd/src/sandbox/types.rs
@@ -21,6 +21,7 @@ pub const CODE_MOUNT_ALREADY_REGISTERED: &str = "MOUNT_ALREADY_REGISTERED";
 pub const CODE_MOUNT_NOT_REGISTERED: &str = "MOUNT_NOT_REGISTERED";
 pub const CODE_MOUNT_SCOPE_MISMATCH: &str = "MOUNT_SCOPE_MISMATCH";
 pub const CODE_MOUNT_ENV_CONFLICT: &str = "MOUNT_ENV_CONFLICT";
+pub const CODE_MOUNT_PLATFORM_UNSUPPORTED: &str = "MOUNT_PLATFORM_UNSUPPORTED";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -299,6 +300,10 @@ impl SandboxError {
 
     pub fn mount_env_conflict(message: impl Into<String>) -> Self {
         Self::new(CODE_MOUNT_ENV_CONFLICT, message)
+    }
+
+    pub fn mount_platform_unsupported(message: impl Into<String>) -> Self {
+        Self::new(CODE_MOUNT_PLATFORM_UNSUPPORTED, message)
     }
 }
 

--- a/crates/ahandd/src/sandbox/types.rs
+++ b/crates/ahandd/src/sandbox/types.rs
@@ -12,6 +12,11 @@ pub const CODE_UNKNOWN_VERSION: &str = "UNKNOWN_VERSION";
 pub const CODE_RUNTIME_NOT_REGISTERED: &str = "RUNTIME_NOT_REGISTERED";
 pub const CODE_INVALID_COMMAND: &str = "INVALID_COMMAND";
 pub const CODE_COMMAND_NOT_FOUND: &str = "COMMAND_NOT_FOUND";
+pub const CODE_MOUNT_SOURCE_NOT_FOUND: &str = "MOUNT_SOURCE_NOT_FOUND";
+pub const CODE_MOUNT_SOURCE_UNSUPPORTED: &str = "MOUNT_SOURCE_UNSUPPORTED";
+pub const CODE_MOUNT_TARGET_INVALID: &str = "MOUNT_TARGET_INVALID";
+pub const CODE_MOUNT_TARGET_CONFLICT: &str = "MOUNT_TARGET_CONFLICT";
+pub const CODE_MOUNT_ACCESS_DENIED: &str = "MOUNT_ACCESS_DENIED";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -253,6 +258,26 @@ impl SandboxError {
 
     pub fn unknown_version(message: impl Into<String>) -> Self {
         Self::new(CODE_UNKNOWN_VERSION, message)
+    }
+
+    pub fn mount_source_not_found(message: impl Into<String>) -> Self {
+        Self::new(CODE_MOUNT_SOURCE_NOT_FOUND, message)
+    }
+
+    pub fn mount_source_unsupported(message: impl Into<String>) -> Self {
+        Self::new(CODE_MOUNT_SOURCE_UNSUPPORTED, message)
+    }
+
+    pub fn mount_target_invalid(message: impl Into<String>) -> Self {
+        Self::new(CODE_MOUNT_TARGET_INVALID, message)
+    }
+
+    pub fn mount_target_conflict(message: impl Into<String>) -> Self {
+        Self::new(CODE_MOUNT_TARGET_CONFLICT, message)
+    }
+
+    pub fn mount_access_denied(message: impl Into<String>) -> Self {
+        Self::new(CODE_MOUNT_ACCESS_DENIED, message)
     }
 }
 

--- a/crates/ahandd/src/sandbox/types.rs
+++ b/crates/ahandd/src/sandbox/types.rs
@@ -45,11 +45,69 @@ pub struct RuntimeProviderConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxMountSpec {
+    pub mount_id: String,
+    pub source: MountSource,
+    pub access: MountAccess,
+    pub scope: MountScope,
+    pub target: Option<PathBuf>,
+    pub env_var: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegisteredSandboxMount {
+    pub mount_id: String,
+    pub source: MountSource,
+    pub access: MountAccess,
+    pub scope: MountScope,
+    pub target: PathBuf,
+    pub env_var: Option<String>,
+    pub source_snapshot: MountSourceSnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MountSource {
+    HostPath(PathBuf),
+    SandboxPath(PathBuf),
+    RuntimePath(PathBuf),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MountAccess {
+    ReadOnly,
+    WriteOnly,
+    ReadWrite,
+    CopyOnWrite,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MountScope {
+    Session,
+    Run { run_id: String },
+    Invocation { invocation_id: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MountSourceSnapshot {
+    pub exists: bool,
+    pub is_dir: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxInvocationContext {
+    pub session_id: String,
+    pub run_id: Option<String>,
+    pub scope_id: Option<String>,
+    pub invocation_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SandboxSessionConfig {
     pub session_id: String,
     pub permission_mode: SandboxPermissionMode,
     pub workspace_root: PathBuf,
     pub network: NetworkPolicy,
+    pub mounts: Vec<SandboxMountSpec>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -91,6 +149,7 @@ pub struct SandboxExecRequest {
     pub cwd: Option<PathBuf>,
     pub env: HashMap<String, String>,
     pub timeout: Option<Duration>,
+    pub context: Option<SandboxInvocationContext>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -264,6 +323,7 @@ mod tests {
             cwd: Some(PathBuf::from("workspace")),
             env: HashMap::from([("EXAMPLE".to_string(), "1".to_string())]),
             timeout: Some(Duration::from_secs(7)),
+            context: None,
         };
 
         assert_eq!(

--- a/crates/ahandd/src/sandbox/types.rs
+++ b/crates/ahandd/src/sandbox/types.rs
@@ -17,6 +17,7 @@ pub const CODE_MOUNT_SOURCE_UNSUPPORTED: &str = "MOUNT_SOURCE_UNSUPPORTED";
 pub const CODE_MOUNT_TARGET_INVALID: &str = "MOUNT_TARGET_INVALID";
 pub const CODE_MOUNT_TARGET_CONFLICT: &str = "MOUNT_TARGET_CONFLICT";
 pub const CODE_MOUNT_ACCESS_DENIED: &str = "MOUNT_ACCESS_DENIED";
+pub const CODE_MOUNT_NOT_REGISTERED: &str = "MOUNT_NOT_REGISTERED";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -85,7 +86,7 @@ pub enum MountAccess {
     CopyOnWrite,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MountScope {
     Session,
     Run { run_id: String },
@@ -278,6 +279,10 @@ impl SandboxError {
 
     pub fn mount_access_denied(message: impl Into<String>) -> Self {
         Self::new(CODE_MOUNT_ACCESS_DENIED, message)
+    }
+
+    pub fn mount_not_registered(message: impl Into<String>) -> Self {
+        Self::new(CODE_MOUNT_NOT_REGISTERED, message)
     }
 }
 

--- a/crates/ahandd/src/sandbox/types.rs
+++ b/crates/ahandd/src/sandbox/types.rs
@@ -19,6 +19,7 @@ pub const CODE_MOUNT_TARGET_CONFLICT: &str = "MOUNT_TARGET_CONFLICT";
 pub const CODE_MOUNT_ACCESS_DENIED: &str = "MOUNT_ACCESS_DENIED";
 pub const CODE_MOUNT_ALREADY_REGISTERED: &str = "MOUNT_ALREADY_REGISTERED";
 pub const CODE_MOUNT_NOT_REGISTERED: &str = "MOUNT_NOT_REGISTERED";
+pub const CODE_MOUNT_SCOPE_MISMATCH: &str = "MOUNT_SCOPE_MISMATCH";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -174,6 +175,7 @@ pub struct RegisteredExecEnvironment {
     pub path_entries: Vec<PathBuf>,
     pub readonly_roots: Vec<PathBuf>,
     pub env: HashMap<String, String>,
+    pub mounts: Vec<RegisteredSandboxMount>,
     pub default_timeout: Duration,
 }
 
@@ -289,6 +291,10 @@ impl SandboxError {
     pub fn mount_not_registered(message: impl Into<String>) -> Self {
         Self::new(CODE_MOUNT_NOT_REGISTERED, message)
     }
+
+    pub fn mount_scope_mismatch(message: impl Into<String>) -> Self {
+        Self::new(CODE_MOUNT_SCOPE_MISMATCH, message)
+    }
 }
 
 #[cfg(test)]
@@ -385,6 +391,7 @@ mod tests {
             cwd: Some(PathBuf::from("workspace")),
             env: HashMap::from([("EXAMPLE".to_string(), "1".to_string())]),
             timeout: Some(Duration::from_secs(7)),
+            context: None,
         };
 
         assert_eq!(
@@ -404,12 +411,14 @@ mod tests {
             path_entries: vec![PathBuf::from("/runtime/python/bin")],
             readonly_roots: vec![PathBuf::from("/runtime/python")],
             env: HashMap::from([("PYTHONNOUSERSITE".to_string(), "1".to_string())]),
+            mounts: Vec::new(),
             default_timeout: Duration::from_secs(30),
         };
 
         assert_eq!(env.path_entries, vec![PathBuf::from("/runtime/python/bin")]);
         assert_eq!(env.readonly_roots, vec![PathBuf::from("/runtime/python")]);
         assert_eq!(env.env["PYTHONNOUSERSITE"], "1");
+        assert!(env.mounts.is_empty());
         assert_eq!(env.default_timeout, Duration::from_secs(30));
     }
 
@@ -420,6 +429,13 @@ mod tests {
 
         assert_eq!(invalid.code, "INVALID_COMMAND");
         assert_eq!(missing.code, "COMMAND_NOT_FOUND");
+    }
+
+    #[test]
+    fn mount_scope_mismatch_constructor_preserves_code() {
+        let err = SandboxError::mount_scope_mismatch("mount scope does not match invocation");
+
+        assert_eq!(err.code, "MOUNT_SCOPE_MISMATCH");
     }
 
     #[test]

--- a/crates/ahandd/tests/sandbox_api.rs
+++ b/crates/ahandd/tests/sandbox_api.rs
@@ -125,7 +125,7 @@ async fn sandbox_api_daemon_handle_registers_lists_and_unregisters_sandbox_mount
 
 #[cfg(target_os = "macos")]
 #[tokio::test]
-async fn execute_sandbox_command_request_env_cannot_override_trusted_mount_env() {
+async fn sandbox_api_execute_sandbox_command_request_env_cannot_override_active_mount_env() {
     let temp = tempfile::tempdir().unwrap();
     let identity_dir = temp.path().join("identity");
     let sandbox_root = temp.path().join("sandbox");
@@ -207,6 +207,168 @@ async fn execute_sandbox_command_request_env_cannot_override_trusted_mount_env()
 
     assert_eq!(result.exit_code, Some(0));
     assert_eq!(result.stdout, registered.target.to_string_lossy());
+
+    handle.shutdown().await.unwrap();
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn sandbox_api_execute_sandbox_command_request_env_for_inactive_mount_fails_closed() {
+    let temp = tempfile::tempdir().unwrap();
+    let identity_dir = temp.path().join("identity");
+    let sandbox_root = temp.path().join("sandbox");
+    let source = temp.path().join("host");
+    std::fs::create_dir_all(&sandbox_root).unwrap();
+    std::fs::create_dir_all(&source).unwrap();
+
+    let cfg = DaemonConfig::builder("ws://127.0.0.1:9/ws", "test-token", &identity_dir)
+        .heartbeat_interval(Duration::from_millis(50))
+        .build();
+    let handle = ahandd::spawn(cfg).await.unwrap();
+    handle
+        .create_sandbox_session(SandboxSessionConfig {
+            session_id: "session-1".to_string(),
+            permission_mode: SandboxPermissionMode::Readonly,
+            workspace_root: sandbox_root.clone(),
+            network: NetworkPolicy::Enabled,
+            mounts: Vec::new(),
+        })
+        .await
+        .unwrap();
+    handle
+        .register_sandbox_runtime(
+            "session-1",
+            RuntimeProviderConfig {
+                name: "shell".to_string(),
+                executable: PathBuf::from("/bin/sh"),
+                readonly_roots: vec![PathBuf::from("/bin")],
+                env: HashMap::new(),
+                default_timeout: Duration::from_secs(3),
+            },
+        )
+        .await
+        .unwrap();
+    handle
+        .register_sandbox_mount(
+            "session-1",
+            SandboxMountSpec {
+                mount_id: "selected-folder".to_string(),
+                source: MountSource::HostPath(source),
+                access: MountAccess::ReadOnly,
+                scope: MountScope::Run {
+                    run_id: "run-1".to_string(),
+                },
+                target: None,
+                env_var: Some("COFFICE_SELECTED_FOLDER_DIR".to_string()),
+            },
+        )
+        .await
+        .unwrap();
+
+    let err = handle
+        .execute_sandbox_command(
+            "session-1",
+            SandboxExecRequest {
+                command: SandboxCommand::Argv {
+                    command: vec!["sh".to_string(), "-c".to_string(), "true".to_string()],
+                },
+                cwd: None,
+                env: HashMap::from([(
+                    "COFFICE_SELECTED_FOLDER_DIR".to_string(),
+                    "/tmp/spoofed".to_string(),
+                )]),
+                timeout: Some(Duration::from_secs(3)),
+                context: Some(SandboxInvocationContext {
+                    session_id: "session-1".to_string(),
+                    run_id: Some("run-2".to_string()),
+                    scope_id: None,
+                    invocation_id: None,
+                }),
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code, "MOUNT_SCOPE_MISMATCH");
+
+    handle.shutdown().await.unwrap();
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn sandbox_api_execute_sandbox_command_inactive_mount_without_request_env_succeeds() {
+    let temp = tempfile::tempdir().unwrap();
+    let identity_dir = temp.path().join("identity");
+    let sandbox_root = temp.path().join("sandbox");
+    let source = temp.path().join("host");
+    std::fs::create_dir_all(&sandbox_root).unwrap();
+    std::fs::create_dir_all(&source).unwrap();
+
+    let cfg = DaemonConfig::builder("ws://127.0.0.1:9/ws", "test-token", &identity_dir)
+        .heartbeat_interval(Duration::from_millis(50))
+        .build();
+    let handle = ahandd::spawn(cfg).await.unwrap();
+    handle
+        .create_sandbox_session(SandboxSessionConfig {
+            session_id: "session-1".to_string(),
+            permission_mode: SandboxPermissionMode::Readonly,
+            workspace_root: sandbox_root.clone(),
+            network: NetworkPolicy::Enabled,
+            mounts: Vec::new(),
+        })
+        .await
+        .unwrap();
+    handle
+        .register_sandbox_runtime(
+            "session-1",
+            RuntimeProviderConfig {
+                name: "shell".to_string(),
+                executable: PathBuf::from("/bin/sh"),
+                readonly_roots: vec![PathBuf::from("/bin")],
+                env: HashMap::new(),
+                default_timeout: Duration::from_secs(3),
+            },
+        )
+        .await
+        .unwrap();
+    handle
+        .register_sandbox_mount(
+            "session-1",
+            SandboxMountSpec {
+                mount_id: "selected-folder".to_string(),
+                source: MountSource::HostPath(source),
+                access: MountAccess::ReadOnly,
+                scope: MountScope::Run {
+                    run_id: "run-1".to_string(),
+                },
+                target: None,
+                env_var: Some("COFFICE_SELECTED_FOLDER_DIR".to_string()),
+            },
+        )
+        .await
+        .unwrap();
+
+    let result = handle
+        .execute_sandbox_command(
+            "session-1",
+            SandboxExecRequest {
+                command: SandboxCommand::Argv {
+                    command: vec![
+                        "sh".to_string(),
+                        "-c".to_string(),
+                        "test -z \"${COFFICE_SELECTED_FOLDER_DIR:-}\"".to_string(),
+                    ],
+                },
+                cwd: None,
+                env: HashMap::new(),
+                timeout: Some(Duration::from_secs(3)),
+                context: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, Some(0));
 
     handle.shutdown().await.unwrap();
 }

--- a/crates/ahandd/tests/sandbox_api.rs
+++ b/crates/ahandd/tests/sandbox_api.rs
@@ -7,8 +7,8 @@ use ahandd::sandbox::{RuntimeExecuteRequest, RuntimeProviderConfig};
 use ahandd::{
     AppToolDef, AppToolHandler, DaemonConfig, args_only_handler,
     sandbox::{
-        HostFileRef, NetworkPolicy, RegisterVersionRequest, SandboxPermissionMode,
-        SandboxSessionConfig,
+        HostFileRef, MountAccess, MountScope, MountSource, NetworkPolicy, RegisterVersionRequest,
+        SandboxMountSpec, SandboxPermissionMode, SandboxSessionConfig,
     },
 };
 
@@ -41,6 +41,83 @@ async fn daemon_handle_exposes_sandbox_permission_updates() {
 
     assert_eq!(snapshot.mode, SandboxPermissionMode::Full);
     assert_eq!(snapshot.version, 2);
+
+    handle.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn sandbox_api_daemon_handle_registers_lists_and_unregisters_sandbox_mounts() {
+    let temp = tempfile::tempdir().unwrap();
+    let identity_dir = temp.path().join("identity");
+    let sandbox_root = temp.path().join("sandbox");
+    let source = temp.path().join("host");
+    std::fs::create_dir_all(&sandbox_root).unwrap();
+    std::fs::create_dir_all(&source).unwrap();
+
+    let cfg = DaemonConfig::builder("ws://127.0.0.1:9/ws", "test-token", &identity_dir)
+        .heartbeat_interval(Duration::from_millis(50))
+        .build();
+    let handle = ahandd::spawn(cfg).await.unwrap();
+    handle
+        .create_sandbox_session(SandboxSessionConfig {
+            session_id: "session-1".to_string(),
+            permission_mode: SandboxPermissionMode::Readonly,
+            workspace_root: sandbox_root.clone(),
+            network: NetworkPolicy::Enabled,
+            mounts: Vec::new(),
+        })
+        .await
+        .unwrap();
+
+    let registered = handle
+        .register_sandbox_mount(
+            "session-1",
+            SandboxMountSpec {
+                mount_id: "selected-folder".to_string(),
+                source: MountSource::HostPath(source.clone()),
+                access: MountAccess::ReadOnly,
+                scope: MountScope::Run {
+                    run_id: "run-1".to_string(),
+                },
+                target: None,
+                env_var: Some("COFFICE_SELECTED_FOLDER_DIR".to_string()),
+            },
+        )
+        .await
+        .unwrap();
+    let mounts = handle.list_sandbox_mounts("session-1").await.unwrap();
+
+    assert_eq!(mounts, vec![registered.clone()]);
+    assert_eq!(
+        registered.source,
+        MountSource::HostPath(source.canonicalize().unwrap())
+    );
+    assert_eq!(
+        registered.target,
+        sandbox_root
+            .canonicalize()
+            .unwrap()
+            .join("workspace/mounts/selected-folder")
+    );
+
+    handle
+        .unregister_sandbox_mount(
+            "session-1",
+            "selected-folder",
+            MountScope::Run {
+                run_id: "run-1".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        handle
+            .list_sandbox_mounts("session-1")
+            .await
+            .unwrap()
+            .is_empty()
+    );
 
     handle.shutdown().await.unwrap();
 }

--- a/crates/ahandd/tests/sandbox_api.rs
+++ b/crates/ahandd/tests/sandbox_api.rs
@@ -4,12 +4,13 @@ use std::{path::PathBuf, time::Duration};
 
 #[cfg(target_os = "macos")]
 use ahandd::sandbox::{RuntimeExecuteRequest, RuntimeProviderConfig};
+#[cfg(target_os = "macos")]
+use ahandd::sandbox::{SandboxCommand, SandboxExecRequest, SandboxInvocationContext};
 use ahandd::{
     AppToolDef, AppToolHandler, DaemonConfig, args_only_handler,
     sandbox::{
         HostFileRef, MountAccess, MountScope, MountSource, NetworkPolicy, RegisterVersionRequest,
-        SandboxCommand, SandboxExecRequest, SandboxInvocationContext, SandboxMountSpec,
-        SandboxPermissionMode, SandboxSessionConfig,
+        SandboxMountSpec, SandboxPermissionMode, SandboxSessionConfig,
     },
 };
 

--- a/crates/ahandd/tests/sandbox_api.rs
+++ b/crates/ahandd/tests/sandbox_api.rs
@@ -8,7 +8,8 @@ use ahandd::{
     AppToolDef, AppToolHandler, DaemonConfig, args_only_handler,
     sandbox::{
         HostFileRef, MountAccess, MountScope, MountSource, NetworkPolicy, RegisterVersionRequest,
-        SandboxMountSpec, SandboxPermissionMode, SandboxSessionConfig,
+        SandboxCommand, SandboxExecRequest, SandboxInvocationContext, SandboxMountSpec,
+        SandboxPermissionMode, SandboxSessionConfig,
     },
 };
 
@@ -118,6 +119,94 @@ async fn sandbox_api_daemon_handle_registers_lists_and_unregisters_sandbox_mount
             .unwrap()
             .is_empty()
     );
+
+    handle.shutdown().await.unwrap();
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn execute_sandbox_command_request_env_cannot_override_trusted_mount_env() {
+    let temp = tempfile::tempdir().unwrap();
+    let identity_dir = temp.path().join("identity");
+    let sandbox_root = temp.path().join("sandbox");
+    let source = temp.path().join("host");
+    std::fs::create_dir_all(&sandbox_root).unwrap();
+    std::fs::create_dir_all(&source).unwrap();
+
+    let cfg = DaemonConfig::builder("ws://127.0.0.1:9/ws", "test-token", &identity_dir)
+        .heartbeat_interval(Duration::from_millis(50))
+        .build();
+    let handle = ahandd::spawn(cfg).await.unwrap();
+    handle
+        .create_sandbox_session(SandboxSessionConfig {
+            session_id: "session-1".to_string(),
+            permission_mode: SandboxPermissionMode::Readonly,
+            workspace_root: sandbox_root.clone(),
+            network: NetworkPolicy::Enabled,
+            mounts: Vec::new(),
+        })
+        .await
+        .unwrap();
+    handle
+        .register_sandbox_runtime(
+            "session-1",
+            RuntimeProviderConfig {
+                name: "shell".to_string(),
+                executable: PathBuf::from("/bin/sh"),
+                readonly_roots: vec![PathBuf::from("/bin")],
+                env: HashMap::new(),
+                default_timeout: Duration::from_secs(3),
+            },
+        )
+        .await
+        .unwrap();
+    let registered = handle
+        .register_sandbox_mount(
+            "session-1",
+            SandboxMountSpec {
+                mount_id: "selected-folder".to_string(),
+                source: MountSource::HostPath(source),
+                access: MountAccess::ReadOnly,
+                scope: MountScope::Run {
+                    run_id: "run-1".to_string(),
+                },
+                target: None,
+                env_var: Some("COFFICE_SELECTED_FOLDER_DIR".to_string()),
+            },
+        )
+        .await
+        .unwrap();
+
+    let result = handle
+        .execute_sandbox_command(
+            "session-1",
+            SandboxExecRequest {
+                command: SandboxCommand::Argv {
+                    command: vec![
+                        "sh".to_string(),
+                        "-c".to_string(),
+                        "printf '%s' \"$COFFICE_SELECTED_FOLDER_DIR\"".to_string(),
+                    ],
+                },
+                cwd: None,
+                env: HashMap::from([(
+                    "COFFICE_SELECTED_FOLDER_DIR".to_string(),
+                    "/tmp/spoofed".to_string(),
+                )]),
+                timeout: Some(Duration::from_secs(3)),
+                context: Some(SandboxInvocationContext {
+                    session_id: "session-1".to_string(),
+                    run_id: Some("run-1".to_string()),
+                    scope_id: None,
+                    invocation_id: None,
+                }),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, Some(0));
+    assert_eq!(result.stdout, registered.target.to_string_lossy());
 
     handle.shutdown().await.unwrap();
 }

--- a/crates/ahandd/tests/sandbox_api.rs
+++ b/crates/ahandd/tests/sandbox_api.rs
@@ -30,6 +30,7 @@ async fn daemon_handle_exposes_sandbox_permission_updates() {
             permission_mode: SandboxPermissionMode::Readonly,
             workspace_root: sandbox_root,
             network: NetworkPolicy::Enabled,
+            mounts: Vec::new(),
         })
         .await
         .unwrap();
@@ -129,6 +130,7 @@ async fn daemon_handle_persists_and_user_commits_candidate_versions() {
             permission_mode: SandboxPermissionMode::Readonly,
             workspace_root: sandbox_root.clone(),
             network: NetworkPolicy::Enabled,
+            mounts: Vec::new(),
         })
         .await
         .unwrap();
@@ -213,6 +215,7 @@ async fn daemon_handle_saves_candidate_version_as_user_selected_file() {
             permission_mode: SandboxPermissionMode::Copy,
             workspace_root: sandbox_root,
             network: NetworkPolicy::Enabled,
+            mounts: Vec::new(),
         })
         .await
         .unwrap();
@@ -261,6 +264,7 @@ async fn daemon_handle_executes_registered_runtime_inside_sandbox() {
             permission_mode: SandboxPermissionMode::Readonly,
             workspace_root: sandbox_root,
             network: NetworkPolicy::Enabled,
+            mounts: Vec::new(),
         })
         .await
         .unwrap();

--- a/crates/ahandd/tests/sandbox_smoke.rs
+++ b/crates/ahandd/tests/sandbox_smoke.rs
@@ -79,6 +79,7 @@ async fn coffice_sandbox_smoke_import_run_register_and_user_commit() {
             permission_mode: SandboxPermissionMode::Readonly,
             workspace_root: sandbox_root.clone(),
             network: NetworkPolicy::Enabled,
+            mounts: Vec::new(),
         })
         .await
         .unwrap();
@@ -147,6 +148,7 @@ async fn coffice_sandbox_smoke_import_run_register_and_user_commit() {
                 cwd: None,
                 env: HashMap::new(),
                 timeout: Some(Duration::from_secs(10)),
+                context: None,
             },
         )
         .await
@@ -168,6 +170,7 @@ async fn coffice_sandbox_smoke_import_run_register_and_user_commit() {
                 cwd: None,
                 env: HashMap::new(),
                 timeout: Some(Duration::from_secs(10)),
+                context: None,
             },
         )
         .await

--- a/crates/ahandd/tests/sandbox_smoke.rs
+++ b/crates/ahandd/tests/sandbox_smoke.rs
@@ -10,8 +10,9 @@ use std::time::Duration;
 use ahandd::{
     DaemonConfig,
     sandbox::{
-        HostFileRef, NetworkPolicy, RegisterVersionRequest, RuntimeProviderConfig, SandboxCommand,
-        SandboxExecRequest, SandboxPermissionMode, SandboxSessionConfig,
+        HostFileRef, MountAccess, MountScope, MountSource, NetworkPolicy, RegisterVersionRequest,
+        RuntimeProviderConfig, SandboxCommand, SandboxExecRequest, SandboxInvocationContext,
+        SandboxMountSpec, SandboxPermissionMode, SandboxSessionConfig,
     },
 };
 
@@ -206,6 +207,98 @@ async fn coffice_sandbox_smoke_import_run_register_and_user_commit() {
         .unwrap();
     assert_eq!(user_commit.bytes_written, 7);
     assert_eq!(std::fs::read_to_string(&source).unwrap(), "changed");
+
+    handle.shutdown().await.unwrap();
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn coffice_sandbox_smoke_readonly_host_directory_mount_reads_and_denies_write() {
+    let temp = tempfile::tempdir().unwrap();
+    let identity_dir = temp.path().join("identity");
+    let sandbox_root = temp.path().join("sandbox");
+    let host_dir = temp.path().join("selected");
+    std::fs::create_dir_all(sandbox_root.join("workspace")).unwrap();
+    std::fs::create_dir_all(&host_dir).unwrap();
+    std::fs::write(host_dir.join("data.txt"), "mounted-data").unwrap();
+
+    let cfg = DaemonConfig::builder("ws://127.0.0.1:9/ws", "test-token", &identity_dir)
+        .heartbeat_interval(Duration::from_millis(50))
+        .build();
+    let handle = ahandd::spawn(cfg).await.unwrap();
+    handle
+        .create_sandbox_session(SandboxSessionConfig {
+            session_id: "session-mount".to_string(),
+            permission_mode: SandboxPermissionMode::Readonly,
+            workspace_root: sandbox_root.clone(),
+            network: NetworkPolicy::Enabled,
+            mounts: Vec::new(),
+        })
+        .await
+        .unwrap();
+    handle
+        .register_sandbox_runtime(
+            "session-mount",
+            RuntimeProviderConfig {
+                name: "sh".to_string(),
+                executable: PathBuf::from("/bin/sh"),
+                readonly_roots: vec![PathBuf::from("/bin")],
+                env: HashMap::new(),
+                default_timeout: Duration::from_secs(10),
+            },
+        )
+        .await
+        .unwrap();
+    handle
+        .register_sandbox_mount(
+            "session-mount",
+            SandboxMountSpec {
+                mount_id: "selected-folder".to_string(),
+                source: MountSource::HostPath(host_dir.clone()),
+                access: MountAccess::ReadOnly,
+                scope: MountScope::Run {
+                    run_id: "run-1".to_string(),
+                },
+                target: None,
+                env_var: Some("COFFICE_SELECTED_FOLDER_DIR".to_string()),
+            },
+        )
+        .await
+        .unwrap();
+
+    let result = handle
+        .execute_sandbox_command(
+            "session-mount",
+            SandboxExecRequest {
+                command: SandboxCommand::Argv {
+                    command: vec![
+                        "sh".to_string(),
+                        "-lc".to_string(),
+                        "cat \"$COFFICE_SELECTED_FOLDER_DIR/data.txt\"; touch \"$COFFICE_SELECTED_FOLDER_DIR/new.txt\"".to_string(),
+                    ],
+                },
+                cwd: None,
+                env: HashMap::new(),
+                timeout: Some(Duration::from_secs(10)),
+                context: Some(SandboxInvocationContext {
+                    session_id: "session-mount".to_string(),
+                    run_id: Some("run-1".to_string()),
+                    scope_id: None,
+                    invocation_id: None,
+                }),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        result.stdout.contains("mounted-data"),
+        "stdout: {:?}, stderr: {:?}",
+        result.stdout,
+        result.stderr
+    );
+    assert_ne!(result.exit_code, Some(0), "{}", result.stderr);
+    assert!(!host_dir.join("new.txt").exists());
 
     handle.shutdown().await.unwrap();
 }

--- a/crates/ahandd/tests/sandbox_types.rs
+++ b/crates/ahandd/tests/sandbox_types.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 use ahandd::sandbox::{
     MountAccess, MountScope, MountSource, MountSourceSnapshot, NetworkPolicy,
-    RegisteredSandboxMount, SandboxExecRequest, SandboxInvocationContext, SandboxMountSpec,
-    SandboxPermissionMode, SandboxSessionConfig,
+    RegisteredSandboxMount, SandboxCommand, SandboxExecRequest, SandboxInvocationContext,
+    SandboxMountSpec, SandboxPermissionMode, SandboxSessionConfig,
 };
 
 #[test]
@@ -80,11 +80,13 @@ fn sandbox_types_preserve_registered_mount_resolution() {
 #[test]
 fn sandbox_types_attach_invocation_context_to_exec_request() {
     let request = SandboxExecRequest {
-        command: vec![
-            "python".to_string(),
-            "-c".to_string(),
-            "print(1)".to_string(),
-        ],
+        command: SandboxCommand::Argv {
+            command: vec![
+                "python".to_string(),
+                "-c".to_string(),
+                "print(1)".to_string(),
+            ],
+        },
         cwd: Some(PathBuf::from("workspace")),
         env: HashMap::from([("EXAMPLE".to_string(), "1".to_string())]),
         timeout: Some(Duration::from_secs(5)),

--- a/crates/ahandd/tests/sandbox_types.rs
+++ b/crates/ahandd/tests/sandbox_types.rs
@@ -73,8 +73,8 @@ fn sandbox_types_preserve_registered_mount_resolution() {
         registered.target,
         PathBuf::from("/sandbox/workspace/mounts/runtime-cache")
     );
-    assert_eq!(registered.source_snapshot.exists, true);
-    assert_eq!(registered.source_snapshot.is_dir, true);
+    assert!(registered.source_snapshot.exists);
+    assert!(registered.source_snapshot.is_dir);
 }
 
 #[test]

--- a/crates/ahandd/tests/sandbox_types.rs
+++ b/crates/ahandd/tests/sandbox_types.rs
@@ -1,0 +1,166 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use ahandd::sandbox::{
+    MountAccess, MountScope, MountSource, MountSourceSnapshot, NetworkPolicy,
+    RegisteredSandboxMount, SandboxExecRequest, SandboxInvocationContext, SandboxMountSpec,
+    SandboxPermissionMode, SandboxSessionConfig,
+};
+
+#[test]
+fn sandbox_types_preserve_mount_spec_intent() {
+    let spec = SandboxMountSpec {
+        mount_id: "selected-folder".to_string(),
+        source: MountSource::HostPath(PathBuf::from("/host/Selected Folder")),
+        access: MountAccess::ReadOnly,
+        scope: MountScope::Run {
+            run_id: "run-1".to_string(),
+        },
+        target: None,
+        env_var: Some("COFFICE_SELECTED_FOLDER_DIR".to_string()),
+    };
+
+    assert_eq!(spec.mount_id, "selected-folder");
+    assert_eq!(
+        spec.source,
+        MountSource::HostPath(PathBuf::from("/host/Selected Folder"))
+    );
+    assert_eq!(spec.access, MountAccess::ReadOnly);
+    assert_eq!(
+        spec.scope,
+        MountScope::Run {
+            run_id: "run-1".to_string()
+        }
+    );
+    assert_eq!(spec.target, None);
+    assert_eq!(
+        spec.env_var,
+        Some("COFFICE_SELECTED_FOLDER_DIR".to_string())
+    );
+}
+
+#[test]
+fn sandbox_types_preserve_registered_mount_resolution() {
+    let registered = RegisteredSandboxMount {
+        mount_id: "runtime-cache".to_string(),
+        source: MountSource::RuntimePath(PathBuf::from("/runtime/cache")),
+        access: MountAccess::CopyOnWrite,
+        scope: MountScope::Invocation {
+            invocation_id: "invoke-1".to_string(),
+        },
+        target: PathBuf::from("/sandbox/workspace/mounts/runtime-cache"),
+        env_var: Some("RUNTIME_CACHE_DIR".to_string()),
+        source_snapshot: MountSourceSnapshot {
+            exists: true,
+            is_dir: true,
+        },
+    };
+
+    assert_eq!(registered.mount_id, "runtime-cache");
+    assert_eq!(
+        registered.source,
+        MountSource::RuntimePath(PathBuf::from("/runtime/cache"))
+    );
+    assert_eq!(registered.access, MountAccess::CopyOnWrite);
+    assert_eq!(
+        registered.scope,
+        MountScope::Invocation {
+            invocation_id: "invoke-1".to_string()
+        }
+    );
+    assert_eq!(
+        registered.target,
+        PathBuf::from("/sandbox/workspace/mounts/runtime-cache")
+    );
+    assert_eq!(registered.source_snapshot.exists, true);
+    assert_eq!(registered.source_snapshot.is_dir, true);
+}
+
+#[test]
+fn sandbox_types_attach_invocation_context_to_exec_request() {
+    let request = SandboxExecRequest {
+        command: vec![
+            "python".to_string(),
+            "-c".to_string(),
+            "print(1)".to_string(),
+        ],
+        cwd: Some(PathBuf::from("workspace")),
+        env: HashMap::from([("EXAMPLE".to_string(), "1".to_string())]),
+        timeout: Some(Duration::from_secs(5)),
+        context: Some(SandboxInvocationContext {
+            session_id: "session-1".to_string(),
+            run_id: Some("run-1".to_string()),
+            scope_id: None,
+            invocation_id: Some("invoke-1".to_string()),
+        }),
+    };
+
+    assert_eq!(
+        request.context.as_ref().unwrap().run_id.as_deref(),
+        Some("run-1")
+    );
+    assert_eq!(
+        request.context.as_ref().unwrap().invocation_id.as_deref(),
+        Some("invoke-1")
+    );
+}
+
+#[test]
+fn sandbox_types_attach_initial_mounts_to_session_config() {
+    let mount = SandboxMountSpec {
+        mount_id: "session-assets".to_string(),
+        source: MountSource::SandboxPath(PathBuf::from("workspace/assets")),
+        access: MountAccess::ReadWrite,
+        scope: MountScope::Session,
+        target: Some(PathBuf::from("workspace/mounts/session-assets")),
+        env_var: None,
+    };
+
+    let config = SandboxSessionConfig {
+        session_id: "session-1".to_string(),
+        permission_mode: SandboxPermissionMode::Readonly,
+        workspace_root: PathBuf::from("/sandbox"),
+        network: NetworkPolicy::Enabled,
+        mounts: vec![mount.clone()],
+    };
+
+    assert_eq!(config.mounts, vec![mount]);
+}
+
+#[test]
+fn sandbox_types_are_exported_from_public_api() {
+    let _public_access: ahandd::MountAccess = MountAccess::WriteOnly;
+    let _public_scope: ahandd::MountScope = MountScope::Session;
+    let _public_source: ahandd::MountSource = MountSource::SandboxPath(PathBuf::from("workspace"));
+    let _public_snapshot: ahandd::MountSourceSnapshot = MountSourceSnapshot {
+        exists: false,
+        is_dir: false,
+    };
+    let _public_context: ahandd::SandboxInvocationContext = SandboxInvocationContext {
+        session_id: "session-1".to_string(),
+        run_id: None,
+        scope_id: None,
+        invocation_id: Some("invoke-1".to_string()),
+    };
+    let _public_spec: ahandd::SandboxMountSpec = SandboxMountSpec {
+        mount_id: "public-spec".to_string(),
+        source: MountSource::HostPath(PathBuf::from("/host/public")),
+        access: MountAccess::ReadOnly,
+        scope: MountScope::Session,
+        target: None,
+        env_var: None,
+    };
+    let _public_mount: ahandd::RegisteredSandboxMount = RegisteredSandboxMount {
+        mount_id: "public-mount".to_string(),
+        source: MountSource::HostPath(PathBuf::from("/host/public")),
+        access: MountAccess::ReadOnly,
+        scope: MountScope::Session,
+        target: PathBuf::from("workspace/mounts/public-mount"),
+        env_var: None,
+        source_snapshot: MountSourceSnapshot {
+            exists: true,
+            is_dir: true,
+        },
+    };
+}


### PR DESCRIPTION
## Summary

Adds a unified sandbox mount API to the aHand daemon and SDK surface:

- introduces `SandboxMountSpec`, `RegisteredSandboxMount`, source/access/scope types, and optional exec invocation context
- supports session/run/invocation-scoped mounts with automatic target allocation under `workspace/mounts`
- exposes register/list/unregister mount methods on `DaemonHandle` and the SDK cloud client
- materializes active read-only host directory mounts for sandbox command execution

## Notes

This PR is stacked on `codex/ahand-sandbox-tool-provider` so the diff stays focused on the mount API layer.

## Validation

- `cargo test -q -p ahand-hub --test app_tool_invoke`
- `cargo test -q -p ahandd app_tool`
- `cargo test -q -p ahandd sandbox_api`
- `cargo test -q -p ahandd sandbox_smoke -- --nocapture`
- `pnpm --filter @ahandai/sdk test -- cloud-client`
