### PR TITLE
[codex] Reuse recovered sandbox mount targets

### DIFF
--- a/crates/ahand-hub/src/http/control_plane.rs
+++ b/crates/ahand-hub/src/http/control_plane.rs
@@ -134,9 +134,7 @@ fn control_rate_limit_ok(
             true
         }
         Err(not_until) => {
-            let wait_ms = not_until
-                .wait_time_from(MonotonicClock::default().now())
-                .as_millis();
+            let wait_ms = not_until.wait_time_from(MonotonicClock.now()).as_millis();
             tracing::warn!(
                 endpoint,
                 external_user_hash = %external_user_hash(external_user_id),

--- a/crates/ahand-hub/src/state.rs
+++ b/crates/ahand-hub/src/state.rs
@@ -48,7 +48,7 @@ pub fn default_control_plane_rate_limiter() -> ControlPlaneRateLimiter {
     let quota = Quota::per_second(std::num::NonZeroU32::new(10).expect("10 is non-zero"))
         .allow_burst(std::num::NonZeroU32::new(100).expect("100 is non-zero"));
     let state = DefaultKeyedStateStore::<String>::default();
-    let clock = MonotonicClock::default();
+    let clock = MonotonicClock;
     RateLimiter::new(quota, state, &clock)
 }
 

--- a/crates/ahandd/src/sandbox/mounts.rs
+++ b/crates/ahandd/src/sandbox/mounts.rs
@@ -48,6 +48,7 @@ pub(crate) fn register_mount_with_existing_targets<'a>(
             &mount_namespace,
             &slug_from_mount_id(&spec.mount_id),
             &existing_targets,
+            &source,
         ),
     };
 
@@ -250,6 +251,7 @@ fn allocate_auto_target(
     canonical_namespace: &Path,
     slug: &str,
     existing_targets: &[PathBuf],
+    source: &MountSource,
 ) -> PathBuf {
     let mut suffix = 1;
     loop {
@@ -259,11 +261,40 @@ fn allocate_auto_target(
             format!("{slug}-{suffix}")
         };
         let candidate = canonical_namespace.join(name);
-        if !path_exists(&candidate) && !target_conflicts(&candidate, existing_targets) {
+        if !target_conflicts(&candidate, existing_targets)
+            && (!path_exists(&candidate) || existing_target_points_to_source(&candidate, source))
+        {
             return candidate;
         }
         suffix += 1;
     }
+}
+
+fn existing_target_points_to_source(candidate: &Path, source: &MountSource) -> bool {
+    let MountSource::HostPath(source) = source else {
+        return false;
+    };
+    let Ok(metadata) = fs::symlink_metadata(candidate) else {
+        return false;
+    };
+    if !metadata.file_type().is_symlink() {
+        return false;
+    }
+    let Ok(link_target) = fs::read_link(candidate) else {
+        return false;
+    };
+    let Some(parent) = candidate.parent() else {
+        return false;
+    };
+    let resolved = if link_target.is_absolute() {
+        link_target
+    } else {
+        parent.join(link_target)
+    };
+    resolved
+        .canonicalize()
+        .map(|target| target == *source)
+        .unwrap_or(false)
 }
 
 fn target_conflicts(candidate: &Path, existing_targets: &[PathBuf]) -> bool {
@@ -412,6 +443,42 @@ mod tests {
         );
         assert!(mount.source_snapshot.exists);
         assert!(mount.source_snapshot.is_dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn auto_target_reuses_existing_symlink_to_same_source() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("sandbox");
+        let namespace = workspace_root.join("workspace").join("mounts");
+        let source = temp.path().join("host").join("Private Client");
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&namespace).unwrap();
+        symlink(
+            source.canonicalize().unwrap(),
+            namespace.join("selected-folder"),
+        )
+        .unwrap();
+
+        let mount = register_for_test(
+            &workspace_root,
+            readonly_host_spec("selected-folder", source.clone()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            mount.target,
+            workspace_root
+                .canonicalize()
+                .unwrap()
+                .join("workspace/mounts/selected-folder")
+        );
+        assert_eq!(
+            mount.source,
+            MountSource::HostPath(source.canonicalize().unwrap())
+        );
     }
 
     #[test]

--- a/crates/ahandd/src/sandbox/registry.rs
+++ b/crates/ahandd/src/sandbox/registry.rs
@@ -245,19 +245,15 @@ impl SandboxRegistry {
                 spec.mount_id
             )));
         }
-        if let Some(env_var) = &spec.env_var {
-            if session
-                .mounts
-                .values()
-                .any(|mount| {
-                    mount.env_var.as_deref() == Some(env_var.as_str())
-                        && mount_scopes_can_overlap(&mount.scope, &spec.scope)
-                })
-            {
-                return Err(SandboxError::mount_env_conflict(format!(
-                    "sandbox mount env var '{env_var}' is already registered"
-                )));
-            }
+        if let Some(env_var) = &spec.env_var
+            && session.mounts.values().any(|mount| {
+                mount.env_var.as_deref() == Some(env_var.as_str())
+                    && mount_scopes_can_overlap(&mount.scope, &spec.scope)
+            })
+        {
+            return Err(SandboxError::mount_env_conflict(format!(
+                "sandbox mount env var '{env_var}' is already registered"
+            )));
         }
         let existing_targets = session
             .mounts
@@ -657,26 +653,24 @@ mod tests {
             )
             .unwrap();
 
-        let run_1_env =
-            registry
-                .session("session-1")
-                .unwrap()
-                .exec_environment_for(Some(&SandboxInvocationContext {
-                    session_id: "session-1".to_string(),
-                    run_id: Some("run-1".to_string()),
-                    scope_id: None,
-                    invocation_id: None,
-                }));
-        let run_2_env =
-            registry
-                .session("session-1")
-                .unwrap()
-                .exec_environment_for(Some(&SandboxInvocationContext {
-                    session_id: "session-1".to_string(),
-                    run_id: Some("run-2".to_string()),
-                    scope_id: None,
-                    invocation_id: None,
-                }));
+        let run_1_env = registry
+            .session("session-1")
+            .unwrap()
+            .exec_environment_for(Some(&SandboxInvocationContext {
+                session_id: "session-1".to_string(),
+                run_id: Some("run-1".to_string()),
+                scope_id: None,
+                invocation_id: None,
+            }));
+        let run_2_env = registry
+            .session("session-1")
+            .unwrap()
+            .exec_environment_for(Some(&SandboxInvocationContext {
+                session_id: "session-1".to_string(),
+                run_id: Some("run-2".to_string()),
+                scope_id: None,
+                invocation_id: None,
+            }));
 
         assert_eq!(
             run_1_env.env["COFFICE_TARGET_FOLDER_DIR"],

--- a/crates/ahandd/tests/sandbox_api.rs
+++ b/crates/ahandd/tests/sandbox_api.rs
@@ -4,12 +4,13 @@ use std::{path::PathBuf, time::Duration};
 
 #[cfg(target_os = "macos")]
 use ahandd::sandbox::{RuntimeExecuteRequest, RuntimeProviderConfig};
+#[cfg(target_os = "macos")]
+use ahandd::sandbox::{SandboxCommand, SandboxExecRequest, SandboxInvocationContext};
 use ahandd::{
     AppToolDef, AppToolHandler, DaemonConfig, args_only_handler,
     sandbox::{
         HostFileRef, MountAccess, MountScope, MountSource, NetworkPolicy, RegisterVersionRequest,
-        SandboxCommand, SandboxExecRequest, SandboxInvocationContext, SandboxMountSpec,
-        SandboxPermissionMode, SandboxSessionConfig,
+        SandboxMountSpec, SandboxPermissionMode, SandboxSessionConfig,
     },
 };
 

--- a/crates/ahandd/tests/sandbox_types.rs
+++ b/crates/ahandd/tests/sandbox_types.rs
@@ -73,8 +73,8 @@ fn sandbox_types_preserve_registered_mount_resolution() {
         registered.target,
         PathBuf::from("/sandbox/workspace/mounts/runtime-cache")
     );
-    assert_eq!(registered.source_snapshot.exists, true);
-    assert_eq!(registered.source_snapshot.is_dir, true);
+    assert!(registered.source_snapshot.exists);
+    assert!(registered.source_snapshot.is_dir);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- reuse an existing auto mount target when it is already a symlink to the same canonical host source
- preserve deterministic suffix behavior for ordinary existing paths or conflicting registered targets
- add a regression test for restart-style mount target recovery
- address current CI fmt/clippy blockers exposed by the PR toolchain

## Verification
- cargo fmt -p ahand-platform -p ahandd -p ahandctl --check
- cargo fmt -p ahand-protocol -p ahand-hub-core -p ahand-hub-store -p ahand-hub --check
- cargo clippy -p ahand-platform -p ahandd -p ahandctl --all-targets -- -D warnings
- cargo clippy -p ahand-protocol -p ahand-hub-core -p ahand-hub-store -p ahand-hub --all-targets --all-features -- -D warnings
- cargo test -p ahandd sandbox::mounts

## Notes
- Attempted the full client test command locally, but the machine ran out of disk space while writing the shared Cargo target directory. The targeted sandbox mount tests passed before that.